### PR TITLE
(feat) vulpea-utils-with-note

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,4 +1,5 @@
 ((emacs-lisp-mode . ((fill-column . 70)
                      (indent-tabs-mode . nil)
-                     (elisp-lint-indent-specs . ((vulpea-utils-with-file . 1)))))
+                     (elisp-lint-indent-specs . ((vulpea-utils-with-file . 1)
+                                                 (vulpea-utils-with-note . 1)))))
  (org-mode . ((fill-column . 80))))

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -48,3 +48,7 @@ Features:
   - =vulpea-meta-remove= - function to remove a =PROP= for =NOTE-OR-ID=.
   - =vulpea-meta-remove= - function to remove all meta for =NOTE-OR-ID=.
   - =vulpea-meta-format= - function to format a =VALUE=.
+- =vulpea-utils= module.
+  - =vulpea-note= type definition.
+  - =vulpea-utils-with-note= - function to execute =BODY= with point at =NOTE=.
+    Supports file-level notes as well as heading notes.

--- a/README.org
+++ b/README.org
@@ -80,6 +80,17 @@ Functions of interest:
 - =vulpea-create= - function to create a new note file with given =TITLE= and
   =TEMPLATE=.
 
+*** =vulpea-utils=
+:PROPERTIES:
+:ID:                     92508fc8-5500-489c-b534-659ebfdb8e9a
+:END:
+
+This module contains =vulpea-note= definition and various utilities. Functions
+of interest:
+
+- =vulpea-utils-with-note= - function to execute =BODY= with point at =NOTE=.
+  Supports file-level notes as well as heading notes.
+
 *** =vulpea-db=
 :PROPERTIES:
 :ID:                     55717e59-d850-4659-8a02-8153fda52fef

--- a/test/vulpea-db-test.el
+++ b/test/vulpea-db-test.el
@@ -15,7 +15,7 @@
 ;;
 ;;; Commentary:
 ;;
-;; Helpers for testing `vulpea-module'.
+;; Test `vulpea-db' module.
 ;;
 ;;; Code:
 

--- a/vulpea-utils.el
+++ b/vulpea-utils.el
@@ -35,6 +35,8 @@
 ;;
 ;;; Code:
 
+(require 'org)
+
 ;;;###autoload
 (cl-defstruct vulpea-note
   id
@@ -45,9 +47,24 @@
 
 ;;;###autoload
 (defmacro vulpea-utils-with-file (file &rest body)
-  "Execute BODY in `org-mode' FILE."
+  "Execute BODY in `org-mode' FILE.
+
+In most cases you should use `vulpea-utils-with-note', because
+that macro properly handles notes with level greater than 0."
   (declare (indent 1) (debug t))
   `(with-current-buffer (find-file-noselect ,file)
+     ,@body))
+
+;;;###autoload
+(defmacro vulpea-utils-with-note (note &rest body)
+  "Execute BODY in with buffer visiting NOTE.
+
+If note level is equal to 0, then the point is placed at the
+beginning of the buffer. Otherwise at the heading with note id."
+  (declare (indent 1) (debug t))
+  `(with-current-buffer (find-file-noselect (vulpea-note-path ,note))
+     (when (> (vulpea-note-level ,note) 0)
+       (goto-char (org-find-entry-with-id (vulpea-note-id ,note))))
      ,@body))
 
 (provide 'vulpea-utils)


### PR DESCRIPTION
Fixes #35

This function actually makes it possible to support heading-level
metadata in `vulpea-meta` API.