### PR TITLE
(feat) provide full note in vulpea-select filter

### DIFF
--- a/test/vulpea-test.el
+++ b/test/vulpea-test.el
@@ -63,7 +63,7 @@
     (expect filter-count :to-equal
             (caar (org-roam-db-query
                    [:select (funcall count *)
-                            :from titles])))))
+                    :from titles])))))
 
 (describe "vulpea-select"
   :var (note)


### PR DESCRIPTION
Instead of getting id only of a selected note, return full notes from
`vulpea--get-title-path-completions`, meaning that users of
`vulpea-select` can filter by id.