### PR TITLE
(feat) return vulpea-note from vulpea-create

### DIFF
--- a/test/vulpea-test.el
+++ b/test/vulpea-test.el
@@ -66,7 +66,7 @@
                             :from titles])))))
 
 (describe "vulpea-select"
-  :var (id)
+  :var (note)
   (before-all
     (vulpea-test--init))
 
@@ -74,7 +74,7 @@
     (vulpea-test--teardown))
 
   (it "creates new file with ID"
-    (setq id
+    (setq note
           (vulpea-create
            "Slarina"
            `("d" "default" plain
@@ -89,14 +89,17 @@
              :unnarrowed t
              :immediate-finish t)))
     (expect vulpea--capture-file-path :to-be nil)
-    (expect (vulpea-db-get-by-id id)
+    (expect note
             :to-equal
             (make-vulpea-note
              :path (expand-file-name "prefix-slarina.org" org-roam-directory)
              :title "Slarina"
              :tags nil
              :level 0
-             :id id))))
+             :id (vulpea-note-id note)))
+    (expect (vulpea-db-get-by-id (vulpea-note-id note))
+            :to-equal
+            note)))
 
 (provide 'vulpea-test)
 ;;; vulpea-test.el ends here

--- a/vulpea.el
+++ b/vulpea.el
@@ -157,7 +157,7 @@ Available variables in the capture context are:
     (when vulpea--capture-file-path
       (org-roam-db-update-file vulpea--capture-file-path)
       (setq vulpea--capture-file-path nil))
-    id))
+    (vulpea-db-get-by-id id)))
 
 (provide 'vulpea)
 ;;; vulpea.el ends here


### PR DESCRIPTION
Follow up
https://github.com/d12frosted/vulpea/commit/b2bf8c222fff6aa52e8077f9eac6c2e074001858

I have analyzed all usages of `vulpea-create` and there are two
patterns:

1. create and then get from db
2. create and then use meta API, which in turn gets note from db

On the other hand, I think it's totally expected when `vulpea-create`
returns a created note.