### PR TITLE
(feat) actually improve performance of specialized queries

### DIFF
--- a/README.org
+++ b/README.org
@@ -428,14 +428,17 @@ when performance is critical, one can use specialized queries:
   provided =DESTINATIONS=;
 
 The following table displays time required to query notes by using
-=vulpea-db-query= vs specialized query on the database of ~9500 notes.
+=vulpea-db-query= vs specialized query on the database of 9554 [[https://github.com/d12frosted/vulpea-test-notes/][generated notes]].
+The difference between various test cases is partially explained by the fact
+that filtering functions result in different amount of notes. Since we need to
+retrieve full note structure, the more notes we have, the more time it takes.
 
-| test          |            generic |  specialized |
-|---------------+--------------------+--------------|
-| =tags-some=   | 4.6693460650999995 | 0.0605194177 |
-| =tags-every=  | 4.7333844436999996 | 1.0618131127 |
-| =links-some=  |       4.8095771283 |  1.362214091 |
-| =links-every= | 4.5517473337999995 | 0.1707312557 |
+| test          | result size |            generic |  specialized |
+|---------------+-------------+--------------------+--------------|
+| =tags-some=   | 30 notes    | 4.6693460650999995 | 0.0605194177 |
+| =tags-every=  | 3168 notes  | 4.7333844436999996 | 1.0618131127 |
+| =links-some=  | 1657 notes  |       4.8095771283 |  1.362214091 |
+| =links-every= | 92 notes    | 4.5517473337999995 | 0.1707312557 |
 
 See [[https://github.com/d12frosted/vulpea/discussions/106#discussioncomment-1601429][this comment]] for more background on why these functions where created.
 

--- a/README.org
+++ b/README.org
@@ -432,10 +432,10 @@ The following table displays time required to query notes by using
 
 | test          |            generic |  specialized |
 |---------------+--------------------+--------------|
-| =tags-some=   | 2.5866148216000003 | 0.0003537717 |
-| =tags-every=  |       2.7016701243 | 0.0003028715 |
-| =links-some=  |       2.7395955169 | 0.0054181364 |
-| =links-every= |        2.704427894 | 0.0169718277 |
+| =tags-some=   | 4.6693460650999995 | 0.0605194177 |
+| =tags-every=  | 4.7333844436999996 | 1.0618131127 |
+| =links-some=  |       4.8095771283 |  1.362214091 |
+| =links-every= | 4.5517473337999995 | 0.1707312557 |
 
 See [[https://github.com/d12frosted/vulpea/discussions/106#discussioncomment-1601429][this comment]] for more background on why these functions where created.
 

--- a/test/vulpea-db-test.el
+++ b/test/vulpea-db-test.el
@@ -435,6 +435,22 @@
                            (cons "ID" "72522ed2-9991-482e-a365-01155c172aa5")
                            (cons "BLOCKED" "")
                            (cons "FILE" (expand-file-name "note-with-alias.org" org-roam-directory))
+                           (cons "PRIORITY" "B")))
+             (make-vulpea-note
+              :path (expand-file-name "note-with-alias.org" org-roam-directory)
+              :title "Alias of the note with alias"
+              :primary-title "Note with an alias"
+              :tags nil
+              :aliases '("Alias of the note with alias")
+              :level 0
+              :id "72522ed2-9991-482e-a365-01155c172aa5"
+              :links '(("id" . "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7"))
+              :properties (list
+                           (cons "CATEGORY" "note-with-alias")
+                           (cons "ROAM_ALIASES" "\"Alias of the note with alias\"")
+                           (cons "ID" "72522ed2-9991-482e-a365-01155c172aa5")
+                           (cons "BLOCKED" "")
+                           (cons "FILE" (expand-file-name "note-with-alias.org" org-roam-directory))
                            (cons "PRIORITY" "B"))))))
 
   (it "returns only notes linking to any of destinations: >1 link"
@@ -485,6 +501,22 @@
                            (cons "FILE" (expand-file-name "note-with-alias.org" org-roam-directory))
                            (cons "PRIORITY" "B")))
              (make-vulpea-note
+              :path (expand-file-name "note-with-alias.org" org-roam-directory)
+              :title "Alias of the note with alias"
+              :primary-title "Note with an alias"
+              :tags nil
+              :aliases '("Alias of the note with alias")
+              :level 0
+              :id "72522ed2-9991-482e-a365-01155c172aa5"
+              :links '(("id" . "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7"))
+              :properties (list
+                           (cons "CATEGORY" "note-with-alias")
+                           (cons "ROAM_ALIASES" "\"Alias of the note with alias\"")
+                           (cons "ID" "72522ed2-9991-482e-a365-01155c172aa5")
+                           (cons "BLOCKED" "")
+                           (cons "FILE" (expand-file-name "note-with-alias.org" org-roam-directory))
+                           (cons "PRIORITY" "B")))
+             (make-vulpea-note
               :path (expand-file-name "note-with-link.org" org-roam-directory)
               :title "Note with link"
               :tags nil
@@ -498,21 +530,19 @@
                            (cons "FILE" (expand-file-name "note-with-link.org" org-roam-directory))
                            (cons "PRIORITY" "B"))))))
 
-  (it "returns the same elements as vulpea-db-query (ignoring aliases)"
+  (it "returns the same elements as vulpea-db-query"
     (let ((links '(("id" . "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7")
                    ("id" . "444f94d7-61e0-4b7c-bb7e-100814c6b4bb"))))
       (expect
        (vulpea-db-query-by-links-some links)
        :to-have-same-items-as
-       (seq-remove
-        #'vulpea-note-primary-title
-        (vulpea-db-query
-         (lambda (note)
-           (let ((note-links (vulpea-note-links note)))
-             (seq-some
-              (lambda (link)
-                (seq-contains-p note-links link))
-              links)))))))))
+       (vulpea-db-query
+        (lambda (note)
+          (let ((note-links (vulpea-note-links note)))
+            (seq-some
+             (lambda (link)
+               (seq-contains-p note-links link))
+             links))))))))
 
 (describe "vulpea-db-query-by-links-every"
   (before-all
@@ -570,6 +600,22 @@
                            (cons "ID" "72522ed2-9991-482e-a365-01155c172aa5")
                            (cons "BLOCKED" "")
                            (cons "FILE" (expand-file-name "note-with-alias.org" org-roam-directory))
+                           (cons "PRIORITY" "B")))
+             (make-vulpea-note
+              :path (expand-file-name "note-with-alias.org" org-roam-directory)
+              :title "Alias of the note with alias"
+              :primary-title "Note with an alias"
+              :tags nil
+              :aliases '("Alias of the note with alias")
+              :level 0
+              :id "72522ed2-9991-482e-a365-01155c172aa5"
+              :links '(("id" . "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7"))
+              :properties (list
+                           (cons "CATEGORY" "note-with-alias")
+                           (cons "ROAM_ALIASES" "\"Alias of the note with alias\"")
+                           (cons "ID" "72522ed2-9991-482e-a365-01155c172aa5")
+                           (cons "BLOCKED" "")
+                           (cons "FILE" (expand-file-name "note-with-alias.org" org-roam-directory))
                            (cons "PRIORITY" "B"))))))
 
   (it "returns only notes linking each and every of destinations: >1 tag"
@@ -610,20 +656,18 @@
             :to-have-same-items-as
             (vulpea-db-query-by-links-some '(("id" . "444f94d7-61e0-4b7c-bb7e-100814c6b4bb")))))
 
-  (it "returns the same elements as vulpea-db-query (ignoring aliases)"
+  (it "returns the same elements as vulpea-db-query"
     (let ((links '(("id" . "444f94d7-61e0-4b7c-bb7e-100814c6b4bb"))))
       (expect
        (vulpea-db-query-by-links-every links)
        :to-have-same-items-as
-       (seq-remove
-        #'vulpea-note-primary-title
-        (vulpea-db-query
-         (lambda (note)
-           (let ((note-links (vulpea-note-links note)))
-             (seq-every-p
-              (lambda (tag)
-                (seq-contains-p note-links tag))
-              links)))))))))
+       (vulpea-db-query
+        (lambda (note)
+          (let ((note-links (vulpea-note-links note)))
+            (seq-every-p
+             (lambda (tag)
+               (seq-contains-p note-links tag))
+             links))))))))
 
 (describe "vulpea-db-get-by-id"
   (before-all

--- a/test/vulpea-perf-test.el
+++ b/test/vulpea-perf-test.el
@@ -49,147 +49,175 @@
          (_ (url-copy-file vulpea-perf-zip-url zip-file-loc))
          (_ (shell-command (format "mkdir -p %s && unzip -qq %s -d %s" temp-loc zip-file-loc temp-loc)))
          (test-notes-dir (expand-file-name "vulpea-test-notes-master/" temp-loc)))
-    (setq org-roam-directory (expand-file-name "notes-generated/notes/" test-notes-dir)
+    (setq org-roam-directory (expand-file-name "notes/" test-notes-dir)
           org-roam-db-location (expand-file-name "org-roam.db" test-notes-dir))
     ;; fix file path values
     (let ((db (emacsql-sqlite org-roam-db-location)))
       (emacsql db (format "update nodes set file = '\"' || '%s' || replace(file, '\"', '') || '\"'"
                           org-roam-directory)))
     (vulpea-db-autosync-enable)
-    (org-roam-db-autosync-enable)
-    (message "Count of notes: %s" (length (vulpea-db-query)))))
+    (org-roam-db-autosync-enable)))
+
+(defmacro vulpea-benchmark-run (n fn &optional to-str &rest args)
+  "Benchmark FN by running it N times with ARGS.
+
+It also prints some possibly useful information. Result of the
+last FN evaluation is converted to string using provided TO-STR
+function.
+
+Return a list of the last FN evaluation result, the total elapsed
+time for execution, the number of garbage collections that ran,
+and the time taken by garbage collection. See also
+`benchmark-run-compiled'."
+  (declare (indent 1) (debug t))
+  `(let* ((v)
+          (result)
+          (name (symbol-name ,fn)))
+     (message "[%s] begin benchmark with %s invocations"
+              name ,n)
+     (setq result
+           (benchmark-run ,n
+             (setq v (funcall ,fn ,@args))))
+     (message "[%s] benchmark result is %s after %s invocations%s"
+              name result ,n
+              (if ,to-str
+                  (concat " => " (funcall ,to-str v))
+                ""))
+     (cons v result)))
+
+(defun vulpea-query-result-to-str (notes)
+  "Convert NOTES to string."
+  (format "%s notes"
+          (seq-length notes)))
 
 (describe "vulpea performance"
   (before-all
     (vulpea-perf--init))
 
+  (before-each
+    (message "Count of notes: %s"
+             (caar (org-roam-db-query "select count(*) from nodes"))))
+
   (after-all
     (vulpea-test--teardown))
 
   (describe "vulpea-select"
-    :var (duration)
     (it "select without filter is relatively fast on 9500+ notes"
       (spy-on 'completing-read
               :and-return-value "bell-bottom sprue Presently the roots")
-      (setq duration
-            (benchmark-run 10
-              (vulpea-select "Note")))
-      (message "duration = %s" duration)
-      ;; 40 seconds for 10 runs is pretty fast for 9500+ notes
-      (expect (car duration) :to-be-less-than 40))
+      (let* ((runs 10)
+             (bres (vulpea-benchmark-run runs
+                     #'vulpea-select nil "Note")))
+        ;; 60 seconds for 10 runs is pretty fast for 9500+ notes
+        (expect (nth 1 bres) :to-be-less-than 60)))
 
     (it "select with filter is relatively fast on 9500+ notes"
       (spy-on 'completing-read
               :and-return-value "bell-bottom sprue Presently the roots")
-      (setq duration
-            (benchmark-run 10
-              (vulpea-select "Note"
-                             :filter-fn
-                             (lambda (n)
-                               (string-prefix-p
-                                "bell-bottom"
-                                (vulpea-note-title n))))))
-      (message "duration = %s" duration)
-      ;; 40 seconds for 10 runs is pretty fast for 9500+ notes
-      (expect (car duration) :to-be-less-than 40)))
+      (let* ((runs 10)
+             (bres (vulpea-benchmark-run runs
+                     #'vulpea-select nil
+                     "Note"
+                     :filter-fn
+                     (lambda (n)
+                       (string-prefix-p
+                        "bell-bottom"
+                        (vulpea-note-title n))))))
+        ;; 60 seconds for 10 runs is pretty fast for 9500+ notes
+        (expect (nth 1 bres) :to-be-less-than 60))))
 
   (describe "vulpea-db-query-by-tags-some"
     (it "specialized query is faster than generic vulpea-db-query"
       (let* ((runs 10)
-             (tags-all (seq-map
-                        #'car
-                        (org-roam-db-query "select tag from tags group by tag order by count(1) desc")))
-             (tags (append (seq-take tags-all 2)
-                           (last tags-all 2)))
-             (duration1 (benchmark-run runs
-                          (vulpea-db-query-by-tags-some tags)))
-             (duration2 (benchmark-run runs
-                          (vulpea-db-query (lambda (note)
-                                             (let ((note-tags (vulpea-note-tags note)))
-                                               (seq-some
-                                                (lambda (tag)
-                                                  (seq-contains-p note-tags tag))
-                                                tags)))))))
-        (message "runs = %s" runs)
-        (message "duration specialized = %s" duration1)
-        (message "duration generic     = %s" duration2)
-        (expect (car duration1)
-                :to-be-less-than
-                (car duration2)))))
+             (tags '("grape" "region"))
+             (bres1 (vulpea-benchmark-run runs
+                      #'vulpea-db-query-by-tags-some
+                      #'vulpea-query-result-to-str
+                      tags))
+             (bres2 (vulpea-benchmark-run runs
+                      #'vulpea-db-query
+                      #'vulpea-query-result-to-str
+                      (lambda (note)
+                        (let ((note-tags (vulpea-note-tags note)))
+                          (seq-some
+                           (lambda (tag)
+                             (seq-contains-p note-tags tag))
+                           tags))))))
+        (expect (seq-length (nth 0 bres1)) :to-be-greater-than 0)
+        (expect (seq-length (nth 0 bres1)) :to-equal (seq-length (nth 0 bres2)))
+        (expect (nth 1 bres1) :to-be-less-than (nth 1 bres2)))))
 
   (describe "vulpea-db-query-by-tags-every"
     (it "specialized query is faster than generic vulpea-db-query"
       (let* ((runs 10)
-             (tags-all (seq-map
-                        #'car
-                        (org-roam-db-query "select tag from tags group by tag order by count(1) desc")))
-             (tags (append (seq-take tags-all 2)
-                           (last tags-all 2)))
-             (duration1 (benchmark-run runs
-                          (vulpea-db-query-by-tags-every tags)))
-             (duration2 (benchmark-run runs
-                          (vulpea-db-query (lambda (note)
-                                             (let ((note-tags (vulpea-note-tags note)))
-                                               (seq-every-p
-                                                (lambda (tag)
-                                                  (seq-contains-p note-tags tag))
-                                                tags)))))))
-        (message "runs = %s" runs)
-        (message "duration specialized = %s" duration1)
-        (message "duration generic     = %s" duration2)
-        (expect (car duration1)
-                :to-be-less-than
-                (car duration2)))))
+             (tags '("wine" "rating"))
+             (bres1 (vulpea-benchmark-run runs
+                      #'vulpea-db-query-by-tags-every
+                      #'vulpea-query-result-to-str
+                      tags))
+             (bres2 (vulpea-benchmark-run runs
+                      #'vulpea-db-query
+                      #'vulpea-query-result-to-str
+                      (lambda (note)
+                        (let ((note-tags (vulpea-note-tags note)))
+                          (seq-every-p
+                           (lambda (tag)
+                             (seq-contains-p note-tags tag))
+                           tags))))))
+        (expect (seq-length (nth 0 bres1)) :to-be-greater-than 0)
+        (expect (seq-length (nth 0 bres1)) :to-equal (seq-length (nth 0 bres2)))
+        (expect (nth 1 bres1) :to-be-less-than (nth 1 bres2)))))
 
   (describe "vulpea-db-query-by-links-some"
     (it "specialized query is faster than generic vulpea-db-query"
       (let* ((runs 10)
              (links-all (seq-map
                          (lambda (link)
-                           (cons "id" link))
+                           (cons "id" (car link)))
                          (org-roam-db-query "select dest from links where \"type\" = '\"id\"' group by dest order by count(1) desc")))
              (links (append (seq-take links-all 2)
                             (last links-all 2)))
-             (duration1 (benchmark-run runs
-                          (vulpea-db-query-by-links-some links)))
-             (duration2 (benchmark-run runs
-                          (vulpea-db-query (lambda (note)
-                                             (let ((note-links (vulpea-note-links note)))
-                                               (seq-some
-                                                (lambda (link)
-                                                  (seq-contains-p note-links link))
-                                                links)))))))
-        (message "runs = %s" runs)
-        (message "duration specialized = %s" duration1)
-        (message "duration generic     = %s" duration2)
-        (expect (car duration1)
-                :to-be-less-than
-                (car duration2)))))
+             (bres1 (vulpea-benchmark-run runs
+                      #'vulpea-db-query-by-links-some
+                      #'vulpea-query-result-to-str
+                      links))
+             (bres2 (vulpea-benchmark-run runs
+                      #'vulpea-db-query
+                      #'vulpea-query-result-to-str
+                      (lambda (note)
+                        (let ((note-links (vulpea-note-links note)))
+                          (seq-some
+                           (lambda (link)
+                             (seq-contains-p note-links link))
+                           links))))))
+        (expect (seq-length (nth 0 bres1)) :to-be-greater-than 0)
+        (expect (seq-length (nth 0 bres1)) :to-equal (seq-length (nth 0 bres2)))
+        (expect (nth 1 bres1) :to-be-less-than (nth 1 bres2)))))
 
   (describe "vulpea-db-query-by-links-every"
     (it "specialized query is faster than generic vulpea-db-query"
       (let* ((runs 10)
              (links-all (seq-map
                          (lambda (link)
-                           (cons "id" link))
+                           (cons "id" (car link)))
                          (org-roam-db-query "select dest from links where \"type\" = '\"id\"' group by dest order by count(1) desc")))
-             (links (append (seq-take links-all 2)
-                            (last links-all 2)))
-             (duration1 (benchmark-run runs
-                          (vulpea-db-query-by-links-every links)))
-             (duration2 (benchmark-run runs
-                          (vulpea-db-query (lambda (note)
-                                             (let ((note-links (vulpea-note-links note)))
-                                               (seq-every-p
-                                                (lambda (link)
-                                                  (seq-contains-p note-links link))
-                                                links)))))))
-        (message "runs = %s" runs)
-        (message "duration specialized = %s" duration1)
-        (message "duration generic     = %s" duration2)
-        (expect (car duration1)
-                :to-be-less-than
-                (car duration2))))))
+             (links (seq-take links-all 2))
+             (bres1 (vulpea-benchmark-run runs
+                      #'vulpea-db-query-by-links-every
+                      #'vulpea-query-result-to-str
+                      links))
+             (bres2 (vulpea-benchmark-run runs
+                      #'vulpea-db-query
+                      #'vulpea-query-result-to-str
+                      (lambda (note)
+                        (let ((note-links (vulpea-note-links note)))
+                          (seq-every-p
+                           (lambda (link)
+                             (seq-contains-p note-links link))
+                           links))))))
+        (expect (seq-length (nth 0 bres1)) :to-be-greater-than 0)
+        (expect (seq-length (nth 0 bres1)) :to-equal (seq-length (nth 0 bres2)))
+        (expect (nth 1 bres1) :to-be-less-than (nth 1 bres2))))))
 
 (provide 'vulpea-perf-test)
 ;;; vulpea-perf-test.el ends here


### PR DESCRIPTION
And again I fall into trap of checking performance of functions with
empty data set. I used notes that I generated during org-roam v1 and
they had invalid format of tags, meaning that there were 0 notes in
the resulting data set, meaning that I didn't really test for notes
retrieval.

Now that is fixed by the following steps.

1. Test set was generated again with org-roam v2 and it contains 9554
   notes with links, properties and proper tags.

2. To make sure that the data set is not malformed, there is a special
   check that result of benchmarked function is not empty.

3. Last, but the thing that actually fix performance - bulk retrieve
   all matched notes instead of using many calls to
   `vulpea-db-get-by-id`. This means that we have one more HUGE and
   FRIGHTENING SQL query, but seems like performance is much better.
   See updated README file.