### PR TITLE
(feat) update db after creating new note using `vulpea-create`

### DIFF
--- a/test/vulpea-test.el
+++ b/test/vulpea-test.el
@@ -88,7 +88,7 @@
                      "#+TITLE: ${title}\n\n")
              :unnarrowed t
              :immediate-finish t)))
-    (org-roam-db-build-cache)
+    (expect vulpea--capture-file-path :to-be nil)
     (expect (vulpea-db-get-by-id id)
             :to-equal
             (make-vulpea-note


### PR DESCRIPTION
The purpose of `vulpea-create` is to allow users programatically
create notes. From my experience, it is often expected that
`org-roam-db` knows about newly created file after calling
`vulpea-create`. So I had to put either
`org-roam-db-build-cache` (which is fast, but still has huge overhead
as it needs to check each file for changes) or
`org-roam-db-update-file` when I know the path to file created by
`vulpea-create` (which is a rare occasion).

So this commit updates `org-roam-db` in an efficient way by only
updating specific file.

One of the possible improvements is to return `vulpea-note` as result
of `vulpea-create` instead of the mere `id`.