### PR TITLE
(feat) remove `vulpea-db-get-title-by-id'

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -25,8 +25,6 @@ Features:
     headings of the note.
   - =vulpea-db-get-file-by-id= - function to get =FILE= of a note represented by
     =ID=. Supports headings of the note.
-  - =vulpea-db-get-title-by-id= - function to get =TITLE= of a note represented
-    by =ID=. Supports headings of the note.
   - =vulpea-db-search-by-title= - function to query notes with =TITLE=.
 - =vulpea-meta= module - for manipulating note metadata represented by
   description list:

--- a/README.org
+++ b/README.org
@@ -85,8 +85,6 @@ This module contains functions to query notes data base. Functions of interest:
   headings of the note.
 - =vulpea-db-get-file-by-id= - function to get =FILE= of a note represented by
   =ID=. Supports headings of the note.
-- =vulpea-db-get-title-by-id= - function to get =TITLE= of a note represented by
-  =ID=. Supports headings of the note.
 - =vulpea-db-search-by-title= - function to query notes with =TITLE=.
 
 *** =vulpea-meta=

--- a/test/vulpea-db-test.el
+++ b/test/vulpea-db-test.el
@@ -110,29 +110,6 @@
                   :level 2
                   :id "cfc39858-351d-4f1e-8f98-10d16d71f49e"))))
 
-(describe "vulpea-db-get-title-by-id"
-  (before-all
-    (vulpea-test--init))
-
-  (after-all
-    (vulpea-test--teardown))
-
-  (it "returns nil when passed unknown id"
-    (expect (vulpea-db-get-title-by-id "00000000-0000-0000-0000-000000000000")
-            :to-be nil))
-
-  (it "returns title of a note by id"
-    (expect (vulpea-db-get-title-by-id "72522ed2-9991-482e-a365-01155c172aa5")
-            :to-equal "Note with an alias"))
-
-  (it "returns sub-heading of a note by id"
-    (expect (vulpea-db-get-title-by-id "b77a4837-71d6-495e-98f1-b576464aacc1")
-            :to-equal "Big note sub-heading"))
-
-  (it "returns sub-sub-heading of a note by id"
-    (expect (vulpea-db-get-title-by-id "cfc39858-351d-4f1e-8f98-10d16d71f49e")
-            :to-equal "Big note sub-sub-heading")))
-
 (describe "vulpea-db-get-file-by-id"
   (before-all
     (vulpea-test--init))

--- a/vulpea-db.el
+++ b/vulpea-db.el
@@ -85,26 +85,6 @@ form: (:path :title :tags :level :id)."
           :id id)))
 
 ;;;###autoload
-(defun vulpea-db-get-title-by-id (id)
-  "Find a note title by ID.
-
-Supports headings in the note."
-  (when-let* ((fls
-               (org-roam-db-query
-                [:select [file level]
-                 :from ids
-                 :where (= id $s1)]
-                id))
-              (fl (+seq-singleton fls))
-              (file (car fl))
-              (level (nth 1 fl)))
-    (if (= 0 level)
-        (org-roam-db--get-title file)
-      (vulpea-with-file file
-        (goto-char (cdr (org-id-find-id-in-file id file)))
-        (org-entry-get (point) "ITEM")))))
-
-;;;###autoload
 (defun vulpea-db-get-file-by-id (id)
   "Get file of note with ID.
 

--- a/vulpea-meta.el
+++ b/vulpea-meta.el
@@ -232,7 +232,7 @@ Please note that all occurrences of PROP are replaced by VALUE."
    ((stringp value)
     (if (string-match-p vulpea-uuid-regexp value)
         (org-link-make-string (concat "id:" value)
-                              (vulpea-db-get-title-by-id value))
+                              (plist-get (vulpea-db-get-by-id value) :title))
       value))
    ((numberp value)
     (number-to-string value))


### PR DESCRIPTION
It actually extracts and discards too much information, so there is little sense
in keeping this function, unlike `vulpea-db-get-file-by-id' which quickly gets
the file.