### PR TITLE
(feat) persist meta in database

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -15,6 +15,7 @@
 *Features*
 
 - [[https://github.com/d12frosted/vulpea/issues/97][vulpea#97]] Expose properties in =vulpea-note=.
+- [[https://github.com/d12frosted/vulpea/issues/100][vulpea#100]] Persist note meta in =org-roam-db=.
 
 ** v0.2.0
 

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -16,6 +16,9 @@
 
 - [[https://github.com/d12frosted/vulpea/issues/97][vulpea#97]] Expose properties in =vulpea-note=.
 - [[https://github.com/d12frosted/vulpea/issues/100][vulpea#100]] Persist note meta in =org-roam-db=.
+- [[https://github.com/d12frosted/vulpea/issues/100][vulpea#100]] Provide an API to access/extract data from =vulpea-note-meta=:
+  - =vulpea-note-meta-get-list= - to get all values of given =PROP= and =TYPE=.
+  - =vulpea-note-meta-get= - to get the first value of given =PROP= and =TYPE=.
 
 ** v0.2.0
 

--- a/README.org
+++ b/README.org
@@ -91,7 +91,11 @@ Users of this library:
 
 #+begin_src emacs-lisp
   (use-package vulpea
-    :ensure t)
+    :ensure t
+    ;; hook into org-roam-db-autosync-mode you wish to enable
+    ;; persistence of meta values (see respective section in README to
+    ;; find out what meta means)
+    :hook ((org-roam-db-autosync-mode . vulpea-db-setup)))
 #+end_src
 
 ** straight.el
@@ -99,6 +103,12 @@ Users of this library:
 #+begin_src emacs-lisp
   (straight-use-package
    '(vulpea :type git :host github :repo "d12frosted/vulpea"))
+
+  ;; hook into org-roam-db-autosync-mode you wish to enable persistence
+  ;; of meta values (see respective section in README to find out what
+  ;; meta means)
+  (add-hook 'org-roam-db-autosync-mode-hook #'vulpea-db-setup)
+
 #+end_src
 
 In case you have [[https://github.com/raxod502/straight.el/#integration-with-use-package][integration]] with [[https://github.com/jwiegley/use-package][use-package]]:
@@ -108,7 +118,11 @@ In case you have [[https://github.com/raxod502/straight.el/#integration-with-use
     :straight (vulpea
                :type git
                :host github
-               :repo "d12frosted/vulpea"))
+               :repo "d12frosted/vulpea")
+    ;; hook into org-roam-db-autosync-mode you wish to enable
+    ;; persistence of meta values (see respective section in README to
+    ;; find out what meta means)
+    :hook ((org-roam-db-autosync-mode . vulpea-db-setup)))
 #+end_src
 
 * Data types

--- a/README.org
+++ b/README.org
@@ -125,6 +125,9 @@ slots/fields:
   =title= is an alias);
 - =vulpea-note-aliases= - aliases of the note;
 - =vulpea-note-tags= - tags of the note;
+- =vulpea-note-meta= - associative list of metadata (see =vulpea-meta= module
+  description for more information), where key is a string and the value is a
+  list of strings.
 
 If =ID= is not present in the note structure, this note is treated as
 non-existent. For example, =vulpea-select= returns such a note, when

--- a/README.org
+++ b/README.org
@@ -200,7 +200,11 @@ configurable values:
 
 ** =vulpea-note=
 
-This module contains =vulpea-note= definition.
+This module contains =vulpea-note= definition and few helpers to access/extract
+data from =vulpea-note-meta= slot:
+
+- =vulpea-note-meta-get-list= - to get all values of given =PROP= and =TYPE=.
+- =vulpea-note-meta-get= - to get the first value of given =PROP= and =TYPE=.
 
 ** =vulpea-db=
 

--- a/test/utils/vulpea-test-utils.el
+++ b/test/utils/vulpea-test-utils.el
@@ -42,11 +42,12 @@
         (new-dir (expand-file-name (make-temp-name "note-files") temporary-file-directory)))
     (copy-directory original-dir new-dir)
     (setq org-roam-directory new-dir)
-    (org-roam-setup)))
+    (vulpea-db-setup)
+    (org-roam-db-autosync-enable)))
 
 (defun vulpea-test--teardown ()
   "Teardown testing environment."
-  (org-roam-teardown)
+  (org-roam-db-autosync-disable)
   (delete-file org-roam-db-location))
 
 (buttercup-define-matcher :to-contain-exactly (file value)

--- a/test/vulpea-db-test.el
+++ b/test/vulpea-db-test.el
@@ -169,7 +169,39 @@
                            (cons "ID" "68f11246-91e1-4d48-b3c6-801a2ef0160b")
                            (cons "BLOCKED" "")
                            (cons "FILE" (expand-file-name "same-name-2.org" org-roam-directory))
-                           (cons "PRIORITY" "B")))))))
+                           (cons "PRIORITY" "B"))))))
+
+  (it "includes meta"
+    (expect (vulpea-db-query
+             (lambda (n)
+               (seq-contains-p
+                (cdr (assoc "singleton" (vulpea-note-meta n)))
+                "only value")))
+            :to-have-same-items-as
+            (list
+             (make-vulpea-note
+              :path (expand-file-name "with-meta.org" org-roam-directory)
+              :title "Note with META"
+              :tags nil
+              :level 0
+              :id "05907606-f836-45bf-bd36-a8444308eddd"
+              :properties (list
+                           (cons "CATEGORY" "with-meta")
+                           (cons "ID" "05907606-f836-45bf-bd36-a8444308eddd")
+                           (cons "BLOCKED" "")
+                           (cons "FILE" (expand-file-name "with-meta.org" org-roam-directory))
+                           (cons "PRIORITY" "B"))
+              :meta
+              '(("name" . ("some name"))
+                ("tags" . ("tag 1" "tag 2" "tag 3"))
+                ("numbers" . ("12" "18" "24"))
+                ("singleton" . ("only value"))
+                ("symbol" . ("red"))
+                ("url" . ("[[https://en.wikipedia.org/wiki/Frappato][wikipedia.org]]"))
+                ("link" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Note without META]]"))
+                ("references" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Note without META]]"
+                                 "[[id:5093fc4e-8c63-4e60-a1da-83fc7ecd5db7][Reference]]"))
+                ("answer" . ("42"))))))))
 
 (describe "vulpea-db-get-by-id"
   (before-all
@@ -193,12 +225,12 @@
              :level 0
              :id "72522ed2-9991-482e-a365-01155c172aa5"
              :properties (list
-                           (cons "CATEGORY" "note-with-alias")
-                           (cons "ROAM_ALIASES" "\"Alias of the note with alias\"")
-                           (cons "ID" "72522ed2-9991-482e-a365-01155c172aa5")
-                           (cons "BLOCKED" "")
-                           (cons "FILE" (expand-file-name "note-with-alias.org" org-roam-directory))
-                           (cons "PRIORITY" "B")))))
+                          (cons "CATEGORY" "note-with-alias")
+                          (cons "ROAM_ALIASES" "\"Alias of the note with alias\"")
+                          (cons "ID" "72522ed2-9991-482e-a365-01155c172aa5")
+                          (cons "BLOCKED" "")
+                          (cons "FILE" (expand-file-name "note-with-alias.org" org-roam-directory))
+                          (cons "PRIORITY" "B")))))
 
   (it "returns note by sub-heading id"
     (expect (vulpea-db-get-by-id "b77a4837-71d6-495e-98f1-b576464aacc1")
@@ -232,7 +264,33 @@
                           (cons "BLOCKED" "")
                           (cons "FILE" (expand-file-name "big-note.org" org-roam-directory))
                           (cons "PRIORITY" "B")
-                          (cons "ITEM" "Big note sub-sub-heading"))))))
+                          (cons "ITEM" "Big note sub-sub-heading")))))
+
+  (it "includes meta in response"
+    (expect (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd")
+            :to-equal
+            (make-vulpea-note
+             :path (expand-file-name "with-meta.org" org-roam-directory)
+             :title "Note with META"
+             :tags nil
+             :level 0
+             :id "05907606-f836-45bf-bd36-a8444308eddd"
+             :properties (list
+                          (cons "CATEGORY" "with-meta")
+                          (cons "ID" "05907606-f836-45bf-bd36-a8444308eddd")
+                          (cons "BLOCKED" "")
+                          (cons "FILE" (expand-file-name "with-meta.org" org-roam-directory))
+                          (cons "PRIORITY" "B"))
+             :meta '(("name" . ("some name"))
+                     ("tags" . ("tag 1" "tag 2" "tag 3"))
+                     ("numbers" . ("12" "18" "24"))
+                     ("singleton" . ("only value"))
+                     ("symbol" . ("red"))
+                     ("url" . ("[[https://en.wikipedia.org/wiki/Frappato][wikipedia.org]]"))
+                     ("link" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Note without META]]"))
+                     ("references" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Note without META]]"
+                                      "[[id:5093fc4e-8c63-4e60-a1da-83fc7ecd5db7][Reference]]"))
+                     ("answer" . ("42")))))))
 
 (describe "vulpea-db-get-file-by-id"
   (before-all

--- a/test/vulpea-meta-test.el
+++ b/test/vulpea-meta-test.el
@@ -20,7 +20,6 @@
 ;;; Code:
 
 (require 'vulpea-test-utils)
-(require 'buttercup)
 (require 'org-roam)
 (require 'vulpea-meta)
 (require 'vulpea-db)

--- a/test/vulpea-note-test.el
+++ b/test/vulpea-note-test.el
@@ -1,0 +1,135 @@
+;;; vulpea-note-test.el --- Test note API -*- lexical-binding: t; -*-
+;;
+;; Copyright (c) 2021 Boris Buliga
+;;
+;; Author: Boris Buliga <d12frosted@d12frosted>
+;; Maintainer: Boris Buliga <d12frosted@d12frosted>
+;;
+;; Created: 18 Aug 2021
+;;
+;; URL: https://github.com/d12frosted/
+;;
+;; License: GPLv3
+;;
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program. If not, see
+;; <http://www.gnu.org/licenses/>.
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; Commentary:
+;;
+;; Test `vulpea-note' module.
+;;
+;;; Code:
+
+(require 'vulpea-test-utils)
+
+(describe "vulpea-note-meta-get"
+  (before-all
+    (vulpea-test--init))
+
+  (after-all
+    (vulpea-test--teardown))
+
+  (it "extracts string value by default"
+    (let ((a (vulpea-note-meta-get (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "name" 'string))
+          (b (vulpea-note-meta-get (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "name")))
+      (expect a :to-equal b)))
+
+  (it "extracts string value"
+    (expect (vulpea-note-meta-get (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "name" 'string)
+            :to-equal "some name"))
+
+  (it "extracts number value"
+    (expect (vulpea-note-meta-get (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "answer" 'number)
+            :to-equal 42))
+
+  (it "extracts link value"
+    (expect (vulpea-note-meta-get (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "link" 'link)
+            :to-equal "444f94d7-61e0-4b7c-bb7e-100814c6b4bb"))
+
+  (it "extracts URL value"
+    (expect (vulpea-note-meta-get (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "url" 'link)
+            :to-equal "https://en.wikipedia.org/wiki/Frappato"))
+
+  (it "extracts note value"
+    (expect (vulpea-note-meta-get (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "link" 'note)
+            :to-equal (vulpea-db-get-by-id "444f94d7-61e0-4b7c-bb7e-100814c6b4bb")))
+
+  (it "extracts symbol value"
+    (expect (vulpea-note-meta-get (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "symbol" 'symbol)
+            :to-equal 'red))
+
+  (it "extracts first element of the list"
+    (expect (vulpea-note-meta-get (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "tags" 'string)
+            :to-equal "tag 1")))
+
+(describe "vulpea-note-meta-get-list"
+  (before-all
+    (vulpea-test--init))
+
+  (after-all
+    (vulpea-test--teardown))
+
+  (it "extracts string value by default"
+    (let ((a (vulpea-note-meta-get-list (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "name" 'string))
+          (b (vulpea-note-meta-get-list (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "name")))
+      (expect a :to-equal b)))
+
+  (it "extracts string value"
+    (expect (vulpea-note-meta-get-list (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "name" 'string)
+            :to-equal '("some name")))
+
+  (it "extracts number value"
+    (expect (vulpea-note-meta-get-list (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "answer" 'number)
+            :to-equal '(42)))
+
+  (it "extracts link value"
+    (expect (vulpea-note-meta-get-list (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "link" 'link)
+            :to-equal '("444f94d7-61e0-4b7c-bb7e-100814c6b4bb")))
+
+  (it "extracts URL value"
+    (expect (vulpea-note-meta-get-list (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "url" 'link)
+            :to-equal '("https://en.wikipedia.org/wiki/Frappato")))
+
+  (it "extracts note value"
+    (expect (vulpea-note-meta-get-list (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "link" 'note)
+            :to-equal (list (vulpea-db-get-by-id "444f94d7-61e0-4b7c-bb7e-100814c6b4bb"))))
+
+  (it "extracts symbol value"
+    (expect (vulpea-note-meta-get-list (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "symbol" 'symbol)
+            :to-equal '(red)))
+
+  (it "extracts list of strings"
+    (expect (vulpea-note-meta-get-list (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "tags" 'string)
+            :to-equal '("tag 1"
+                        "tag 2"
+                        "tag 3")))
+
+  (it "extracts list of numbers"
+    (expect (vulpea-note-meta-get-list (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "numbers" 'number)
+            :to-equal '(12 18 24)))
+
+  (it "extracts list of links"
+    (expect (vulpea-note-meta-get-list (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "references" 'link)
+            :to-equal '("444f94d7-61e0-4b7c-bb7e-100814c6b4bb"
+                        "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7")))
+
+  (it "extracts list of notes"
+    (expect (vulpea-note-meta-get-list (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "references" 'note)
+            :to-equal (list (vulpea-db-get-by-id "444f94d7-61e0-4b7c-bb7e-100814c6b4bb")
+                            (vulpea-db-get-by-id "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7")))))
+
+(provide 'vulpea-note-test)
+;;; vulpea-note-test.el ends here

--- a/vulpea-note.el
+++ b/vulpea-note.el
@@ -35,8 +35,6 @@
 ;;
 ;;; Code:
 
-(require 'org-roam)
-
 (cl-defstruct vulpea-note
   id
   path
@@ -45,19 +43,8 @@
   primary-title
   aliases
   tags
-  properties)
-
-(defun vulpea-note-from-node (node)
-  "Convert NODE represented as `org-roam-node' to `vulpea-note'."
-  (when (org-roam-node-title node)
-    (make-vulpea-note
-     :id (org-roam-node-id node)
-     :path (org-roam-node-file node)
-     :level (or (org-roam-node-level node) 0)
-     :title (org-roam-node-title node)
-     :aliases (org-roam-node-aliases node)
-     :tags (org-roam-node-tags node)
-     :properties (org-roam-node-properties node))))
+  properties
+  meta)
 
 (provide 'vulpea-note)
 ;;; vulpea-note.el ends here

--- a/vulpea-note.el
+++ b/vulpea-note.el
@@ -35,6 +35,8 @@
 ;;
 ;;; Code:
 
+(require 'ol)
+
 (cl-defstruct vulpea-note
   id
   path
@@ -45,6 +47,59 @@
   tags
   properties
   meta)
+
+(autoload 'vulpea-db-get-by-id "vulpea-db")
+
+(defun vulpea-note-meta-get-list (note prop &optional type)
+  "Get all values of PROP from NOTE meta.
+
+Each element value depends on TYPE:
+
+- string (default) - an interpreted object (without trailing
+  newline)
+- number - an interpreted number
+- link - path of the link (either ID of the linked note or raw link)
+- note - linked `vulpea-note'
+- symbol - an interned symbol."
+  (setq type (or type 'string))
+  (let ((items (cdr (assoc prop (vulpea-note-meta note)))))
+    (seq-map
+     (lambda (item)
+       (pcase type
+         (`string item)
+         (`symbol (intern item))
+         (`number (string-to-number item))
+         (`note (if (string-match org-link-bracket-re item)
+                    (let ((link (match-string 1 item)))
+                      (if (string-prefix-p "id:" link)
+                          (vulpea-db-get-by-id
+                           (string-remove-prefix "id:" link))
+                        (user-error "Expected id link, but got '%s'"
+                                    item)))
+                  (user-error "Expected link, but got '%s'" item)))
+         (`link (if (string-match org-link-bracket-re item)
+                    (let ((link (match-string 1 item)))
+                      (if (string-prefix-p "id:" link)
+                          (string-remove-prefix "id:" link)
+                        link))))))
+     items)))
+
+(defun vulpea-note-meta-get (note prop &optional type)
+  "Get value of PROP from NOTE meta.
+
+Result depends on TYPE:
+
+- string (default) - an interpreted object (without trailing
+  newline)
+- number - an interpreted number
+- link - path of the link (either ID of the linked note or raw link)
+- note - linked `vulpea-note'
+- symbol - an interned symbol.
+
+If the note contains multiple values for a given PROP, the first
+one is returned. In case all values are required, use
+`vulpea-note-meta-get-list'."
+  (car (vulpea-note-meta-get-list note prop type)))
 
 (provide 'vulpea-note)
 ;;; vulpea-note.el ends here

--- a/vulpea.el
+++ b/vulpea.el
@@ -95,7 +95,7 @@ start the capture process."
   (let* ((node (org-roam-node-at-point 'assert))
          (backlinks (seq-map
                      (lambda (x)
-                       (vulpea-note-from-node
+                       (vulpea-db--from-node
                         (org-roam-backlink-source-node x)))
                      (org-roam-backlinks-get node))))
     (unless backlinks


### PR DESCRIPTION
Fixes #100

The approach is to hook into `org-roam-db` routine. It is not ideal
and intrusive, but provides a quick means to achieve the goal without
writing infrastructure for database management.

`vulpea-note-meta` is an associative list. Every key is a string and
the value is a list of strings. Since semantics of each property are
known only to the end user (e.g. it's a link to some other note and
there can be a single value, etc.) we persist only string. In order to
make it easier to access the data with respect of semantics we need
some API similar to existing meta API, but working on assoc. This will
be covered in the upcoming commit.