### PR TITLE
(fix) meta formatting upon insertion to file without meta

### DIFF
--- a/test/note-files/reference.org
+++ b/test/note-files/reference.org
@@ -1,4 +1,4 @@
 :PROPERTIES:
 :ID:                     5093fc4e-8c63-4e60-a1da-83fc7ecd5db7
 :END:
-#+TITLE: Reference
+#+title: Reference

--- a/test/note-files/with-meta.org
+++ b/test/note-files/with-meta.org
@@ -1,7 +1,7 @@
 :PROPERTIES:
 :ID:                     05907606-f836-45bf-bd36-a8444308eddd
 :END:
-#+TITLE: Note with META
+#+title: Note with META
 
 - name :: some name
 - tags :: tag 1
@@ -15,3 +15,5 @@
 - references :: [[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Note without META]]
 - references :: [[id:5093fc4e-8c63-4e60-a1da-83fc7ecd5db7][Reference]]
 - answer :: 42
+
+Don't mind me. I am a content of this note.

--- a/test/note-files/without-meta.org
+++ b/test/note-files/without-meta.org
@@ -2,3 +2,5 @@
 :ID:                     444f94d7-61e0-4b7c-bb7e-100814c6b4bb
 :END:
 #+title: Note without META
+
+Just some text to make sure that meta is inserted before.

--- a/vulpea-meta.el
+++ b/vulpea-meta.el
@@ -180,16 +180,19 @@ Please note that all occurrences of PROP are replaced by VALUE."
         ;; line
         (let* ((element (or (car (last (org-element-map buffer 'keyword #'identity)))
                             (car (org-element-map buffer 'property-drawer #'identity))))
-               (point (if element
-                          (org-element-property :end element)
-                        1)))
+               (point (if element (org-element-property :end element) 1))
+               (eob (eq point (point-max))))
           (goto-char point)
+          (when eob
+            (insert "\n"))
           (seq-do
            (lambda (val)
              (insert "- " prop " :: "
                      (vulpea-meta--format val)
-                     "\n\n"))
-           values)))))))
+                     "\n"))
+           values)
+          (unless eob
+            (insert "\n"))))))))
 
 (defun vulpea-meta-remove (id prop)
   "Delete values of PROP for note with ID."


### PR DESCRIPTION
It turns out that it was not working properly nor for note without body, nor for
note with body.