### PR TITLE
(feat) improve read performance

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -28,11 +28,20 @@ Features:
   - =vulpea-db-search-by-title= - function to query notes with =TITLE=.
 - =vulpea-meta= module - for manipulating note metadata represented by
   description list:
-  - =vulpea-meta-get= - function to get a value of =PROP= for =NOTE-OR-ID=.
+  - =vulpea-meta= - function to get metadata from =NOTE-OR-ID=. In most cases
+    you should not use this function unless performance is important. In this
+    case, take a look at bang functions, e.g. =vulpea-meta-get!=.
+  - =vulpea-meta-get= - function to get a value of =PROP= for note with =ID=.
     Value is parsed based on the passed =TYPE= or as a string if omitted.
+  - =vulpea-meta-get!= - function to get a value of =PROP= from =META= (result
+    of =vulpea-meta=). Value is parsed based on the passed =TYPE= or as a string
+    if omitted. Use it performing multiple read operations in a row.
   - =vulpea-meta-get-list= - function to get all values of =PROP= for note with
     =ID=. Values are parsed based on the passed =TYPE= or as a string if
     omitted.
+  - =vulpea-meta-get-list!= - function to get all values of =PROP= from =META=
+    (result of =vulpea-meta=). Values are parsed based on the passed =TYPE= or
+    as a string if omitted. Use it performing multiple read operations in a row.
   - =vulpea-meta-set= - function to set =VALUE= of =PROP= for =NOTE-OR-ID=.
     Supports multi-value properties.
   - =vulpea-meta-remove= - function to remove a =PROP= for =NOTE-OR-ID=.

--- a/README.org
+++ b/README.org
@@ -111,10 +111,19 @@ first description list in the note, e.g. list like:
 
 Functions of interest:
 
-- =vulpea-meta-get= - function to get a value of =PROP= for =NOTE-OR-ID=. Value
-  is parsed based on the passed =TYPE= or as a string if omitted.
+- =vulpea-meta= - function to get metadata from =NOTE-OR-ID=. In most cases you
+  should not use this function unless performance is important. In this case,
+  take a look at bang functions, e.g. =vulpea-meta-get!=.
+- =vulpea-meta-get= - function to get a value of =PROP= for note with =ID=.
+  Value is parsed based on the passed =TYPE= or as a string if omitted.
+- =vulpea-meta-get!= - function to get a value of =PROP= from =META= (result of
+  =vulpea-meta=). Value is parsed based on the passed =TYPE= or as a string if
+  omitted. Use it performing multiple read operations in a row.
 - =vulpea-meta-get-list= - function to get all values of =PROP= for note with
   =ID=. Values are parsed based on the passed =TYPE= or as a string if omitted.
+- =vulpea-meta-get-list!= - function to get all values of =PROP= from =META=
+  (result of =vulpea-meta=). Values are parsed based on the passed =TYPE= or as
+  a string if omitted. Use it performing multiple read operations in a row.
 - =vulpea-meta-set= - function to set =VALUE= of =PROP= for =NOTE-OR-ID=.
   Supports multi-value properties.
 - =vulpea-meta-remove= - function to remove a =PROP= for =NOTE-OR-ID=.

--- a/test/vulpea-meta-perf-test.el
+++ b/test/vulpea-meta-perf-test.el
@@ -1,0 +1,67 @@
+;;; vulpea-meta-perf-test.el --- Performance test of `vulpea-meta' module -*- lexical-binding: t; -*-
+;;
+;; Copyright (c) 2021 Boris Buliga
+;;
+;; Author: Boris Buliga <boris@d12frosted.io>
+;; Maintainer: Boris Buliga <boris@d12frosted.io>
+;;
+;; Created: 18 Jan 2021
+;;
+;; URL: https://github.com/d12frosted/vulpea
+;;
+;; License: GPLv3
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; Commentary:
+;;
+;;; Code:
+
+(require 'vulpea-test-utils)
+(require 'buttercup)
+(require 'org-roam)
+(require 'vulpea-meta)
+(require 'vulpea-db)
+
+(describe "vulpea-meta-get"
+  :var ((id "05907606-f836-45bf-bd36-a8444308eddd"))
+  (before-all
+    (vulpea-test--init))
+
+  (after-all
+    (vulpea-test--teardown))
+
+  (it "using parsed meta is faster than using id"
+    (let* ((meta (vulpea-meta id))
+           (res-id
+            (benchmark-run 10
+              (vulpea-meta-get id "symbol")))
+           (res-meta
+            (benchmark-run 10
+              (vulpea-meta-get! meta "symbol"))))
+      (message "res-id   = %s" res-id)
+      (message "res-meta = %s" res-meta)
+      (expect (car res-meta) :to-be-less-than (car res-id)))))
+
+(describe "vulpea-meta-get-list"
+  :var ((id "05907606-f836-45bf-bd36-a8444308eddd"))
+  (before-all
+    (vulpea-test--init))
+
+  (after-all
+    (vulpea-test--teardown))
+
+  (it "using parsed meta is faster than using id"
+    (let* ((meta (vulpea-meta id))
+           (res-id
+            (benchmark-run 10
+              (vulpea-meta-get-list id "tags")))
+           (res-meta
+            (benchmark-run 10
+              (vulpea-meta-get-list! meta "tags"))))
+      (message "res-id   = %s" res-id)
+      (message "res-meta = %s" res-meta)
+      (expect (car res-meta) :to-be-less-than (car res-id)))))
+
+(provide 'vulpea-meta-perf-test)
+;;; vulpea-meta-perf-test.el ends here


### PR DESCRIPTION
Fixes #64

Running 10 `vulpea-meta-get` vs `vulpea-meta-get!` results are

```
[00:12.847]  res-id   = (0.047566000000000004 1 0.033386999999999944)
[00:12.847]  res-meta = (0.00068 0 0.0)
```

Running 10 `vulpea-meta-get-list` vs `vulpea-meta-get-list!` results
are

```
[00:15.171]  res-id   = (0.047298999999999994 1 0.03286300000000009)
[00:15.171]  res-meta = (0.000779 0 0.0)
```

As you can see, there is noticeable difference in performance.