### PR TITLE
(feat) support passing extra context for templates to vulpea-create

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -14,6 +14,12 @@
 
 Primarily a stabilization and bug-fix release.
 
+*Features*
+
+- [[https://github.com/d12frosted/vulpea/pull/84][vulpea#84]] Support passing extra context for templates to =vulpea-create=. This
+  is a breaking change, now instead of passing =id= argument, you should pass
+  =(list (cons 'id id))=. While being more verbose it gives much more power.
+
 *Fixes*
 
 - [[https://github.com/d12frosted/vulpea/pull/80][vulpea#80]] Fix how =org-roam-capture--new-file= is called from advice.

--- a/test/utils/vulpea-test-utils.el
+++ b/test/utils/vulpea-test-utils.el
@@ -51,5 +51,28 @@
   (delete-file org-roam-db-location)
   (org-roam-db--close))
 
+(buttercup-define-matcher :to-contain-exactly (file value)
+  (cl-destructuring-bind
+      ((file-expr . file) (value-expr . value))
+      (mapcar #'buttercup--expr-and-value (list file value))
+    (let* ((content (vulpea-test--map-file
+                     (lambda (_)
+                       (buffer-substring-no-properties (point-min)
+                                                       (point-max)))
+                     file))
+           (spec (format-spec-make
+                  ?F (format "%S" file-expr)
+                  ?f (format "%S" file)
+                  ?V (format "%S" value-expr)
+                  ?v (format "%S" value)
+                  ?c (format "%S" content))))
+      (if (string-equal content value)
+          (cons t (buttercup-format-spec
+                   "Expected `%F' not to have content equal to `%v'"
+                   spec))
+        (cons nil (buttercup-format-spec
+                   "Expected `%F' to have content equal to `%v', but instead `%F' has content equal to `%c'"
+                   spec))))))
+
 (provide 'vulpea-test-utils)
 ;;; vulpea-test-utils.el ends here

--- a/test/vulpea-meta-test.el
+++ b/test/vulpea-meta-test.el
@@ -246,29 +246,6 @@
                         'item #'identity))
             :to-equal 0)))
 
-(buttercup-define-matcher :to-contain-exactly (file value)
-  (cl-destructuring-bind
-      ((file-expr . file) (value-expr . value))
-      (mapcar #'buttercup--expr-and-value (list file value))
-    (let* ((content (vulpea-test--map-file
-                     (lambda (_)
-                       (buffer-substring-no-properties (point-min)
-                                                       (point-max)))
-                     file))
-           (spec (format-spec-make
-                  ?F (format "%S" file-expr)
-                  ?f (format "%S" file)
-                  ?V (format "%S" value-expr)
-                  ?v (format "%S" value)
-                  ?c (format "%S" content))))
-      (if (string-equal content value)
-          (cons t (buttercup-format-spec
-                   "Expected `%F' not to have content equal to `%v'"
-                   spec))
-        (cons nil (buttercup-format-spec
-                   "Expected `%F' to have content equal to `%v', but instead `%F' has content equal to `%c'"
-                   spec))))))
-
 (describe "vulpea-meta-format"
   (before-all
     (vulpea-test--init))

--- a/test/vulpea-test.el
+++ b/test/vulpea-test.el
@@ -73,7 +73,7 @@
   (after-all
     (vulpea-test--teardown))
 
-  (it "creates new file with ID and syncs database"
+  (it "creates new file and syncs database"
     (setq note
           (vulpea-create
            "Slarina"
@@ -99,7 +99,105 @@
              :id (vulpea-note-id note)))
     (expect (vulpea-db-get-by-id (vulpea-note-id note))
             :to-equal
-            note)))
+            note))
+
+  (it "creates new file with passed id"
+    (setq note
+          (vulpea-create
+           "Frappato"
+           `("d" "default" plain
+             #'org-roam-capture--get-point
+             "%?"
+             :file-name "prefix-${slug}"
+             :head ,(concat
+                     ":PROPERTIES:\n"
+                     ":ID:                     ${id}\n"
+                     ":END:\n"
+                     "#+TITLE: ${title}\n\n")
+             :unnarrowed t
+             :immediate-finish t)
+           (list (cons 'id "xyz"))))
+    (expect note
+            :to-equal
+            (make-vulpea-note
+             :path (expand-file-name "prefix-frappato.org" org-roam-directory)
+             :title "Frappato"
+             :tags nil
+             :level 0
+             :id "xyz"))
+    (expect (vulpea-db-get-by-id "xyz")
+            :to-equal
+            note))
+
+  (it "creates new file without taking title or slug from passed context"
+    (setq note
+          (vulpea-create
+           "Nerello Mascalese"
+           `("d" "default" plain
+             #'org-roam-capture--get-point
+             "%?"
+             :file-name "prefix-${slug}"
+             :head ,(concat
+                     ":PROPERTIES:\n"
+                     ":ID:                     ${id}\n"
+                     ":END:\n"
+                     "#+TITLE: ${title}\n\n")
+             :unnarrowed t
+             :immediate-finish t)
+           (list (cons 'title "hehe")
+                 (cons 'slug "xoxo"))))
+    (expect note
+            :to-equal
+            (make-vulpea-note
+             :path (expand-file-name "prefix-nerello_mascalese.org" org-roam-directory)
+             :title "Nerello Mascalese"
+             :tags nil
+             :level 0
+             :id (vulpea-note-id note)))
+    (expect (vulpea-db-get-by-id (vulpea-note-id note))
+            :to-equal
+            note))
+
+  (it "creates new file with additional context"
+    (setq note
+          (vulpea-create
+           "Aglianico"
+           `("d" "default" plain
+             #'org-roam-capture--get-point
+             "%?"
+             :file-name "prefix-${slug}"
+             :head ,(concat
+                     ":PROPERTIES:\n"
+                     ":ID:                     ${id}\n"
+                     ":END:\n"
+                     "#+TITLE: ${title}\n"
+                     "#+ROAM_KEY: ${url}"
+                     "\n")
+             :unnarrowed t
+             :immediate-finish t)
+           (list (cons 'url "https://d12frosted.io"))))
+    (expect note
+            :to-equal
+            (make-vulpea-note
+             :path (expand-file-name "prefix-aglianico.org" org-roam-directory)
+             :title "Aglianico"
+             :tags nil
+             :level 0
+             :id (vulpea-note-id note)))
+    (expect (vulpea-db-get-by-id (vulpea-note-id note))
+            :to-equal
+            note)
+    (expect (vulpea-note-path note)
+            :to-contain-exactly
+            (format
+             ":PROPERTIES:
+:ID:                     %s
+:END:
+#+TITLE: Aglianico
+#+ROAM_KEY: https://d12frosted.io
+
+"
+             (vulpea-note-id note)))))
 
 (provide 'vulpea-test)
 ;;; vulpea-test.el ends here

--- a/vulpea.el
+++ b/vulpea.el
@@ -148,10 +148,10 @@ Calls ORIG-FUNC with ALLOW-EXISTING-FILE-P."
             :around
             #'vulpea--capture-new-file)
 
-(defun vulpea-create (title template &optional id)
+(defun vulpea-create (title template &optional context)
   "Create a new note file with TITLE using TEMPLATE.
 
-Returns ID of created note.
+Returns id of created note.
 
 See `org-roam-capture-templates' for description of TEMPLATE.
 
@@ -159,14 +159,20 @@ Available variables in the capture context are:
 
 - slug
 - title
-- ID (passed or generated)"
-  (let* ((id (or id (org-id-new)))
+- id (passed via CONTEXT or generated)
+- all other values from CONTEXT"
+  (let* ((id (or (and context
+                      (alist-get 'id context))
+                 (org-id-new)))
          (org-roam-capture--info
-          (list
-           (cons 'title title)
-           (cons 'slug (funcall org-roam-title-to-slug-function
-                                title))
-           (cons 'id id)))
+          (append
+           (list
+            (cons 'title title)
+            (cons 'slug (funcall org-roam-title-to-slug-function
+                                 title)))
+           context
+           (list
+            (cons 'id id))))
          (org-roam-capture--context 'title)
          (org-roam-capture-templates (list template)))
     (org-roam-capture--capture)


### PR DESCRIPTION
This is a breaking change, now instead of passing `id` argument, you
should pass `(list (cons 'id id))`. While being more verbose it gives
much more power.