### PR TITLE
(feat) better new line handing in `vulpea-meta-set'

### DIFF
--- a/test/vulpea-meta-test.el
+++ b/test/vulpea-meta-test.el
@@ -376,6 +376,73 @@ Just some text to make sure that meta is inserted before.
 - age :: 42
 "))
 
+    (it "inserts values with respect to trailing new lines in file without body"
+      (vulpea-test--map-file (lambda (_)
+                               ;; first line after the header
+                               (goto-char 124)
+                               (insert "\n\n\n\n\n"))
+                             reference-file)
+      (vulpea-meta-set reference-id
+                       "references"
+                       '("5093fc4e-8c63-4e60-a1da-83fc7ecd5db7"
+                         "05907606-f836-45bf-bd36-a8444308eddd")
+                       'append)
+      (vulpea-meta-set reference-id "age" 42 'append)
+      (expect reference-file
+              :to-contain-exactly
+              ":PROPERTIES:
+:ID:                     5093fc4e-8c63-4e60-a1da-83fc7ecd5db7
+:END:
+#+title: Reference
+#+roam_tags: tag1 tag2
+
+- references :: [[id:5093fc4e-8c63-4e60-a1da-83fc7ecd5db7][Reference]]
+- references :: [[id:05907606-f836-45bf-bd36-a8444308eddd][Note with META]]
+- age :: 42
+
+
+
+
+
+"))
+
+    (it "inserts values with respect to trailing new lines in file with body"
+      (vulpea-test--map-file (lambda (_)
+                               ;; first line after the body
+                               (goto-char 168)
+                               (insert "\n\n\n")
+                               ;; first line after the header
+                               (goto-char 109)
+                               (insert "\n\n\n\n\n"))
+                             without-meta-file)
+      (vulpea-meta-set without-meta-id
+                       "references"
+                       '("5093fc4e-8c63-4e60-a1da-83fc7ecd5db7"
+                         "05907606-f836-45bf-bd36-a8444308eddd")
+                       'append)
+      (vulpea-meta-set without-meta-id "age" 42 'append)
+      (expect without-meta-file
+              :to-contain-exactly
+              ":PROPERTIES:
+:ID:                     444f94d7-61e0-4b7c-bb7e-100814c6b4bb
+:END:
+#+title: Note without META
+
+- references :: [[id:5093fc4e-8c63-4e60-a1da-83fc7ecd5db7][Reference]]
+- references :: [[id:05907606-f836-45bf-bd36-a8444308eddd][Note with META]]
+- age :: 42
+
+
+
+
+
+
+Just some text to make sure that meta is inserted before.
+
+
+
+"))
+
     (it "cleans meta from a note with body"
       (vulpea-meta-clean with-meta-id)
       (expect with-meta-file

--- a/vulpea-meta.el
+++ b/vulpea-meta.el
@@ -176,14 +176,13 @@ which case VALUE is added at the end of the meta."
                  ;; :bullet and other properties
                  (img (org-element-copy (car items-all)))
                  (point (if append
-                            (org-element-property :end pl)
+                            (- (org-element-property :end pl)
+                               (org-element-property :post-blank pl))
                           (org-element-property :begin pl)))
-                 (eob (eq point (point-max))))
+                 eob)
             ;; when APPEND and body is present, insert new item on the next line
             ;; after the last item
-            (if (and append (not eob))
-                (goto-char (- point 1))
-              (goto-char point))
+            (goto-char point)
             (seq-do
              (lambda (val)
                (insert
@@ -200,19 +199,17 @@ which case VALUE is added at the end of the meta."
         ;; line
         (let* ((element (or (car (last (org-element-map buffer 'keyword #'identity)))
                             (car (org-element-map buffer 'property-drawer #'identity))))
-               (point (if element (org-element-property :end element) 1))
-               (eob (eq point (point-max))))
+               (point (if element (- (org-element-property :end element)
+                                     (org-element-property :post-blank element))
+                        (point-min))))
           (goto-char point)
-          (when eob
-            (insert "\n"))
+          (insert "\n")
           (seq-do
            (lambda (val)
              (insert "- " prop " :: "
                      (vulpea-meta--format val)
                      "\n"))
-           values)
-          (unless eob
-            (insert "\n"))))))))
+           values)))))))
 
 ;;;###autoload
 (defun vulpea-meta-remove (id prop)


### PR DESCRIPTION
1. Do not use hacks with trying to guess the end of buffer.
2. Do not try to guess how much to go back in order to put meta straight after
   the latest keyword or property block divided by newline.
3. Instead use :post-blank property to do the calculations. Bless the person who
   implemented it!