### PR TITLE
(feat) support require match in vulpea-select

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -17,8 +17,13 @@ Primarily a stabilization and bug-fix release.
 *Features*
 
 - [[https://github.com/d12frosted/vulpea/pull/84][vulpea#84]] Support passing extra context for templates to =vulpea-create=. This
-  is a breaking change, now instead of passing =id= argument, you should pass
+  is a /breaking change/, now instead of passing =id= argument, you should pass
   =(list (cons 'id id))=. While being more verbose it gives much more power.
+- [[https://github.com/d12frosted/vulpea/pull/85][vulpea#85]] Support require match in =vulpea-select=. This is a /breaking
+  change/, as arguments to =vulpea-select= are passed as keys. In my experience,
+  most of the times first two arguments are =nil= and they are rarely needed. In
+  this way, API of this function is cleaner and opens a way to add new
+  functionality there.
 
 *Fixes*
 

--- a/test/vulpea-test.el
+++ b/test/vulpea-test.el
@@ -57,7 +57,8 @@
     (spy-on 'org-roam-completion--completing-read
             :and-return-value "(tag1,tag2) Reference")
 
-    (vulpea-select "Note" nil nil
+    (vulpea-select "Note"
+                   :filter-fn
                    (lambda (_)
                      (setq filter-count (+ 1 filter-count))))
     (expect filter-count :to-equal

--- a/vulpea.el
+++ b/vulpea.el
@@ -56,14 +56,18 @@
 (require 'vulpea-meta)
 (require 'vulpea-db)
 
-(defun vulpea-select (prompt &optional
-                             initial-prompt
-                             completions
-                             filter-fn)
+(cl-defun vulpea-select (prompt
+                         &key
+                         require-match
+                         initial-prompt
+                         completions
+                         filter-fn)
   "Select a note.
 
 Returns a selected `vulpea-note'. If `vulpea-note-id' is nil, it
 means that user selected non-existing note.
+
+When REQUIRE-MATCH is non-nil, use may select only existing note.
 
 PROMPT is a message to present.
 
@@ -85,6 +89,7 @@ as its argument a `vulpea-note'."
          (title-with-tags (org-roam-completion--completing-read
                            (concat prompt ": ")
                            completions
+                           :require-match require-match
                            :initial-input initial-prompt)))
     (or (cdr (assoc title-with-tags completions))
         (make-vulpea-note


### PR DESCRIPTION
This is a *breaking change*, as arguments to *vulpea-select* are
passed as keys. In my experience, most of the times first two
arguments are `nil` and they are rarely needed. In this way, API of
this function is cleaner and opens a way to add new functionality
there.