### PR TITLE
(dev) mark makem.sh as vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+makem.sh linguist-vendored


### PR DESCRIPTION
Otherwise Vulpea is treated as bash project. Which is not the truth.