### PR TITLE
(dev) schedule tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,8 @@ on:
     paths-ignore:
       - "**/*.md"
       - "**/*.org"
+  schedule:
+    - cron: "0 6 * * *"
 
 jobs:
   build:


### PR DESCRIPTION
Since Vulpea is not a library that is going to get updates every day, but `org`
and `org-roam` are packages that constantly change, I would love to know
proactively if something breaks due to upstream changes.