### PR TITLE
(feat) use view table for query operations

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -2,6 +2,7 @@
                      (indent-tabs-mode . nil)
                      (elisp-lint-indent-specs . ((vulpea-utils-with-file . 1)
                                                  (vulpea-utils-with-note . 1)
-                                                 (org-with-point-at . 1)))))
+                                                 (org-with-point-at . 1)
+                                                 (org-element-map . 2)))))
  (org-mode . ((fill-column . 80)
               (vulpea-id-auto-targets nil))))

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -12,6 +12,13 @@
 :ID:                     32a267f4-dd27-44b9-a045-5835a5c8503f
 :END:
 
+This release main feature is dedicate view table to boost performance of query
+operations. In addition, it provides some specialized queries for situations
+when set of notes can be narrowed down by tags or links.
+
+In addition, =vulpea-note= now has properties, meta and links as part of its
+structure.
+
 *Features*
 
 - [[https://github.com/d12frosted/vulpea/issues/97][vulpea#97]] Expose properties in =vulpea-note=.
@@ -36,6 +43,8 @@
     the provided =DESTINATIONS=;
   - =vulpea-db-query-by-links-every= - return all notes linking each and every
     provided =DESTINATIONS=;
+- [[https://github.com/d12frosted/vulpea/pull/116][vulpea#116]] improve query performance by building and maintaining a separate
+  view table.
 
 ** v0.2.0
 

--- a/Eldev
+++ b/Eldev
@@ -21,3 +21,6 @@
             (eldev-load-project-dependencies 'lint nil t)
             (require 'emacsql)
             (call-interactively #'emacsql-fix-vector-indentation)))
+
+;; just make sure that that error goes away
+(setq-default org-roam-v2-ack t)

--- a/README.org
+++ b/README.org
@@ -57,7 +57,7 @@ Users of this library:
    1. =vulpea-db-query= is a great interface for quick database search without
       knowing its scheme. In many cases you just want to have a fully
       materialized note instead of a structure that lacks, say tags or aliases.
-      So you don't need to write any extra SQL.
+      So you don't need to write any extra SQL. See [[#performance][Performance]].
    2. =vulpea-select= is a configurable interface for selecting a note with an
       optional filter. Note rendering is controlled by two variables:
       - =vulpea-select-describe-fn= - description of the note (by default
@@ -166,8 +166,8 @@ non-existent. For example, =vulpea-select= returns such a note, when
 ** Mandatory =ID= property
 
 Please note, that each existing =vulpea-note= (!) must contain an =ID= for
-Vulpea to be operational. =org-roam= should cover this, but another way to
-always ensure existence of =ID= is to use the following code:
+Vulpea to be operational. Starting with v2 =org-roam= should cover this, but
+another way to always ensure existence of =ID= is to use the following code:
 
 #+begin_src emacs-lisp
   (defun +org-auto-id-add-to-headlines-in-file ()
@@ -186,8 +186,8 @@ always ensure existence of =ID= is to use the following code:
 
 * Metadata
 
-In general, metadata is an key value pairs that is represented by the first
-description list in the note, e.g. list like:
+In general, metadata is a list of key value pairs that is represented by the
+first description list in the note, e.g. list like:
 
 #+begin_src org-mode
 - key1 :: value1
@@ -283,14 +283,18 @@ This module contains =vulpea-note= definition and few helpers to access/extract
 
 ** =vulpea-db=
 
-This module contains functions to query notes data base. Functions of interest:
+This module contains functions to query notes data base. In order for most of
+these functions to operate, one needs to enable =vulpea-db-autosync-mode= (see
+[[#install][Install]] section), for example, using =vulpea-db-autosync-enable=. This hooks
+into =org-roam.db= by adding two extra tables:
 
-- =vulpea-db-get-id-by-file= - function to get =ID= of a note represented by =FILE=.
-- =vulpea-db-get-by-id= - function to get note represented by =ID=. Supports
-  headings of the note.
-- =vulpea-db-get-file-by-id= - function to get =FILE= of a note represented by
-  =ID=. Supports headings of the note.
-- =vulpea-db-search-by-title= - function to query notes with =TITLE=.
+- =meta= - for storing [[#metadata][Metadata]];
+- =notes= - a view table of fully materialized note (see [[#performance][Performance]]).
+
+You might need to perform a full re-sync of =org-roam.db=.
+
+Functions of interest:
+
 - =vulpea-db-query= - function to query notes with generic predicate. This
   function is very powerful as it allows to apply Emacs Lisp predicate on
   /every/ note. This might be not very efficient on big set of notes, in such
@@ -303,6 +307,13 @@ This module contains functions to query notes data base. Functions of interest:
   provided =DESTINATIONS=.
 - =vulpea-db-query-by-links-every= - return all notes linking each and every
   provided =DESTINATIONS=.
+- =vulpea-db-get-by-id= - function to get note represented by =ID=. Supports
+  headings of the note.
+- =vulpea-db-get-id-by-file= - function to get =ID= of a note represented by
+  =FILE=.
+- =vulpea-db-get-file-by-id= - function to get =FILE= of a note represented by
+  =ID=. Supports headings of the note.
+- =vulpea-db-search-by-title= - function to query notes with =TITLE=.
 
 ** =vulpea-meta=
 
@@ -416,7 +427,8 @@ This library provides multiple functions to query notes from the database.
 Basically, there is one powerful =vulpea-db-query= allowing to filter notes by
 any =vulpea-note= based predicate. The only downside of this power is
 performance and memory penalty as all notes are loaded into memory. In cases
-when performance is critical, one can use specialized queries:
+when performance is critical and the set of notes can be narrowed down, one can
+use specialized queries:
 
 - =vulpea-db-query-by-tags-some= - return all notes tagged with one of the
   provided =TAGS=.
@@ -441,6 +453,19 @@ retrieve full note structure, the more notes we have, the more time it takes.
 | =links-every= | 92 notes    |       1.0204833089 |       0.0545313596 |
 
 See [[https://github.com/d12frosted/vulpea/discussions/106#discussioncomment-1601429][this comment]] for more background on why these functions where created.
+
+In order to make these functions as fast as possible, =vulpea-db= module builds
+and maintains a view table called =notes=. While it does drastically improve
+query performance (see the table below), it adds a small footprint on
+synchronisation time. See [[https://github.com/d12frosted/vulpea/pull/116][vulpea#116]] for more information on this feature and
+measurements.
+
+| test          | result size |            [[https://github.com/d12frosted/vulpea/blob/master/vulpea-db.el#L76-L155][regular]] |         view table |     ratio |
+|---------------+-------------+--------------------+--------------------+-----------|
+| =tags-some=   | 30 notes    | 4.6693460650999995 |       1.0112478712 | 4.6174100 |
+| =tags-every=  | 3168 notes  | 4.7333844436999996 |       1.0059819176 | 4.7052381 |
+| =links-some=  | 1657 notes  |       4.8095771283 | 1.0462236128999999 | 4.5970833 |
+| =links-every= | 92 notes    | 4.5517473337999995 |       1.0204833089 | 4.4603839 |
 
 * Coding
 

--- a/README.org
+++ b/README.org
@@ -423,9 +423,9 @@ when performance is critical, one can use specialized queries:
 - =vulpea-db-query-by-tags-every= - return all notes tagged by every tag from
   the list of provided =TAGS=.
 - =vulpea-db-query-by-links-some= - return all notes linking at least one of the
-  provided =DESTINATIONS=;
+  provided =DESTINATIONS=.
 - =vulpea-db-query-by-links-every= - return all notes linking each and every
-  provided =DESTINATIONS=;
+  provided =DESTINATIONS=.
 
 The following table displays time required to query notes by using
 =vulpea-db-query= vs specialized query on the database of 9554 [[https://github.com/d12frosted/vulpea-test-notes/][generated notes]].
@@ -433,12 +433,12 @@ The difference between various test cases is partially explained by the fact
 that filtering functions result in different amount of notes. Since we need to
 retrieve full note structure, the more notes we have, the more time it takes.
 
-| test          | result size |            generic |  specialized |
-|---------------+-------------+--------------------+--------------|
-| =tags-some=   | 30 notes    | 4.6693460650999995 | 0.0605194177 |
-| =tags-every=  | 3168 notes  | 4.7333844436999996 | 1.0618131127 |
-| =links-some=  | 1657 notes  |       4.8095771283 |  1.362214091 |
-| =links-every= | 92 notes    | 4.5517473337999995 | 0.1707312557 |
+| test          | result size |            generic |        specialized |
+|---------------+-------------+--------------------+--------------------|
+| =tags-some=   | 30 notes    |       1.0112478712 |       0.0066033426 |
+| =tags-every=  | 3168 notes  |       1.0059819176 | 0.5709392964999999 |
+| =links-some=  | 1657 notes  | 1.0462236128999999 |       0.4248580532 |
+| =links-every= | 92 notes    |       1.0204833089 |       0.0545313596 |
 
 See [[https://github.com/d12frosted/vulpea/discussions/106#discussioncomment-1601429][this comment]] for more background on why these functions where created.
 

--- a/test/note-files-extra/sicily.org
+++ b/test/note-files-extra/sicily.org
@@ -1,0 +1,4794 @@
+:PROPERTIES:
+:ID:    b0dae07d-8789-4737-b830-db775715cbf0
+:END:
+
+<<mw-page-base>>
+
+<<mw-head-base>>
+
+<<content>>
+<<top>>
+
+<<siteNotice>>
+
+* Sicily
+  :PROPERTIES:
+  :CUSTOM_ID: firstHeading
+  :CLASS: firstHeading
+  :END:
+
+<<bodyContent>>
+
+<<siteSub>>
+From Wikipedia, the free encyclopedia
+
+<<contentSub>>
+
+<<contentSub2>>
+
+<<jump-to-nav>>
+
+[[#mw-head][Jump to navigation]] [[#searchInput][Jump to search]]
+
+<<mw-content-text>>
+
+Island in the Mediterranean, region of Italy
+
+This article is about the region of Italy. For other uses, see
+[[/wiki/Sicily_(disambiguation)][Sicily (disambiguation)]].
+
+"Sicilia" redirects here. For the Roman province, see
+[[/wiki/Sicilia_(Roman_province)][Sicilia (Roman province)]]. For the
+Italian film about Sicily, see [[/wiki/Sicilia!][Sicilia!]]
+
+[[/wiki/Geographic_coordinate_system][Coordinates]]:
+[[//geohack.toolforge.org/geohack.php?pagename=Sicily&params=37_30_N_14_00_E_scale:2500000_source:GNS][37°30′N
+14°00′E﻿ / ﻿37.500°N 14.000°E﻿ / 37.500; 14.000]]
+
+Autonomous region of Italy
+
+| Sicily                                                                                                                                                            |                                                                                                                        |
+|                                                                                                                                                                   |                                                                                                                        |
+| /Sicilia/  ([[/wiki/Italian_language][Italian]])\\                                                                                                                |                                                                                                                        |
+| /Sicilia/  ([[/wiki/Sicilian_language][Sicilian]])                                                                                                                |                                                                                                                        |
+| [[/wiki/Regions_of_Italy#Autonomous_regions_with_special_statute][Autonomous region of Italy]]                                                                    |                                                                                                                        |
+| [[/wiki/File:Sicilian_Flag.svg][[[//upload.wikimedia.org/wikipedia/commons/thumb/8/84/Sicilian_Flag.svg/100px-Sicilian_Flag.svg.png]]]]                           |                                                                                                                        |
+|                                                                                                                                                                   |                                                                                                                        |
+| [[/wiki/Flag_of_Sicily][Flag]]                                                                                                                                    |                                                                                                                        |
+|                                                                                                                                                                   |                                                                                                                        |
+| [[/wiki/File:Coat_of_arms_of_Sicily.svg][[[//upload.wikimedia.org/wikipedia/commons/thumb/d/df/Coat_of_arms_of_Sicily.svg/50px-Coat_of_arms_of_Sicily.svg.png]]]] |                                                                                                                        |
+|                                                                                                                                                                   |                                                                                                                        |
+| [[/wiki/Coat_of_arms_of_Sicily][Coat of arms]]                                                                                                                    |                                                                                                                        |
+| Anthem: /[[/wiki/Madreterra][Madreterra]]/                                                                                                                        |                                                                                                                        |
+| [[/wiki/File:Sicily_in_Italy.svg][[[//upload.wikimedia.org/wikipedia/commons/thumb/1/12/Sicily_in_Italy.svg/250px-Sicily_in_Italy.svg.png]]]]                     |                                                                                                                        |
+| [[/wiki/List_of_sovereign_states][Country]]                                                                                                                       | [[//upload.wikimedia.org/wikipedia/en/thumb/0/03/Flag_of_Italy.svg/23px-Flag_of_Italy.svg.png]] [[/wiki/Italy][Italy]] |
+| [[/wiki/Capital_city][Capital]]                                                                                                                                   | [[/wiki/Palermo][Palermo]]                                                                                             |
+| Government                                                                                                                                                        |                                                                                                                        |
+|  • President                                                                                                                                                      | [[/wiki/Nello_Musumeci][Nello Musumeci]] ([[/wiki/Diventer%C3%A0_Bellissima][DB]])                                     |
+| Area                                                                                                                                                              |                                                                                                                        |
+|  • Total                                                                                                                                                          | 25,711 km^{2} (9,927 sq mi)                                                                                            |
+| Population                                                                                                                                                        |                                                                                                                        |
+|                                                                                                                                                                   |                                                                                                                        |
+|  (2019)^{[[#cite_note-1][[1]]]} (8.3% of Italy)                                                                                                                   |                                                                                                                        |
+|  • Total                                                                                                                                                          | 4,969,147                                                                                                              |
+|  • Density                                                                                                                                                        | 190/km^{2} (500/sq mi)                                                                                                 |
+| [[/wiki/Demonym][Demonym(s)]]                                                                                                                                     | English: [[/wiki/Sicilians][Sicilian]]\\                                                                               |
+|                                                                                                                                                                   | [[/wiki/Italian_language][Italian]]: /Siciliano/ (man)\\                                                               |
+|                                                                                                                                                                   | [[/wiki/Italian_language][Italian]]: /Siciliana/ (woman)                                                               |
+| Ethnicity                                                                                                                                                         |                                                                                                                        |
+|                                                                                                                                                                   |                                                                                                                        |
+| ^{[[#cite_note-2][[2]]]}                                                                                                                                          |                                                                                                                        |
+|  • Sicilian                                                                                                                                                       | 98%                                                                                                                    |
+| [[/wiki/Time_zone][Time zone]]                                                                                                                                    | [[/wiki/UTC%2B1][UTC+1]] ([[/wiki/Central_European_Time][CET]])                                                        |
+|  • Summer ([[/wiki/Daylight_saving_time][DST]])                                                                                                                   | [[/wiki/UTC%2B2][UTC+2]] ([[/wiki/Central_European_Summer_Time][CEST]])                                                |
+| [[/wiki/ISO_3166_code][ISO 3166 code]]                                                                                                                            | IT-82                                                                                                                  |
+| [[/wiki/List_of_Italian_regions_by_GDP][GDP (nominal)]]                                                                                                           | €89.2 billion (2018)^{[[#cite_note-ec.europa.eu-3][[3]]]}                                                              |
+| [[/wiki/List_of_Italian_regions_by_GDP][GDP per capita]]                                                                                                          | €17,800 (2018)^{[[#cite_note-ec.europa.eu-3][[3]]]}                                                                    |
+| [[/wiki/Human_Development_Index][HDI]] (2019)                                                                                                                     | 0.845^{[[#cite_note-GlobalDataLab-4][[4]]]}\\                                                                          |
+|                                                                                                                                                                   | very high · [[/wiki/List_of_Italian_regions_by_Human_Development_Index][21st of 21]]                                   |
+| [[/wiki/First-level_NUTS_of_the_European_Union#Italy][NUTS Region]]                                                                                               | ITG                                                                                                                    |
+| Website                                                                                                                                                           | [[http://pti.regione.sicilia.it/][PTI.Regione.Sicilia.it]]                                                             |
+
+[[/wiki/File:Sicily_Map.png][[[//upload.wikimedia.org/wikipedia/commons/thumb/a/a0/Sicily_Map.png/280px-Sicily_Map.png]]]]
+
+[[/wiki/File:Sicily_Map.png][]]
+
+Sicily
+
+*Sicily* ([[/wiki/Italian_language][Italian]]: /Sicilia/
+[[/wiki/Help:IPA/Italian][[siˈtʃiːlja]]];
+[[/wiki/Sicilian_language][Sicilian]]: /Sicilia/
+[[/wiki/Help:IPA/Sicilian][[sɪˈʃiːlja]]]) is the
+[[/wiki/List_of_islands_in_the_Mediterranean][largest island]] in the
+[[/wiki/Mediterranean_Sea][Mediterranean Sea]] and one of the 20
+[[/wiki/Regions_of_Italy][regions]] of [[/wiki/Italy][Italy]]. It is one
+of the five
+[[/wiki/Regions_of_Italy#Autonomous_regions_with_special_statute][Italian
+autonomous regions]] and is officially referred to as /Regione
+Siciliana/. The region has 5 million inhabitants. Its
+[[/wiki/Capital_city][capital city]] is [[/wiki/Palermo][Palermo]].
+
+Sicily is in the central Mediterranean Sea, south of the
+[[/wiki/Italian_Peninsula][Italian Peninsula]], from which it is
+separated by the narrow [[/wiki/Strait_of_Messina][Strait of Messina]].
+Its most prominent landmark is [[/wiki/Mount_Etna][Mount Etna]], one of
+the tallest active volcanoes in Europe,^{[[#cite_note-5][[5]]]} and one
+of the most active in the world, currently 3,357 m (11,014 ft) high. The
+island has a typical [[/wiki/Mediterranean_climate][Mediterranean
+climate]].
+
+The earliest [[/wiki/Archaeological_record][archaeological evidence]] of
+human activity on the island dates from as early as 12,000
+BC.^{[[#cite_note-6][[6]]][[#cite_note-7][[7]]]} By around 750 BC,
+Sicily had three [[/wiki/Phoenicia][Phoenician]] and a dozen
+[[/wiki/Greeks_in_Italy][Greek colonies]] and it was later the site of
+the [[/wiki/Sicilian_Wars][Sicilian Wars]] and the
+[[/wiki/Punic_Wars][Punic Wars]]. After the end of the Roman province of
+[[/wiki/Sicilia_(Roman_province)][Sicilia]] with the fall of the
+[[/wiki/Roman_Empire][Roman Empire]] in the 5th century AD, Sicily was
+ruled during the [[/wiki/Early_Middle_Ages][Early Middle Ages]] by the
+[[/wiki/Vandals][Vandals]], the [[/wiki/Ostrogoths][Ostrogoths]], the
+[[/wiki/Byzantine_Empire][Byzantine Empire]], and the
+[[/wiki/Emirate_of_Sicily][Emirate of Sicily]]. The
+[[/wiki/Norman_conquest_of_southern_Italy][Norman conquest of southern
+Italy]] led to the creation of the [[/wiki/County_of_Sicily][County of
+Sicily]] in 1071, that was succeeded by
+[[/wiki/Kingdom_of_Sicily][Kingdom of Sicily]], a state that existed
+from 1130 until 1816.^{[[#cite_note-8][[8]]][[#cite_note-9][[9]]]}
+Later, it was unified under the [[/wiki/House_of_Bourbon][House of
+Bourbon]] with the [[/wiki/Kingdom_of_Naples][Kingdom of Naples]] as the
+[[/wiki/Kingdom_of_the_Two_Sicilies][Kingdom of the Two Sicilies]]. The
+island became part of [[/wiki/Italy][Italy]] in 1860 following the
+[[/wiki/Expedition_of_the_Thousand][Expedition of the Thousand]], a
+revolt led by [[/wiki/Giuseppe_Garibaldi][Giuseppe Garibaldi]] during
+the [[/wiki/Italian_unification][Italian unification]], and a
+plebiscite. Sicily was given special status as an
+[[/wiki/Autonomous_administrative_division][autonomous region]] on 15
+May 1946, 18 days before the
+[[/wiki/Italian_institutional_referendum,_1946][Italian institutional
+referendum of 1946]].
+
+Sicily has a rich and unique culture, especially with regard to the
+[[#Art_and_architecture][arts]], [[/wiki/Music_of_Sicily][music]],
+[[#Literature][literature]], [[/wiki/Sicilian_cuisine][cuisine]], and
+[[/wiki/Sicilian_Baroque][architecture]]. It is also home to important
+[[/wiki/Archaeology][archaeological]] and ancient sites, such as the
+[[/wiki/Necropolis_of_Pantalica][Necropolis of Pantalica]], the
+[[/wiki/Valle_dei_Templi][Valley of the Temples]],
+[[/wiki/Erice][Erice]] and [[/wiki/Selinunte][Selinunte]].
+[[/wiki/Byzantine][Byzantine]], [[/wiki/Arab][Arab]],
+[[/wiki/Romans_(people)][Roman]] and [[/wiki/Normans][Norman]] rule over
+Sicily has led to a blend of cultural influences.
+
+<<toc>>
+
+** Contents
+   :PROPERTIES:
+   :CUSTOM_ID: mw-toc-heading
+   :END:
+
+- [[#Geography][1 Geography]]
+
+  - [[#Rivers][1.1 Rivers]]
+  - [[#Climate][1.2 Climate]]
+
+- [[#Flora_and_fauna][2 Flora and fauna]]
+- [[#History][3 History]]
+
+  - [[#Prehistory][3.1 Prehistory]]
+  - [[#Antiquity][3.2 Antiquity]]
+  - [[#Germanic_rule_(469-535)][3.3 Germanic rule (469-535)]]
+  - [[#Byzantine_period_(535–965)][3.4 Byzantine period (535--965)]]
+  - [[#Arab_Period_(827–1091)][3.5 Arab Period (827--1091)]]
+  - [[#Norman_Sicily_(1038–1198)][3.6 Norman Sicily (1038--1198)]]
+  - [[#Kingdom_of_Sicily][3.7 Kingdom of Sicily]]
+  - [[#Hohenstaufen_dynasty][3.8 Hohenstaufen dynasty]]
+  - [[#Sicily_under_Aragonese_rule][3.9 Sicily under Aragonese rule]]
+  - [[#Italian_unification][3.10 Italian unification]]
+  - [[#20th_and_21st_centuries][3.11 20th and 21st centuries]]
+
+- [[#Demographics][4 Demographics]]
+
+  - [[#Emigration][4.1 Emigration]]
+  - [[#Largest_cities][4.2 Largest cities]]
+  - [[#Religion][4.3 Religion]]
+
+- [[#Politics][5 Politics]]
+
+  - [[#Administrative_divisions][5.1 Administrative divisions]]
+
+- [[#Economy][6 Economy]]
+
+  - [[#Agriculture][6.1 Agriculture]]
+  - [[#Industry_and_manufacturing][6.2 Industry and manufacturing]]
+  - [[#Statistics][6.3 Statistics]]
+
+    - [[#GDP_growth][6.3.1 GDP growth]]
+    - [[#Economic_sectors][6.3.2 Economic sectors]]
+    - [[#Unemployment_rate][6.3.3 Unemployment rate]]
+
+- [[#Transport][7 Transport]]
+
+  - [[#Roads][7.1 Roads]]
+  - [[#Railways][7.2 Railways]]
+  - [[#Airports][7.3 Airports]]
+  - [[#Ports][7.4 Ports]]
+  - [[#Planned_bridge][7.5 Planned bridge]]
+
+- [[#Tourism][8 Tourism]]
+
+  - [[#UNESCO_World_Heritage_Sites][8.1 UNESCO World Heritage Sites]]
+
+    - [[#Tentative_Sites][8.1.1 Tentative Sites]]
+
+  - [[#Archeological_sites][8.2 Archeological sites]]
+  - [[#Castles][8.3 Castles]]
+  - [[#Coastal_towers][8.4 Coastal towers]]
+
+- [[#Culture][9 Culture]]
+
+  - [[#Art_and_architecture][9.1 Art and architecture]]
+
+    - [[#Sicilian_Baroque][9.1.1 Sicilian Baroque]]
+
+  - [[#Music_and_film][9.2 Music and film]]
+  - [[#Literature][9.3 Literature]]
+  - [[#Language][9.4 Language]]
+  - [[#Science][9.5 Science]]
+  - [[#Education][9.6 Education]]
+  - [[#Cuisine][9.7 Cuisine]]
+  - [[#Sports][9.8 Sports]]
+  - [[#Popular_culture][9.9 Popular culture]]
+  - [[#Traditional_items][9.10 Traditional items]]
+  - [[#Flag_and_emblem][9.11 Flag and emblem]]
+
+- [[#See_also][10 See also]]
+- [[#References][11 References]]
+- [[#Further_reading][12 Further reading]]
+- [[#External_links][13 External links]]
+
+** Geography[[[/w/index.php?title=Sicily&action=edit&section=1][edit]]]
+   :PROPERTIES:
+   :CUSTOM_ID: geographyedit
+   :END:
+
+See also: [[/wiki/Geology_of_Sicily][Geology of Sicily]]
+
+[[/wiki/File:Sguardo_sul_Parco_Monti_Sicani.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/1/19/Sguardo_sul_Parco_Monti_Sicani.jpg/220px-Sguardo_sul_Parco_Monti_Sicani.jpg]]]]
+
+[[/wiki/File:Sguardo_sul_Parco_Monti_Sicani.jpg][]]
+
+Sicilian landscape, the [[/wiki/Monti_Sicani][Monti Sicani]] a mountain
+chain in western Sicily
+
+Sicily has a roughly triangular shape, earning it the name /Trinacria/.
+To the north-east, it is separated from [[/wiki/Calabria][Calabria]] and
+the rest of the Italian mainland by the
+[[/wiki/Strait_of_Messina][Strait of Messina]], about 3 km (1.9 mi) wide
+in the north, and about 16 km (9.9 mi) wide in the southern
+part.^{[[#cite_note-10][[10]]]} The northern and southern coasts are
+each about 280 km (170 mi) long measured as a straight line, while the
+eastern coast measures around 180 km (110 mi); total coast length is
+[[/wiki/Length_of_coast][estimated]] at 1,484 km (922 mi). The total
+area of the island is 25,711 km^{2}
+(9,927 sq mi),^{[[#cite_note-11][[11]]]} while the
+[[/wiki/Autonomous_administrative_division][Autonomous Region]] of
+Sicily (which includes smaller surrounding islands) has an area of
+27,708 km^{2} (10,698 sq mi).^{[[#cite_note-12][[12]]]}
+
+The terrain of inland Sicily is mostly hilly and is intensively
+cultivated wherever possible. Along the northern coast, the mountain
+ranges of [[/wiki/Madonie][Madonie]], 2,000 m (6,600 ft),
+[[/wiki/Nebrodi][Nebrodi]], 1,800 m (5,900 ft), and
+[[/wiki/Peloritani][Peloritani]], 1,300 m (4,300 ft), are an extension
+of the mainland [[/wiki/Apennines][Apennines]]. The cone of
+[[/wiki/Mount_Etna][Mount Etna]] dominates the eastern coast. In the
+southeast lie the lower [[/wiki/Hyblaean_Mountains][Hyblaean
+Mountains]], 1,000 m (3,300 ft).^{[[#cite_note-frommers-13][[13]]]} The
+mines of the [[/wiki/Enna][Enna]] and
+[[/wiki/Caltanissetta][Caltanissetta]] districts were part of a leading
+[[/wiki/Sulphur][sulphur]]-producing area throughout the 19th century,
+but have declined since the 1950s.
+
+Sicily and its surrounding small islands have some highly active
+volcanoes. This is due to the fact Sicily is geographically on the
+northern edge of the [[/wiki/African_Plate][African continental
+plate]].^{[[#cite_note-14][[14]]]} Mount Etna is the largest active
+volcano in Europe and still casts black ash over the island with its
+ever-present eruptions. It currently stands 3,329 metres (10,922 ft)
+high, though this varies with summit eruptions; the mountain is 21 m
+(69 ft) lower now than it was in 1981. It is the highest mountain in
+Italy south of the [[/wiki/Alps][Alps]]. Etna covers an area of
+1,190 km^{2} (459 sq mi) with a basal circumference of 140 km (87 mi).
+This makes it by far the largest of the three
+[[/wiki/Volcanism_in_Italy][active volcanoes in Italy]], being about two
+and a half times the height of the next largest,
+[[/wiki/Mount_Vesuvius][Mount Vesuvius]]. In
+[[/wiki/Greek_mythology][Greek mythology]], the deadly monster
+[[/wiki/Typhon][Typhon]] was trapped under the mountain by
+[[/wiki/Zeus][Zeus]], the god of the sky.^{[[#cite_note-15][[15]]]}
+Mount Etna is widely regarded as a cultural symbol and icon of Sicily.
+
+- 
+
+  [[/wiki/File:Mt_Etna_and_Catania1.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/3/39/Mt_Etna_and_Catania1.jpg/939px-Mt_Etna_and_Catania1.jpg]]]]
+
+  Mount Etna rising over suburbs of Catania
+
+The [[/wiki/Aeolian_Islands][Aeolian Islands]] in the
+[[/wiki/Tyrrhenian_Sea][Tyrrhenian Sea]], to the northeast of mainland
+Sicily form a volcanic complex, and include
+[[/wiki/Stromboli][Stromboli]]. The three volcanoes of
+[[/wiki/Vulcano][Vulcano]], [[/wiki/Vulcanello][Vulcanello]] and
+[[/wiki/Lipari][Lipari]] are also currently active, although the latter
+is usually dormant. Off the southern coast of Sicily, the underwater
+volcano of [[/wiki/Ferdinandea][Ferdinandea]], which is part of the
+larger [[/wiki/Empedocles_(volcano)][Empedocles volcano]], last erupted
+in 1831. It is located between the coast of
+[[/wiki/Agrigento][Agrigento]] and the island of
+[[/wiki/Pantelleria][Pantelleria]] (which itself is a dormant volcano).
+
+From a geographical perspective, also forming a part of Sicily is the
+Maltese Archipelago, the islands home to the
+[[/wiki/Republic_of_Malta][republic of Malta]].
+
+The [[/wiki/Autonomous_administrative_division][autonomous region]] also
+includes several neighbouring islands: the
+[[/wiki/Aegadian_Islands][Aegadian Islands]], the Aeolian Islands,
+Pantelleria and [[/wiki/Lampedusa][Lampedusa]].
+
+*** Rivers[[[/w/index.php?title=Sicily&action=edit&section=2][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: riversedit
+    :END:
+
+[[/wiki/File:Papiro-Ciane.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/b/be/Papiro-Ciane.jpg/220px-Papiro-Ciane.jpg]]]]
+
+[[/wiki/File:Papiro-Ciane.jpg][]]
+
+View of the [[/wiki/Ciane][Ciane]] river
+
+The island is [[/wiki/Drainage][drained]] by several rivers, most of
+which flow through the central area and enter the sea at the south of
+the island. The [[/wiki/Salso][Salso]] flows through parts of Enna and
+Caltanissetta before entering the
+[[/wiki/Mediterranean_Sea][Mediterranean Sea]] at the port of
+[[/wiki/Licata][Licata]]. To the east, the
+[[/wiki/Alcantara_(river)][Alcantara]] flows through the province of
+[[/wiki/Messina][Messina]] and enters the sea at
+[[/wiki/Giardini_Naxos][Giardini Naxos]], and the
+[[/wiki/Simeto][Simeto]], which flows into the
+[[/wiki/Ionian_Sea][Ionian Sea]] south of [[/wiki/Catania][Catania]].
+Other important rivers on the island are the [[/wiki/Belice][Belice]]
+and [[/wiki/Platani_(river)][Platani]] in the southwest.
+
+| River                                  | Length         |
+| [[/wiki/Salso][Salso]]                 | 144 km (89 mi) |
+| [[/wiki/Simeto][Simeto]]               | 113 km (70 mi) |
+| [[/wiki/Belice][Belice]]               | 107 km (66 mi) |
+| [[/wiki/Dittaino][Dittaino]]           | 105 km (65 mi) |
+| Platani                                | 103 km (64 mi) |
+| [[/wiki/Gornalunga][Gornalunga]]       | 81 km (50 mi)  |
+| [[/wiki/Gela_(river)][Gela]]           | 74 km (46 mi)  |
+| Salso Cimarosa                         | 72 km (45 mi)  |
+| Torto                                  | 58 km (36 mi)  |
+| [[/wiki/Irminio][Irminio]]             | 57 km (35 mi)  |
+| [[/wiki/Dirillo][Dirillo]]             | 54 km (34 mi)  |
+| [[/wiki/Verdura][Verdura]]             | 53 km (33 mi)  |
+| [[/wiki/Alcantara_(river)][Alcantara]] | 52 km (32 mi)  |
+| [[/wiki/Tellaro][Tellaro]]             | 45 km (28 mi)  |
+| [[/wiki/Anapo][Anapo]]                 | 40 km (25 mi)  |
+
+*** Climate[[[/w/index.php?title=Sicily&action=edit&section=3][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: climateedit
+    :END:
+
+[[/wiki/File:Veduta-Vallone-Caltanissetta.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/b/bb/Veduta-Vallone-Caltanissetta.jpg/220px-Veduta-Vallone-Caltanissetta.jpg]]]]
+
+[[/wiki/File:Veduta-Vallone-Caltanissetta.jpg][]]
+
+Inner Sicily
+
+Sicily has a typical [[/wiki/Mediterranean_climate][Mediterranean
+climate]] with mild and wet winters and hot, dry summers with very
+changeable intermediate seasons. On the coasts, especially in the
+south-west, the climate is affected by the African currents and summers
+can be scorching.
+
+Snow falls above 900--1000 metres, but it can fall in the hills. The
+interior mountains, especially [[/wiki/Nebrodi][Nebrodi]],
+[[/wiki/Madonie][Madonie]], and [[/wiki/Mount_Etna][Etna]], enjoy a full
+mountain climate, with heavy snowfalls during winter. The summit of
+Mount Etna is usually snow-capped from October to May.
+
+On the other hand, especially in the summer, it is not unusual that
+there is the [[/wiki/Sirocco][sirocco]], the wind from the Sahara.
+Rainfall is scarce, and water proves deficient in some provinces where a
+water crisis can happen occasionally.
+
+According to the Regional Agency for Waste and Water, on 10 August 1999,
+the weather station of [[/wiki/Catenanuova][Catenanuova]] (EN) recorded
+a maximum temperature of 48.5 °C (119 °F).^{[[#cite_note-16][[16]]]} The
+official European record -- measured by minimum/maximum thermometers --
+is held by Athens, Greece, which reported a maximum of 48.0 °C (118 °F)
+in 1977.^{[[#cite_note-17][[17]]]} Total precipitation is highly
+variable, generally increasing with elevation. In general, the southern
+and southeast coast receives the least rainfall (less than 50 cm
+(20 in)), and the northern and northeastern highlands the most (over
+100 cm (39 in)).
+
+** Flora and
+fauna[[[/w/index.php?title=Sicily&action=edit&section=4][edit]]]
+   :PROPERTIES:
+   :CUSTOM_ID: flora-and-faunaedit
+   :END:
+
+[[/wiki/File:Zingaro_Sicilia_2005-09-30-2.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Zingaro_Sicilia_2005-09-30-2.jpg/220px-Zingaro_Sicilia_2005-09-30-2.jpg]]]]
+
+[[/wiki/File:Zingaro_Sicilia_2005-09-30-2.jpg][]]
+
+[[/wiki/Riserva_naturale_dello_Zingaro][Zingaro Natural Reserve]]
+
+[[/wiki/File:Canis_lupus_cristaldii_subsp._nov.png][[[//upload.wikimedia.org/wikipedia/commons/thumb/3/37/Canis_lupus_cristaldii_subsp._nov.png/220px-Canis_lupus_cristaldii_subsp._nov.png]]]]
+
+[[/wiki/File:Canis_lupus_cristaldii_subsp._nov.png][]]
+
+[[/wiki/Sicilian_wolf][Sicilian wolf]]
+
+Sicily is an often-quoted example of man-made
+[[/wiki/Deforestation][deforestation]], which has occurred since Roman
+times, when the island was turned into an agricultural
+region.^{[[#cite_note-frommers-13][[13]]]} This gradually dried the
+climate, leading to a decline in rainfall and the drying of rivers. The
+central and southwest provinces are practically devoid of any
+forest.^{[[#cite_note-18][[18]]]} In Northern Sicily, there are three
+important forests; near Mount Etna, in the [[/wiki/Nebrodi][Nebrodi
+Mountains]] and in the
+[[/w/index.php?title=Bosco_della_Ficuzza&action=edit&redlink=1][Bosco
+della Ficuzza]]
+([[https://it.wikipedia.org/wiki/Riserva_naturale_orientata_Bosco_della_Ficuzza,_Rocca_Busambra,_Bosco_del_Cappelliere_e_Gorgo_del_Drago][it]])
+Natural Reserve near [[/wiki/Palermo][Palermo]]. The Nebrodi Mountains
+Regional Park, established on 4 August 1993 and covering 86,000 hectares
+(210,000 acres), is the largest protected natural area of Sicily; and
+contains the largest forest in Sicily, the [[/wiki/Caronia][Caronia]].
+The [[/wiki/Hundred_Horse_Chestnut][Hundred Horse Chestnut]] (Castagno
+dei Cento Cavalli), in [[/wiki/Sant%27Alfio][Sant'Alfio]], on the
+eastern slopes of Mount Etna, is the largest and oldest known
+[[/wiki/Chestnut][chestnut]] tree in the world at 2,000 -- 4,000 years
+old.^{[[#cite_note-19][[19]]]}
+
+Sicily has a wide variety of fauna. Species include the
+[[/wiki/European_wildcat][European wildcat]], [[/wiki/Red_fox][red
+fox]], [[/wiki/Least_weasel][least weasel]], [[/wiki/Pine_marten][pine
+marten]], [[/wiki/Roe_deer][roe deer]], [[/wiki/Wild_boar][wild boar]],
+[[/wiki/Crested_porcupine][crested porcupine]],
+[[/wiki/European_hedgehog][European hedgehog]],
+[[/wiki/Common_toad][common toad]], /[[/wiki/Vipera_aspis][Vipera
+aspis]]/, [[/wiki/Golden_eagle][golden eagle]],
+[[/wiki/Peregrine_falcon][peregrine falcon]],
+[[/wiki/Eurasian_hoopoe][Eurasian hoopoe]] and
+[[/wiki/Black-winged_stilt][black-winged
+stilt]].^{[[#cite_note-20][[20]]]} The [[/wiki/Sicilian_wolf][Sicilian
+wolf]] (/Canis lupus cristaldii/) was an [[/wiki/Endemic][endemic]] wolf
+[[/wiki/Subspecies_of_Canis_lupus][subspecies]] that was driven to
+extinction in the 20th century.
+
+The [[/wiki/Riserva_naturale_dello_Zingaro][Zingaro Natural Reserve]] is
+one of the best examples of unspoiled coastal wilderness in
+Sicily.^{[[#cite_note-21][[21]]]}
+
+Surrounding waters including the [[/wiki/Strait_of_Messina][Strait of
+Messina]] [[/wiki/Marine_Life_of_the_Straits_of_Messina][are home to
+varieties of birds and marine life]], including larger species such as
+[[/wiki/Greater_flamingo][greater flamingo]] and [[/wiki/Fin_whale][fin
+whale]].
+
+** History[[[/w/index.php?title=Sicily&action=edit&section=5][edit]]]
+   :PROPERTIES:
+   :CUSTOM_ID: historyedit
+   :END:
+
+Main article: [[/wiki/History_of_Sicily][History of Sicily]]
+
+The name /[[/wiki/Sicilia_(Roman_province)][Sicilia]]/ was given to the
+[[/wiki/Roman_province][Roman province]] in 241 BC. It is derived from
+the name of the [[/wiki/Sicels][Sikeloi]], who inhabited the eastern
+part of the island. The ancient name of the island is /Trinacria/ (Greek
+[[https://en.wiktionary.org/wiki/%CE%A4%CF%81%CE%B9%CE%BD%CE%B1%CE%BA%CF%81%CE%AF%CE%B1][Τρινακρία]]
+"having three headlands") for its triangular shape, likely a
+re-interpretation of earlier ([[/wiki/Homeric_Greek][Homeric]])
+/[[/wiki/Thrinacia][Thrinacia]]/. The Greek name was rendered as
+/Trīnācrĭa/ in [[/wiki/Classical_Latin][classical Latin]]
+([[/wiki/Virgil][Virgil]],
+[[/wiki/Ovid][Ovid]]).^{[[#cite_note-22][[22]]][[#cite_note-23][[23]]]}
+
+*** Prehistory[[[/w/index.php?title=Sicily&action=edit&section=6][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: prehistoryedit
+    :END:
+
+[[/wiki/File:Dolmen_di_Avola.JPG][[[//upload.wikimedia.org/wikipedia/commons/thumb/2/25/Dolmen_di_Avola.JPG/220px-Dolmen_di_Avola.JPG]]]]
+
+[[/wiki/File:Dolmen_di_Avola.JPG][]]
+
+Dolmen of [[/wiki/Avola][Avola]], east Sicily
+
+[[/wiki/File:Argimusco_tramonto_equinozio,_Sicilia.JPG][[[//upload.wikimedia.org/wikipedia/commons/thumb/a/ae/Argimusco_tramonto_equinozio%2C_Sicilia.JPG/220px-Argimusco_tramonto_equinozio%2C_Sicilia.JPG]]]]
+
+[[/wiki/File:Argimusco_tramonto_equinozio,_Sicilia.JPG][]]
+
+Megaliths of [[/wiki/Argimusco][Argimusco]],
+[[/wiki/Montalbano_Elicona][Montalbano Elicona]].
+
+The original classical-era inhabitants of Sicily comprised three defined
+groups of the [[/wiki/List_of_ancient_peoples_of_Italy][ancient peoples
+of Italy]]. The most prominent and by far the earliest of these, the
+[[/wiki/Sicani][Sicani]], who ([[/wiki/Thucydides][Thucydides]] writes)
+arrived from the [[/wiki/Iberian_Peninsula][Iberian Peninsula]] (perhaps
+[[/wiki/Catalonia][Catalonia]]).^{[[#cite_note-24][[24]]][[#cite_note-25][[25]]]}
+Some modern scholars, however, suggest classifying the Sicani as
+possibly an [[/wiki/Illyrians][Illyrian]]
+tribe.^{[[#cite_note-26][[26]]]} Important historical evidence has been
+discovered in the form of cave drawings by the Sicani, dated from the
+end of the [[/wiki/Pleistocene][Pleistocene]] epoch around 8000
+BC.^{[[#cite_note-sicanian-27][[27]]]} The arrival of the first humans
+on the island correlates with the extinction of the
+[[/wiki/Sicilian_hippopotamus][Sicilian hippopotamus]] and the
+[[/wiki/Elephas_mnaidriensis][Sicilian dwarf elephant]]. The
+[[/wiki/Elymians][Elymians]], thought to have come from the area of the
+[[/wiki/Aegean_Sea][Aegean Sea]], became the next tribe to join the
+Sicanians on Sicily.^{[[#cite_note-28][[28]]]}
+
+[[/wiki/File:Dolmenmontebubbonia.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/d/dc/Dolmenmontebubbonia.jpg/220px-Dolmenmontebubbonia.jpg]]]]
+
+[[/wiki/File:Dolmenmontebubbonia.jpg][]]
+
+Dolmen of [[/wiki/Monte_Bubbonia][Monte Bubbonia]], south Sicily
+
+Recent discoveries of [[/wiki/Dolmen][dolmens]] on the island (dating to
+the second half of the third millennium BC) seem to offer new insights
+into the culture of primitive Sicily. It is well known that the
+Mediterranean region went through a quite intricate prehistory, so much
+so that it is difficult to piece together the muddle of different
+peoples who have followed each other. The impact of two influences is
+clear, however: the European one coming from the Northwest, and the
+Mediterranean influence of a clear eastern
+heritage.^{[[#cite_note-Piccolo-dolmens-29][[29]]][[#cite_note-30][[30]]]}
+
+No evidence survives of any warring between the tribes, but the
+Sicanians moved eastwards when the Elymians settled in the northwest
+corner of the island. The [[/wiki/Sicels][Sicels]] are
+thought^{[[#cite_note-sicanian-27][[27]]]} to have originated in
+[[/wiki/Liguria][Liguria]]; they arrived from mainland Italy in 1200 BC
+and forced the Sicanians to move back across Sicily and to settle in the
+middle of the island.^{[[#cite_note-sicanian-27][[27]]]} Other minor
+[[/wiki/Ancient_peoples_of_Italy][Italic groups]] who settled in Sicily
+included the [[/wiki/Ausones][Ausones]]
+([[/wiki/Aeolian_Islands][Aeolian Islands]], [[/wiki/Milazzo][Milazzo]])
+and the [[/wiki/Morgetes][Morgetes]] of
+[[/wiki/Morgantina][Morgantina]].
+
+*** Antiquity[[[/w/index.php?title=Sicily&action=edit&section=7][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: antiquityedit
+    :END:
+
+Main articles: [[/wiki/Magna_Graecia][Magna Graecia]],
+[[/wiki/Ancient_Rome][Ancient Rome]], and
+[[/wiki/Sicilia_(Roman_province)][Sicilia (Roman province)]]
+
+[[/wiki/File:Sicily_2008_082_Mozia.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/7/7f/Sicily_2008_082_Mozia.jpg/220px-Sicily_2008_082_Mozia.jpg]]]]
+
+[[/wiki/File:Sicily_2008_082_Mozia.jpg][]]
+
+Ruins of the ancient [[/wiki/Phoenicia][Phoenician]] city of
+[[/wiki/Motya][Motya]]
+
+[[/wiki/File:Greek_temples_in_Sicily-Agrigento-Selinunte-Segesta.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/a/a5/Greek_temples_in_Sicily-Agrigento-Selinunte-Segesta.jpg/275px-Greek_temples_in_Sicily-Agrigento-Selinunte-Segesta.jpg]]]]
+
+[[/wiki/File:Greek_temples_in_Sicily-Agrigento-Selinunte-Segesta.jpg][]]
+
+Clockwise from top: temples of
+[[/wiki/Temple_of_Concordia,_Agrigento][Concordia]] and
+[[/wiki/Temple_of_Hera_Lacinia][Hera Lacinia]] in
+[[/wiki/Agrigento][Agrigento]], the temple of
+[[/wiki/Segesta][Segesta]], and the [[/wiki/Temple_E_(Selinus)][Temple
+E]] in [[/wiki/Selinunte][Selinunte]].
+
+[[/wiki/File:Sicilia_SPQR.png][[[//upload.wikimedia.org/wikipedia/commons/thumb/0/08/Sicilia_SPQR.png/220px-Sicilia_SPQR.png]]]]
+
+[[/wiki/File:Sicilia_SPQR.png][]]
+
+The Sicilian province within the Roman Empire
+
+The [[/wiki/Phoenicia][Phoenician]] settlements in the western part of
+the island predate the arrival of [[/wiki/Greek_people][Greek]]
+colonists.^{[[#cite_note-catholi-31][[31]]]} From about 750 BC, the
+Greeks began to live in Sicily ([[/wiki/Ancient_Greek_language][Ancient
+Greek]]: Σικελία -- /Sikelia/), establishing many significant
+settlements. The most important colony was in
+[[/wiki/Syracuse,_Sicily][Syracuse]]; others grew up at
+[[/wiki/Agrigentum][Akragas]], [[/wiki/Selinunte][Selinunte]],
+[[/wiki/Gela][Gela]], [[/wiki/Himera][Himera]] and
+[[/wiki/Messina][Zancle]].^{[[#cite_note-32][[32]]]} The native Sicani
+and Sicel peoples became [[/wiki/Cultural_assimilation][absorbed]] into
+the [[/wiki/Ancient_Greece][Hellenic culture]] with relative ease, and
+the area became part of /[[/wiki/Magna_Graecia][Magna Graecia]]/ - along
+with the coasts of the [[/wiki/Southern_Italy][south of the Italian
+peninsula]], which the Greeks had also colonised. Sicily had very
+fertile soils, and the successful introduction of
+[[/wiki/Olive][olives]] and [[/wiki/Grape_vine][grape vines]] fostered a
+great deal of profitable trading.^{[[#cite_note-knowital-33][[33]]]}
+[[/wiki/Culture_of_Greece][Greek culture]] significantly included
+[[/wiki/Religion_in_ancient_Greece][Greek religion]], and the settlers
+built many [[/wiki/Ancient_Greek_temple][temples]] throughout Sicily,
+including several in the /Valley of the Temples/ at
+[[/wiki/Agrigento][Agrigento]].^{[[#cite_note-34][[34]]]}
+
+Politics on the island became intertwined with those of Greece;
+[[/wiki/Syracuse,_Sicily][Syracuse]] became desired by the
+[[/wiki/Athenian][Athenians]] who set out on the
+[[/wiki/Sicilian_Expedition][Sicilian Expedition]] (415--413 BC) during
+the [[/wiki/Peloponnesian_War][Peloponnesian War]]. Syracuse gained
+[[/wiki/Sparta][Sparta]] and [[/wiki/Ancient_Corinth][Corinth]] as
+allies and, as a result, defeated the Athenian expedition. The victors
+destroyed the Athenian army and their ships, selling most of the
+survivors into
+[[/wiki/Slavery_in_ancient_Greece][slavery]].^{[[#cite_note-35][[35]]]}
+
+[[/wiki/File:Taormina_BW_2012-10-05_16-05-05.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/4/46/Taormina_BW_2012-10-05_16-05-05.jpg/220px-Taormina_BW_2012-10-05_16-05-05.jpg]]]]
+
+[[/wiki/File:Taormina_BW_2012-10-05_16-05-05.jpg][]]
+
+Greco-Roman theatre at [[/wiki/Taormina][Taormina]]
+
+Greek Syracuse controlled eastern Sicily while
+[[/wiki/Carthage][Carthage]] controlled the
+West.^{[[#cite_note-36][[36]]]} The two cultures began to clash, leading
+to the [[/wiki/Greek-Punic_wars][Greek-Punic wars]] (between 580 and 265
+BC). The Greek states had begun to make peace with the
+[[/wiki/Roman_Republic][Roman Republic]] in 262
+BC,^{[/[[/wiki/Wikipedia:Citation_needed][citation needed]]/]} and the
+Romans sought to [[/wiki/Annexation][annex]] Sicily as their republic's
+first [[/wiki/Roman_province][province]]. Rome attacked Carthage's
+holdings in Sicily in the [[/wiki/First_Punic_War][First Punic War]]
+(264 to 241 BC) and won, making Sicily the first Roman province outside
+of the [[/wiki/Italian_Peninsula][Italian Peninsula]] by 242
+BC.^{[[#cite_note-hutch-37][[37]]]}
+
+In the [[/wiki/Second_Punic_War][Second Punic War]] (218 to 201 BC), the
+Carthaginians attempted to recapture Sicily. Some of the Greek cities on
+the island sided with the Carthaginians.
+[[/wiki/Archimedes][Archimedes]], who lived in Syracuse, helped the
+Carthaginians, Roman troops killed him after they invaded Syracuse in
+213 BC.^{[[#cite_note-38][[38]]]} The Carthaginian attempt failed, and
+Rome was even more unrelenting in its annihilation of the invaders this
+time; [[/wiki/Roman_consul][Roman consul]]
+[[/wiki/Marcus_Valerius_Laevinus][M. Valerian]] told the
+[[/wiki/Roman_Senate][Roman Senate]] in 210 BC that "no Carthaginian
+remains in Sicily".^{[[#cite_note-39][[39]]]}
+
+As the Roman Republic's [[/wiki/Granary][granary]], Sicily ranked as an
+important province, divided into two [[/wiki/Quaestor][quaestor]] ships:
+Syracuse to the east and [[/wiki/Lilybaeum][Lilybaeum]] to the
+west.^{[[#cite_note-catholi-31][[31]]]} Some attempt was
+made^{[/[[/wiki/Wikipedia:Manual_of_Style/Words_to_watch#Unsupported_attributions][by
+whom?]]/]} under [[/wiki/Augustus][Augustus]] (Roman Emperor from 27 BC
+to 14 AD) to introduce the [[/wiki/Latin_language][Latin language]] to
+the island, but Sicily was allowed to remain largely Greek in a cultural
+sense.^{[[#cite_note-catholi-31][[31]]]} The once prosperous and
+contented island went into sharp decline when [[/wiki/Verres][Verres]]
+became governor of Sicily (73 to 71 BC). In 70 BC noted figure
+[[/wiki/Cicero][Cicero]] condemned the misgovernment of Verres in his
+oration /[[/wiki/In_Verrem][In Verrem]]/.^{[[#cite_note-40][[40]]]}
+
+Various groups used the island as a power base at different times: slave
+insurgents occupied it during the [[/wiki/First_Servile_War][First]]
+(135−132 BC) and [[/wiki/Second_Servile_War][Second]] (104−100 BC)
+[[/wiki/Servile_Wars][Servile Wars]], and [[/wiki/Sextus_Pompey][Sextus
+Pompey]] had his headquarters there during the
+[[/wiki/War_between_Sextus_Pompey_and_the_Second_Triumvirate][Sicilian
+revolt]] of 44 to 36 BC. Christianity first appeared in Sicily during
+the years following AD 200; between this time and AD 313, when Emperor
+[[/wiki/Constantine_I][Constantine the Great]] finally lifted the
+prohibition on Christianity, a significant number of
+[[/wiki/Sicilians][Sicilians]] had become [[/wiki/Martyr][martyrs]],
+including [[/wiki/Agatha_of_Sicily][Agatha]],
+[[/wiki/Saint_Christina_of_Bolsena][Christina]],
+[[/wiki/Saint_Lucy][Lucy]], and
+[[/wiki/Euplius][Euplius]].^{[[#cite_note-earlymediev-41][[41]]]}
+Christianity grew rapidly in Sicily over the next two
+centuries.^{[/[[/wiki/Wikipedia:Citation_needed][citation needed]]/]}
+Sicily remained a Roman province for around 700
+years.^{[[#cite_note-earlymediev-41][[41]]]}
+
+*** <<Germanic_rule_.28469-535.29>>Germanic rule
+(469-535)[[[/w/index.php?title=Sicily&action=edit&section=8][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: germanic-rule-469-535edit
+    :END:
+The [[/wiki/Western_Roman_Empire][Western Roman Empire]] began falling
+apart after the great invasion of [[/wiki/Vandals][Vandals]], Alans, and
+Sueves [[/wiki/Crossing_of_the_Rhine][across the Rhine]] on the last day
+of 406. Eventually the Vandals, after roaming about western and southern
+[[/wiki/Hispania][Hispania]] (present-day [[/wiki/Iberia][Iberia]]) for
+20 years, moved to North Africa in 429. They occupied Carthage in 439.
+(The Franks moved south from present-day Belgium. The Visigoths moved
+west and eventually settled in Aquitaine in 418; the Burgundians settled
+in present-day Savoy in 443). The Vandals found themselves in a position
+to threaten Sicily - only 100 miles away from their North African
+bases.^{[[#cite_note-jpriv-42][[42]]]} After taking Carthage the
+Vandals, personally led by King [[/wiki/Gaiseric][Gaiseric]], laid siege
+to Palermo in 440 as the opening act in an attempt to wrest the island
+from Roman rule.^{[[#cite_note-43][[43]]]} The Vandals made another
+attempt to take the island one year after the 455 sack of Rome, at
+Agrigento, but were defeated decisively by [[/wiki/Ricimer][Ricimir]] in
+a [[/wiki/Battle_of_Corsica][naval victory off Corsica]]
+in 456.^{[[#cite_note-44][[44]]]} The island remained under Roman rule
+until 469. The Vandals lost possession of the island 8 years later in
+477 to the [[/wiki/Germanic_peoples][East Germanic tribe]] of the
+Ostrogoths, who then controlled Italy and
+Dalmatia.^{[[#cite_note-jpriv-42][[42]]]} The island was
+returned^{[/[[/wiki/Wikipedia:Avoid_weasel_words][to whom?]]/]} for
+payment of tribute to [[/wiki/Odoacer][Odoacer]], king of the
+Ostrogoths. He ruled Italy from 476 to 488 in the name of the
+[[/wiki/Byzantine_(Eastern_Roman)_Empire][Byzantine (Eastern Roman)]]
+Emperor. The Vandals kept a toehold in Lilybaeum, a port on the west
+coast. They lost this in 491 after making one last attempt to conquer
+the island from this port.^{[[#cite_note-45][[45]]]} The
+[[/wiki/Ostrogoths][Ostrogothic]] conquest of Sicily (and of Italy as a
+whole) under [[/wiki/Theodoric_the_Great][Theodoric the Great]] began
+in 488. The Byzantine Emperor [[/wiki/Zeno_(emperor)][Zeno]] had
+appointed Theodoric as a military commander in Italy. The Goths were
+Germanic, but Theodoric fostered Roman culture and government and
+allowed freedom of religion.^{[[#cite_note-46][[46]]]} In 461 from the
+age of seven or eight until 17 or 18 Theodoric had become a Byzantine
+hostage; he resided in the great palace of Constantinople, was favored
+by Emperor [[/wiki/Leo_I_(emperor)][Leo I]] (r. 457--474) and learned to
+read and write and do arithmetic.^{[[#cite_note-47][[47]]]}
+
+*** <<Byzantine_period_.28535.E2.80.93965.29>>Byzantine period
+(535--965)[[[/w/index.php?title=Sicily&action=edit&section=9][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: byzantine-period-535965edit
+    :END:
+
+[[/wiki/File:Sicily_by_Piri_Reis.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/5/5e/Sicily_by_Piri_Reis.jpg/220px-Sicily_by_Piri_Reis.jpg]]]]
+
+[[/wiki/File:Sicily_by_Piri_Reis.jpg][]]
+
+Historic map of Sicily by [[/wiki/Piri_Reis][Piri Reis]]
+
+Further information: [[/wiki/Byzantine_Empire][Byzantine Empire]]
+
+After taking areas occupied by the Vandals in North Africa, Justinian
+decided to retake Italy as an ambitious attempt to recover the lost
+provinces in the West. The re-conquests marked an end to over 150 years
+of accommodationist policies with tribal invaders. His first target was
+Sicily (known as the [[/wiki/Gothic_War_(535%E2%80%93554)][Gothic War
+(535--554)]] began between the Ostrogoths and the Eastern Roman Empire,
+also known as the [[/wiki/Byzantine_Empire][Byzantine Empire]]). His
+general [[/wiki/Belisarius][Belisarius]] was assigned the
+task.^{[[#cite_note-48][[48]]]} Sicily was used as a base for the
+Byzantines to conquer the rest of Italy, with [[/wiki/Naples][Naples]],
+Rome, [[/wiki/Milan][Milan]]. It took five years before the Ostrogoth
+capital [[/wiki/Ravenna][Ravenna]] fell
+in 540.^{[[#cite_note-hisnet-49][[49]]]} However, the new Ostrogoth king
+[[/wiki/Totila][Totila]] counterattacked, moving down the Italian
+peninsula, plundering and conquering Sicily in 550. Totila was defeated
+and killed in the [[/wiki/Battle_of_Taginae][Battle of Taginae]] by
+Byzantine general [[/wiki/Narses][Narses]] in 552 but Italy was in
+ruins.^{[[#cite_note-hisnet-49][[49]]]}
+
+At the time of the reconquest Greek was still the predominant language
+spoken on the island. Sicily was invaded by the
+[[/wiki/Rashidun_army][Arab forces]] of [[/wiki/Uthman_Ibn_Affan][Caliph
+Uthman]] in 652, but the Arabs failed to make any permanent gains. They
+returned to Syria with their booty.^{[[#cite_note-50][[50]]]} Raids
+seeking loot continued until the mid-8th
+century.^{[[#cite_note-51][[51]]]}
+
+The Eastern Roman Emperor
+[[/wiki/Constans_II_(Byzantine_Empire)][Constans II]] decided to move
+from [[/wiki/Constantinople][Constantinople]] to
+[[/wiki/Syracuse,_Sicily][Syracuse]] in 660. The following year he
+launched an assault from Sicily against the [[/wiki/Lombardy][Lombard]]
+[[/wiki/Duchy_of_Benevento][Duchy of Benevento]], which occupied most of
+southern Italy.^{[[#cite_note-travsyrac-52][[52]]]} Rumors that the
+capital of the empire was to be moved to Syracuse probably cost Constans
+his life, as he was assassinated
+in 668.^{[[#cite_note-travsyrac-52][[52]]]} His son
+[[/wiki/Constantine_IV][Constantine IV]] succeeded him. A brief
+usurpation in Sicily by [[/wiki/Mezezius][Mezezius]] was quickly
+suppressed by this emperor. Contemporary accounts report that the Greek
+language was widely spoken on the island during this
+period.^{[[#cite_note-53][[53]]]} In 740 Emperor
+[[/wiki/Leo_III_the_Isaurian][Leo III the Isaurian]] transferred Sicily
+from the jurisdiction of the church of Rome to that of Constantinople,
+placing the island within the eastern branch of the
+Church.^{[[#cite_note-54][[54]]]}
+
+In 826 [[/wiki/Euphemius_(Sicily)][Euphemius]], the Byzantine commander
+in Sicily, having apparently killed his wife, forced a nun to marry him.
+Emperor [[/wiki/Michael_II][Michael II]] caught wind of the matter and
+ordered general Constantine to end the marriage and cut off Euphemius'
+head. Euphemius rose up, killed Constantine, and then occupied Syracuse;
+he, in turn, was defeated and driven out to North
+Africa.^{[[#cite_note-stan-55][[55]]]} He offered the rule of Sicily to
+[[/wiki/Ziyadat_Allah_I_of_Aghlabids][Ziyadat Allah]], the
+[[/wiki/Aghlabid][Aghlabid]] Emir of [[/wiki/Tunisia][Tunisia]], in
+return for a position as a general and a place of safety. A
+[[/wiki/Muslim_conquests][Muslim army]] was then sent to the island
+consisting of [[/wiki/Arab][Arabs]], [[/wiki/Berber_people][Berbers]],
+[[/wiki/Cretans][Cretans]], and
+[[/wiki/Persian_people][Persians]].^{[[#cite_note-stan-55][[55]]]}
+
+The [[/wiki/Muslim_conquest_of_Sicily][Muslim conquest of Sicily]] was a
+[[/wiki/See-saw][see-saw]] affair and met with fierce resistance. It
+took over a century for Byzantine Sicily to be conquered; the largest
+city, Syracuse, held out until 878 and the Greek city of
+[[/wiki/Taormina][Taormina]] fell in 962. It was not until 965 that all
+of Sicily was conquered by the
+[[/wiki/Arabs][Arabs]].^{[[#cite_note-stan-55][[55]]]} In the
+11th-century Byzantine armies carried out a partial reconquest of the
+island under [[/wiki/George_Maniakes][George Maniakes]], but it was
+their [[/wiki/Italo-Norman][Norman]] mercenaries who would eventually
+complete the island's reconquest at the end of the century.
+
+*** <<Arab_Period_.28827.E2.80.931091.29>>Arab Period
+(827--1091)[[[/w/index.php?title=Sicily&action=edit&section=10][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: arab-period-8271091edit
+    :END:
+
+Main article: [[/wiki/Emirate_of_Sicily][Emirate of Sicily]]
+
+[[/wiki/File:Cuba_muqarna.jpeg][[[//upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Cuba_muqarna.jpeg/220px-Cuba_muqarna.jpeg]]]]
+
+[[/wiki/File:Cuba_muqarna.jpeg][]]
+
+[[/wiki/Arabesque][Arabesque]] on a wall in the
+[[/wiki/Cuba,_Palermo][Cuba Palace]] in Palermo
+
+The Arabs [[/wiki/Arab_Agricultural_Revolution][initiated land
+reforms]], which increased productivity and encouraged the growth of
+[[/wiki/Smallholding][smallholdings]], undermining the dominance of the
+[[/wiki/Latifundium][latifundia]]. The [[/wiki/Arabs][Arabs]] further
+improved irrigation systems. The language spoken in Sicily under Arab
+rule was [[/wiki/Siculo-Arabic][Siculo-Arabic]] and
+[[/wiki/Influence_of_Arabic_on_other_languages][Arabic influence]] is
+still present in some Sicilian words today. Although long extinct in
+Sicily, the language has developed into what is now the
+[[/wiki/Maltese_language][Maltese language]] on the islands of
+[[/wiki/Malta][Malta]]
+today.^{[/[[/wiki/Wikipedia:Citation_needed][citation needed]]/]}
+
+[[/wiki/File:Palermo_Vicolo_Meschita39904.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/d/d1/Palermo_Vicolo_Meschita39904.jpg/180px-Palermo_Vicolo_Meschita39904.jpg]]]]
+
+[[/wiki/File:Palermo_Vicolo_Meschita39904.jpg][]]
+
+Trilingual sign in [[/wiki/Palermo][Palermo]] in Italian,
+[[/wiki/Hebrew_language][Hebrew]] and [[/wiki/Arabic][Arabic]]
+
+A description of [[/wiki/Palermo][Palermo]] was given by
+[[/wiki/Ibn_Hawqal][Ibn Hawqal]], an
+[[/wiki/History_of_Islamic_economics][Arab merchant]] who visited Sicily
+in 950. A walled suburb, called the Al-Kasr (the palace), is the centre
+of Palermo to this day, with the great Friday mosque on the site of the
+later Roman cathedral. The suburb of al-Khalisa (modern
+[[/wiki/Kalsa][Kalsa]]) contained the [[/wiki/Sultan][Sultan]]'s palace,
+baths, a mosque, government offices, and a private prison.
+[[/wiki/Ibn_Hawqal][Ibn Hawqal]] reckoned 7,000 individual butchers
+trading in 150 shops. Palermo was initially ruled by the
+[[/wiki/Aghlabids][Aghlabids]]; later it was the centre of Emirate of
+Sicily under the nominal suzerainty of the
+[[/wiki/Fatimid_Caliphate][Fatimid
+Caliphate]].^{[/[[/wiki/Wikipedia:Citation_needed][citation needed]]/]}
+During the reign of this dynasty revolts by Byzantine Sicilians
+continuously occurred especially in the east where Greek-speaking
+Christians predominated. Parts of the island were re-occupied before
+revolts were being quashed. During Muslim rule agricultural products
+such as oranges, lemons, [[/wiki/Pistachio][pistachio]] and
+[[/wiki/Sugarcane][sugarcane]] were brought to
+Sicily.^{[[#cite_note-jpriv-42][[42]]]} Under the Arab rule the island
+was divided in [[/wiki/Three_valli_of_Sicily][three administrative
+regions]], or "vals", roughly corresponding to the three "points" of
+Sicily: [[/wiki/Val_di_Mazara][Val di Mazara]] in the west;
+[[/wiki/Val_Demone][Val Demone]] in the northeast; and
+[[/wiki/Val_di_Noto][Val di Noto]] in the southeast. As
+[[/wiki/Dhimmi][dhimmis]], that is as members of a protected class of
+approved monotheists the [[/wiki/Eastern_Orthodox_Church][Eastern
+Orthodox Christians]] were allowed [[/wiki/Freedom_of_religion][freedom
+of religion]], but had to pay a tax, the [[/wiki/Jizya][jizya]] (in lieu
+of the obligatory alms tax, the zakat, paid by Muslims), and were
+restricted from active participation in public affairs.
+
+The [[/wiki/Emirate_of_Sicily][Emirate of Sicily]] began to fragment as
+intra-dynastic quarreling fractured the Muslim
+regime.^{[[#cite_note-stan-55][[55]]]} During this time, there was also
+a small Jewish presence.^{[[#cite_note-56][[56]]]}
+
+*** <<Norman_Sicily_.281038.E2.80.931198.29>>Norman Sicily
+(1038--1198)[[[/w/index.php?title=Sicily&action=edit&section=11][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: norman-sicily-10381198edit
+    :END:
+
+See also: [[/wiki/Norman_conquest_of_southern_Italy][Norman conquest of
+southern Italy]]
+
+[[/wiki/File:Calabria,_trifollaro_di_ruggieri_I_d%27altavilla,_1072-1101.JPG][[[//upload.wikimedia.org/wikipedia/commons/thumb/a/ab/Calabria%2C_trifollaro_di_ruggieri_I_d%27altavilla%2C_1072-1101.JPG/220px-Calabria%2C_trifollaro_di_ruggieri_I_d%27altavilla%2C_1072-1101.JPG]]]]
+
+[[/wiki/File:Calabria,_trifollaro_di_ruggieri_I_d%27altavilla,_1072-1101.JPG][]]
+
+[[/wiki/Roger_I_of_Sicily][Roger I]] conqueror and first count of
+Sicily, depicted on a [[/wiki/Trifollaris][Trifollaris]]
+
+[[/wiki/File:Cefalucathedralnight.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/7/75/Cefalucathedralnight.jpg/220px-Cefalucathedralnight.jpg]]]]
+
+[[/wiki/File:Cefalucathedralnight.jpg][]]
+
+The cathedral of [[/wiki/Cefal%C3%B9][Cefalù]] at night
+
+In 1038, seventy years after losing their last cities in Sicily, the
+Byzantines under the Greek general [[/wiki/George_Maniakes][George
+Maniakes]] invaded the island together with their
+[[/wiki/Varangian_guard][Varangian]] and [[/wiki/Normans][Norman]]
+mercenaries. Maniakes was killed in a Byzantine civil war in 1043 before
+completing a reconquest and the Byzantines withdrew. The Normans invaded
+in 1061.^{[[#cite_note-Boise_State_University_Sicily_under_the_ormans-57][[57]]]}
+After taking [[/wiki/Apulia][Apulia]] and [[/wiki/Calabria][Calabria]],
+Roger occupied [[/wiki/Messina][Messina]] with an army of 700 knights.
+In 1068, Roger was victorious at [[/wiki/Misilmeri][Misilmeri]]. Most
+crucial was the siege of Palermo, whose fall in 1071 eventually resulted
+in all Sicily coming under Norman
+control.^{[[#cite_note-initalymag-58][[58]]]} The conquest was completed
+in 1091 when they captured [[/wiki/Noto][Noto]] the last Arab
+stronghold. Palermo continued to be the capital under the
+[[/wiki/Normans][Normans]].
+
+The Norman [[/wiki/Hauteville_family][Hauteville family]], descendants
+of [[/wiki/Vikings][Vikings]], appreciated and admired the rich and
+layered culture in which they now found themselves. They also introduced
+their own culture, customs, and politics in the region. Many Normans in
+Sicily adopted the habits and comportment of Muslim rulers and their
+Byzantine subjects in dress, language, literature, even to the extent of
+having palace [[/wiki/Eunuch][eunuchs]] and, according to some accounts,
+a harem.^{[[#cite_note-59][[59]]][[#cite_note-60][[60]]]}
+
+*** Kingdom of
+Sicily[[[/w/index.php?title=Sicily&action=edit&section=12][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: kingdom-of-sicilyedit
+    :END:
+
+Main articles: [[/wiki/Kingdom_of_Sicily][Kingdom of Sicily]] and
+[[/wiki/List_of_monarchs_of_Sicily][List of monarchs of Sicily]]
+
+[[/wiki/File:MonrealeCathedral-pjt1.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/2/2a/MonrealeCathedral-pjt1.jpg/220px-MonrealeCathedral-pjt1.jpg]]]]
+
+[[/wiki/File:MonrealeCathedral-pjt1.jpg][]]
+
+The [[/wiki/Cathedral_of_Monreale][Cathedral of Monreale]].
+
+Roger died in 1101. His wife [[/wiki/Adelaide_del_Vasto][Adelaide]]
+ruled until 1112 when their son [[/wiki/Roger_II_of_Sicily][Roger II of
+Sicily]] came of
+age.^{[[#cite_note-Boise_State_University_Sicily_under_the_ormans-57][[57]]]}
+Having succeeded his brother [[/wiki/Simon_of_Sicily][Simon]] as Count
+of Sicily, Roger II was ultimately able to raise the status of the
+island to a kingdom in 1130, along with his other holdings, which
+included the [[/wiki/Maltese_Islands][Maltese Islands]] and the Duchies
+of [[/wiki/Duchy_of_Apulia][Apulia]] and
+[[/wiki/Duchy_of_Calabria][Calabria]].^{[[#cite_note-initalymag-58][[58]]][[#cite_note-malta-61][[61]]]}
+
+Roger II appointed the powerful Greek [[/wiki/George_of_Antioch][George
+of Antioch]] to be his "emir of emirs" and continued the syncretism of
+his father. During this period, the Kingdom of Sicily was prosperous and
+politically powerful, becoming one of the wealthiest states in all of
+Europe---even wealthier than the [[/wiki/Kingdom_of_England][Kingdom of
+England]].^{[[#cite_note-62][[62]]]}
+
+The court of Roger II became the most luminous centre of culture in the
+Mediterranean, both from Europe and the Middle East, like the
+multi-ethnic [[/wiki/Caliphate_of_C%C3%B3rdoba][Caliphate of Córdoba]],
+then only just eclipsed. This attracted scholars, scientists, poets,
+artists, and artisans of all kinds. Laws were issued in the language of
+the community to whom they were addressed in Norman Sicily, at the time
+when the culture was still heavily Arab and
+Greek.^{[[#cite_note-Advanced_Studies_in_Cultural_History-63][[63]]][[#cite_note-Loud,_G._A._2007_494-64][[64]]]}
+Governance was by rule of law which promoted justice. Muslims, Jews,
+[[/wiki/Byzantine_Greeks][Byzantine Greeks]], Lombards, and Normans
+worked together fairly amicably. During this time many extraordinary
+buildings were
+constructed.^{[[#cite_note-Advanced_Studies_in_Cultural_History-63][[63]]]}
+
+However this situation changed as the Normans to secure the island
+imported immigrants from [[/wiki/Normandy][Normandy]],
+[[/wiki/England][England]], Lombardy, Piedmont, Provence and
+[[/wiki/Campania][Campania]]. Linguistically, the island shifted from
+being one-third Greek- and two-thirds Arabic-speaking at the time of the
+Norman conquest to becoming fully
+[[/wiki/Linguistic_Latinisation][Latinised]].^{[[#cite_note-Loud,_G._A._2007_494-64][[64]]]}
+In terms of religion the island became completely Roman Catholic
+(bearing in mind that until 1054 the Churches owing allegiance to the
+Pope and the Patriarch of Constantinople belonged to one Church); Sicily
+before the Norman conquest was under Eastern Orthodox
+Patriarch.^{[[#cite_note-normansbestof-65][[65]]]} After Pope Innocent
+III made him Papal Legate in 1098, Roger I created several Catholic
+bishoprics while still allowing the construction of 12 Greek-speaking
+monasteries (the Greek language, monasteries, and 1500 parishes
+continued to exist until the adherents of the Greek Rite were forced in
+1585 to convert to Catholicism or leave; a small pocket of
+Greek-speakers still live in Messina).
+
+*** Hohenstaufen
+dynasty[[[/w/index.php?title=Sicily&action=edit&section=13][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: hohenstaufen-dynastyedit
+    :END:
+
+[[/wiki/File:Ortigia,_castello_maniace,_interno,_sala_01.JPG][[[//upload.wikimedia.org/wikipedia/commons/thumb/e/ef/Ortigia%2C_castello_maniace%2C_interno%2C_sala_01.JPG/220px-Ortigia%2C_castello_maniace%2C_interno%2C_sala_01.JPG]]]]
+
+[[/wiki/File:Ortigia,_castello_maniace,_interno,_sala_01.JPG][]]
+
+Interior of [[/wiki/Castello_Maniace][Castello Maniace]]
+
+After a century, the Norman [[/wiki/Hauteville_family][Hauteville]]
+dynasty died out; the last direct descendant and heir of Roger,
+[[/wiki/Constance_of_Sicily][Constance]], married
+[[/wiki/Henry_VI,_Holy_Roman_Emperor][Emperor Henry
+VI]].^{[[#cite_note-dieli-66][[66]]]} This eventually led to the crown
+of Sicily being passed on to the
+[[/wiki/Hohenstaufen_Dynasty][Hohenstaufen Dynasty]], who were Germans
+from [[/wiki/Swabia][Swabia]]. The last of the Hohenstaufens,
+[[/wiki/Frederick_II,_Holy_Roman_Emperor][Frederick II]], the only son
+of [[/wiki/Constance_of_Sicily][Constance]], was one of the greatest and
+most cultured men of the Middle Ages. His mother's will had asked
+[[/wiki/Pope_Innocent_III][Pope Innocent III]] to undertake the
+guardianship of her son. Frederick was four when at
+[[/wiki/Palermo][Palermo]], he was crowned [[/wiki/King_of_Sicily][King
+of Sicily]] in 1198. Frederick received no systematic education and was
+allowed to run free in the streets of [[/wiki/Palermo][Palermo]]. There
+he picked up the many languages he heard spoken, such as Arabic and
+Greek, and learned some of the lore of the Jewish community. At age
+twelve, he dismissed Innocent's deputy regent and took over the
+government; at fifteen he married [[/wiki/Constance_of_Aragon][Constance
+of Aragon]], and began his reclamation of the imperial crown.
+Subsequently, due to Muslim rebellions, Frederick II destroyed the
+remaining Muslim presence in Sicily, estimated at 60,000 persons, moving
+all to the city of Lucera in Apulia between 1221
+and 1226.^{[[#cite_note-67][[67]]]}
+
+Conflict between the Hohenstaufen house and the [[/wiki/Papacy][Papacy]]
+led, in 1266, to [[/wiki/Pope_Innocent_IV][Pope Innocent IV]] crowning
+the [[/wiki/Capetian_House_of_Anjou][French prince]]
+[[/wiki/Charles_I_of_Naples][Charles]], [[/wiki/Count_of_Anjou][count of
+Anjou]] and [[/wiki/List_of_rulers_of_Provence][Provence]], as the king
+of both Sicily and Naples.^{[[#cite_note-dieli-66][[66]]]}
+
+*** Sicily under Aragonese
+rule[[[/w/index.php?title=Sicily&action=edit&section=14][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: sicily-under-aragonese-ruleedit
+    :END:
+
+[[/wiki/File:Francesco_Hayez_023.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/a/aa/Francesco_Hayez_023.jpg/220px-Francesco_Hayez_023.jpg]]]]
+
+[[/wiki/File:Francesco_Hayez_023.jpg][]]
+
+Depiction of the [[/wiki/Sicilian_Vespers][Sicilian Vespers]]
+
+Strong opposition to French officialdom due to mistreatment and taxation
+saw the local peoples of Sicily rise up, leading in 1282 to an
+[[/wiki/Insurrection][insurrection]] known as the
+[[/wiki/War_of_the_Sicilian_Vespers][War of the Sicilian Vespers]],
+which eventually saw almost the entire French population on the island
+killed.^{[[#cite_note-dieli-66][[66]]]} During the war, the Sicilians
+turned to [[/wiki/Peter_III_of_Aragon][Peter III of Aragon]], son-in-law
+of the last Hohenstaufen king, for support after being rejected by the
+Pope. Peter gained control of Sicily from the French, who, however,
+retained control of the [[/wiki/Kingdom_of_Naples][Kingdom of Naples]].
+A crusade was launched in August 1283 against Peter III and the Kingdom
+of Aragon by [[/wiki/Pope_Martin_IV][Pope Martin IV]] (a pope from
+[[/wiki/%C3%8Ele-de-France][Île-de-France]]), but it failed. The wars
+continued until the [[/wiki/Peace_of_Caltabellotta][peace of
+Caltabellotta]] in 1302, which saw Peter's son
+[[/wiki/Frederick_III_of_Sicily][Frederick III]] recognized as the king
+of the Isle of Sicily, while [[/wiki/Charles_II_of_Naples][Charles II]]
+was recognized as the king of Naples by [[/wiki/Pope_Boniface_VIII][Pope
+Boniface VIII]].^{[[#cite_note-dieli-66][[66]]]} Sicily was ruled as an
+independent kingdom by relatives of the kings of Aragon until 1409 and
+then as part of the [[/wiki/Crown_of_Aragon][Crown of
+Aragon]].^{[[#cite_note-knowital-33][[33]]]} In October 1347, in
+Messina, Sicily, the [[/wiki/Black_Death][Black Death]] first arrived in
+Europe.^{[[#cite_note-68][[68]]]}
+
+Between the 15th-18th centuries, waves of [[/wiki/Greeks][Greeks]] from
+the [[/wiki/Peloponnese][Peloponnese]] (such as the
+[[/wiki/Maniots][Maniots]]) and [[/wiki/Arvanites][Arvanites]] migrated
+to Sicily in large numbers to escape persecution after the
+[[/wiki/Ottoman_conquest_of_the_Balkans][Ottoman conquest of the
+Peloponnese]]. They brought with them [[/wiki/Eastern_Orthodoxy][Eastern
+Orthodoxy]] as well as the [[/wiki/Greek_language][Greek]] and
+[[/wiki/Arvanitika][Arvanitika]] languages to the island, once again
+adding onto the extensive
+[[/wiki/Byzantine][Byzantine]]/[[/wiki/Greek_Culture][Greek]]
+influence.^{[/[[/wiki/Wikipedia:Citation_needed][citation needed]]/]}
+
+[[/wiki/File:Catania_BW_2012-10-06_11-23-47.JPG][[[//upload.wikimedia.org/wikipedia/commons/thumb/a/ae/Catania_BW_2012-10-06_11-23-47.JPG/220px-Catania_BW_2012-10-06_11-23-47.JPG]]]]
+
+[[/wiki/File:Catania_BW_2012-10-06_11-23-47.JPG][]]
+
+[[/wiki/Sicilian_Baroque][Sicilian Baroque]] in
+[[/wiki/Catania][Catania]].
+
+The onset of the [[/wiki/Spanish_Inquisition][Spanish Inquisition]] in
+1492 led to [[/wiki/Ferdinand_II_of_Aragon][Ferdinand II]] decreeing the
+expulsion of all Jews from Sicily.^{[[#cite_note-dieli-66][[66]]]} The
+eastern part of the island was hit by very destructive earthquakes in
+1542 and 1693. Just a few years before the latter earthquake, the island
+was struck by a ferocious
+[[/wiki/Plague_(disease)][plague]].^{[[#cite_note-dieli-66][[66]]]} The
+[[/wiki/1693_Sicily_earthquake][earthquake in 1693]] took an estimated
+60,000 lives.^{[[#cite_note-69][[69]]]} There were revolts during the
+17th century, but these were quelled with significant force, especially
+the revolts of Palermo and Messina.^{[[#cite_note-knowital-33][[33]]]}
+[[/wiki/Barbary_pirates][North African]]
+[[/wiki/Barbary_slave_trade][slave raids]] discouraged settlement along
+the coast until the 19th
+century.^{[[#cite_note-70][[70]]][[#cite_note-71][[71]]]} The
+[[/wiki/Treaty_of_Utrecht][Treaty of Utrecht]] in 1713 saw Sicily
+assigned to the [[/wiki/House_of_Savoy][House of Savoy]]; however, this
+period of rule lasted only seven years, as it was exchanged for the
+island of [[/wiki/Sardinia][Sardinia]] with
+[[/wiki/Charles_VI,_Holy_Roman_Emperor][Emperor Charles VI]] of the
+Austrian [[/wiki/House_of_Habsburg][Habsburg
+Dynasty]].^{[[#cite_note-72][[72]]]}
+
+While the Austrians were concerned with the
+[[/wiki/War_of_the_Polish_Succession][War of the Polish Succession]], a
+[[/wiki/House_of_Bourbon][Bourbon]] prince,
+[[/wiki/Charles_III_of_Spain][Charles]] from Spain was able to conquer
+Sicily and Naples.^{[[#cite_note-73][[73]]]} At first Sicily was able to
+remain as an independent kingdom under [[/wiki/Personal_union][personal
+union]], while the Bourbons ruled over both from Naples. However, the
+advent of [[/wiki/Napoleon_I][Napoleon]]'s
+[[/wiki/First_French_Empire][First French Empire]] saw Naples taken at
+the [[/wiki/Battle_of_Campo_Tenese][Battle of Campo Tenese]] and
+Bonapartist [[/wiki/King_of_Naples][King of Naples]] were installed.
+[[/wiki/Ferdinand_I_of_the_Two_Sicilies][Ferdinand III]] the Bourbon was
+forced to retreat to Sicily which he was still in complete control of
+with the help of [[/wiki/Royal_Navy][British naval]]
+protection.^{[[#cite_note-74][[74]]]}
+
+Following this, Sicily joined the [[/wiki/Napoleonic_Wars][Napoleonic
+Wars]], and subsequently the British under
+[[/wiki/Lord_William_Bentinck][Lord William Bentinck]] established a
+military and diplomatic presence on the island to protect against a
+French invasion. After the wars were won, Sicily and Naples formally
+merged as the [[/wiki/Two_Sicilies][Two Sicilies]] under the Bourbons.
+Major [[/wiki/Revolutionary][revolutionary]] movements occurred in 1820
+and 1848 against the Bourbon government with Sicily seeking
+independence; the second of which, the
+[[/wiki/Sicilian_revolution_of_independence_of_1848][1848 revolution]]
+resulted in a short period of independence for Sicily. However, in 1849
+the Bourbons retook control of the island and dominated it
+until 1860.^{[[#cite_note-75][[75]]]}
+
+*** Italian
+unification[[[/w/index.php?title=Sicily&action=edit&section=15][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: italian-unificationedit
+    :END:
+
+See also: [[/wiki/Risorgimento][Risorgimento]]
+
+[[/wiki/File:Battle_of_Calatafimi.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/a/a0/Battle_of_Calatafimi.jpg/220px-Battle_of_Calatafimi.jpg]]]]
+
+[[/wiki/File:Battle_of_Calatafimi.jpg][]]
+
+Battle of [[/wiki/Calatafimi][Calatafimi]], 1860
+
+The [[/wiki/Expedition_of_the_Thousand][Expedition of the Thousand]] led
+by [[/wiki/Giuseppe_Garibaldi][Giuseppe Garibaldi]] captured Sicily in
+1860, as part of the
+/[[/wiki/Italian_unification][Risorgimento]]/.^{[[#cite_note-modern-76][[76]]]}
+The conquest started at [[/wiki/Marsala][Marsala]], and native Sicilians
+joined him in the capture of the southern Italian peninsula. Garibaldi's
+march was completed with the [[/wiki/Siege_of_Gaeta_(1861)][Siege of
+Gaeta]], where the final [[/wiki/Bourbons][Bourbons]] were expelled and
+Garibaldi announced his dictatorship in the name of
+[[/wiki/Victor_Emanuel_II_of_Italy][Victor Emmanuel II]] of
+[[/wiki/Kingdom_of_Sardinia][Kingdom of
+Sardinia]].^{[[#cite_note-77][[77]]]} Sicily became part of the Kingdom
+of Sardinia after a referendum where more than 75% of Sicily voted in
+favour of the annexation on 21 October 1860 (but not everyone was
+allowed to vote). As a result of the
+[[/wiki/Proclamation_of_the_Kingdom_of_Italy][proclamation of the
+Kingdom of Italy]], Sicily became part of the kingdom on 17 March 1861.
+
+The Sicilian economy (and the wider /[[/wiki/Mezzogiorno][mezzogiorno]]/
+economy) remained relatively underdeveloped after the
+[[/wiki/Italian_unification][Italian unification]], in spite of the
+strong investments made by the [[/wiki/Kingdom_of_Italy][Kingdom of
+Italy]] in terms of modern infrastructure, and this caused an
+unprecedented [[/wiki/Italian_diaspora][wave of
+emigration]].^{[[#cite_note-modern-76][[76]]]} In 1894, organisations of
+workers and peasants known as the /[[/wiki/Fasci_Siciliani][Fasci
+Siciliani]]/ protested against the bad social and economic conditions of
+the island, but they were suppressed in a few
+days.^{[[#cite_note-78][[78]]][[#cite_note-79][[79]]]} The
+[[/wiki/1908_Messina_earthquake][Messina earthquake]] of 28 December
+1908 killed more than 80,000 people.^{[[#cite_note-80][[80]]]}
+
+This period was also characterized by the first contact between the
+[[/wiki/Sicilian_mafia][Sicilian mafia]] (the crime syndicate also known
+as Cosa Nostra) and the Italian government. The Mafia's origins are
+still uncertain, but it is generally accepted that it emerged in the
+18th century initially in the role of private enforcers hired to protect
+the property of landowners and merchants from the groups of
+[[/wiki/Bandits][bandits]] (/Briganti/) who frequently pillaged the
+countryside and towns. The battle against the Mafia made by the Kingdom
+of Italy was controversial and ambiguous. The
+[[/wiki/Carabinieri][Carabinieri]] (the military police of Italy) and
+sometimes the [[/wiki/Regio_Esercito][Italian army]] were often involved
+in terrible fights against the mafia members, but their efforts were
+frequently useless because of the secret co-operation between the mafia
+and local government and also because of the weakness of the Italian
+judicial system.^{[[#cite_note-81][[81]]]}
+
+*** 20th and 21st
+centuries[[[/w/index.php?title=Sicily&action=edit&section=16][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: th-and-21st-centuriesedit
+    :END:
+
+[[/wiki/File:Private_Roy_W._Humphrey_of_Toledo,_Ohio_is_being_given_blood_plasma_after_he_was_wounded_by_shrapnel_in_Sicily_on_8-9-43_-_NARA_-_197268.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/6/64/Private_Roy_W._Humphrey_of_Toledo%2C_Ohio_is_being_given_blood_plasma_after_he_was_wounded_by_shrapnel_in_Sicily_on_8-9-43_-_NARA_-_197268.jpg/220px-Private_Roy_W._Humphrey_of_Toledo%2C_Ohio_is_being_given_blood_plasma_after_he_was_wounded_by_shrapnel_in_Sicily_on_8-9-43_-_NARA_-_197268.jpg]]]]
+
+[[/wiki/File:Private_Roy_W._Humphrey_of_Toledo,_Ohio_is_being_given_blood_plasma_after_he_was_wounded_by_shrapnel_in_Sicily_on_8-9-43_-_NARA_-_197268.jpg][]]
+
+Private Roy W. Humphrey of [[/wiki/Toledo,_Ohio][Toledo, Ohio]] is being
+given [[/wiki/Blood_plasma][blood plasma]] after he was wounded by
+[[/wiki/Shrapnel_(fragment)][shrapnel]] in Sicily on 9 August 1943.
+
+In the 1920s, the [[/wiki/Italian_fascism][Fascist]] regime began a
+stronger military action against the Mafia, which was led by
+[[/wiki/Prefect][prefect]] [[/wiki/Cesare_Mori][Cesare Mori]], who was
+known as the "Iron Prefect" because of his iron-fisted campaigns. This
+was the first time in which an operation against the Sicilian mafia
+ended with considerable success.^{[[#cite_note-modern-76][[76]]]} There
+was an [[/wiki/Allied_invasion_of_Sicily][Allied invasion of Sicily]]
+during World War II starting on 10 July 1943. In preparation for the
+invasion, the Allies
+[[/wiki/Collaborations_between_the_United_States_government_and_Italian_Mafia][revitalised]]
+the Mafia to aid them. The invasion of Sicily contributed to the
+[[/wiki/25_Luglio][25 July crisis]]; in general, the Allied victors were
+warmly embraced by Sicily.^{[[#cite_note-autogenerated1-82][[82]]]}
+
+Italy [[/wiki/Birth_of_the_Italian_Republic][became a Republic]] in 1946
+and, as part of the [[/wiki/Constitution_of_Italy][Constitution of
+Italy]], Sicily was one of the five [[/wiki/Regions_of_Italy][regions]]
+given special status as an
+[[/wiki/Autonomous_administrative_division][autonomous
+region]].^{[[#cite_note-83][[83]]]} Both the partial Italian
+[[/wiki/Land_reform][land reform]] and special funding from the Italian
+government's /[[/wiki/Cassa_per_il_Mezzogiorno][Cassa per il
+Mezzogiorno]]/ (Fund for the South) from 1950 to 1984 helped the
+Sicilian economy. During this period, the economic and social condition
+of the island was generally improved thanks to important investments on
+infrastructures such as [[/wiki/Motorways][motorways]] and
+[[/wiki/Airports][airports]], and thanks to the creation of important
+industrial and commercial areas.^{[[#cite_note-84][[84]]]} In the 1980s,
+the Mafia was deeply weakened by a second important campaign led by
+magistrates [[/wiki/Giovanni_Falcone][Giovanni Falcone]] and
+[[/wiki/Paolo_Borsellino][Paolo Borsellino]].^{[[#cite_note-85][[85]]]}
+Between 1990 and 2005, the [[/wiki/Unemployment_rate][unemployment
+rate]] fell from about 23% to
+11%.^{[[#cite_note-86][[86]]][[#cite_note-87][[87]]]}
+
+The Cosa Nostra has traditionally been the most powerful group in
+Sicily, especially around Palermo.^{[[#cite_note-88][[88]]]} A police
+investigation in summer 2019 also confirmed strong links between the
+Palermo area [[/wiki/Sicilian_Mafia][Sicilian Mafia]] and American
+organized crime, particularly the [[/wiki/Gambino_crime_family][Gambino
+crime family]].^{[[#cite_note-89][[89]]]} According to
+/[[/wiki/La_Repubblica][La Repubblica]]/, "Off they go, through the
+streets of Passo di Rigano, Boccadifalco, Torretta and at the same time,
+Brooklyn, Staten Island, New Jersey. Because from Sicily to the US, the
+old mafia has returned".^{[[#cite_note-90][[90]]]}
+
+** Demographics[[[/w/index.php?title=Sicily&action=edit&section=17][edit]]]
+   :PROPERTIES:
+   :CUSTOM_ID: demographicsedit
+   :END:
+
+Main article: [[/wiki/Sicilians][Sicilians]]
+
+[[/wiki/File:Palermo-Panorama-bjs-3.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/5/52/Palermo-Panorama-bjs-3.jpg/220px-Palermo-Panorama-bjs-3.jpg]]]]
+
+[[/wiki/File:Palermo-Panorama-bjs-3.jpg][]]
+
+The city of [[/wiki/Palermo][Palermo]]
+
+| Year                                                           | Pop.      | ±%      |
+| 1861                                                           | 2,409,000 | ---     |
+| 1871                                                           | 2,590,000 | +7.5%   |
+| 1881                                                           | 2,933,000 | +13.2%  |
+| 1901                                                           | 3,568,000 | +21.7%  |
+| 1911                                                           | 3,812,000 | +6.8%   |
+| 1921                                                           | 4,223,000 | +10.8%  |
+| 1931                                                           | 3,906,000 | −7.5%   |
+| 1936                                                           | 4,000,000 | +2.4%   |
+| 1951                                                           | 4,487,000 | +12.2%  |
+| 1961                                                           | 4,721,000 | +5.2%   |
+| 1971                                                           | 4,681,000 | −0.8%   |
+| 1981                                                           | 4,907,000 | +4.8%   |
+| 1991                                                           | 4,966,000 | +1.2%   |
+| 2001                                                           | 4,969,000 | +0.1%   |
+| 2011                                                           | 5,002,904 | +0.7%   |
+| 2019                                                           | 4,969,147 | −0.7%   |
+| Source: [[/wiki/Istituto_Nazionale_di_Statistica][ISTAT]] 2017 |           |         |
+#+caption: Historical population
+
+About five million people live in Sicily, making it the
+[[/wiki/List_of_regions_of_Italy#List_of_regions][fourth most populated
+region in Italy]]. In the first century after the
+[[/wiki/Italian_unification][Italian unification]], Sicily had one of
+the most negative [[/wiki/Net_migration_rate][net migration rates]]
+among the regions of Italy because of the emigration of millions of
+people to Northern Italy, other European countries, North America, South
+America and Australia. Like the South of Italy and Sardinia, immigration
+to the island is very low compared to other regions of Italy because
+workers tend to head to [[/wiki/Northern_Italy][Northern Italy]]
+instead, due to better employment and industrial opportunities.
+According to [[/wiki/Istituto_Nazionale_di_Statistica][ISTAT]] figures
+from 2017,^{[[#cite_note-91][[91]]]} show around 175,000 immigrants out
+of the total 5,029,615 population;^{[[#cite_note-92][[92]]]}
+[[/wiki/Romanians][Romanians]] with more than 50,000 make up the most
+immigrants, followed by [[/wiki/Tunisians][Tunisians]],
+[[/wiki/Moroccans][Moroccans]], [[/wiki/Sri_Lankan_Tamil_diaspora][Sri
+Lankans]], [[/wiki/Albanians][Albanians]], and others mostly from
+Eastern Europe.^{[/[[/wiki/Wikipedia:Verifiability][failed
+verification]]/]} As in the rest of Italy, the official language is
+Italian and the primary religion is [[/wiki/Roman_Catholicism][Roman
+Catholicism]].^{[[#cite_note-93][[93]]][[#cite_note-94][[94]]]}
+
+*** Emigration[[[/w/index.php?title=Sicily&action=edit&section=18][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: emigrationedit
+    :END:
+
+See also: [[/wiki/Sicilian_Americans][Sicilian Americans]]
+
+[[/wiki/File:A_Sicilian_caf%C3%A9_in_New_York_-_Drawn_by_W.A._Rogers._LCCN2013645874.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/1/15/A_Sicilian_caf%C3%A9_in_New_York_-_Drawn_by_W.A._Rogers._LCCN2013645874.jpg/220px-A_Sicilian_caf%C3%A9_in_New_York_-_Drawn_by_W.A._Rogers._LCCN2013645874.jpg]]]]
+
+[[/wiki/File:A_Sicilian_caf%C3%A9_in_New_York_-_Drawn_by_W.A._Rogers._LCCN2013645874.jpg][]]
+
+A Sicilian café in [[/wiki/New_York_City][New York]] 1889
+
+Since the Italian unification, Sicily, along with the entire south of
+the Italian peninsula has been strongly marked by
+[[/wiki/Forced_displacement][coerced emigration]], partly induced by a
+planned de-industrialization of the south in order to favour the
+northern regions.^{[[#cite_note-95][[95]]]} After
+[[/wiki/Italian_unification][Italian unification]] most of the
+[[/wiki/Kingdom_of_the_Two_Sicilies][Kingdom of the Two Sicilies]]'s
+former National Bank, the [[/wiki/Banco_di_Napoli][Banco delle Due
+Sicilie]]'s assets were transferred to
+Piedmont.^{[[#cite_note-96][[96]]]} During the first decades of the
+Risorgimento, a rising number of Sicilian and South Italian
+manufactories were driven into ruin due to high taxation imposed by the
+central government. Furthermore, an embargo imposed on goods coming from
+South Italian manufacturers, that effectively barred them from exporting
+to the north and abroad, were also key factors that led to further
+impoverishment of the entire region. South Italian and Sicilian
+emigration started shortly after the Unification of Italy and has not
+stopped ever since. By the beginning of the 1900s, less than 40 years
+after the Unification, what was formerly known as the Kingdom of the Two
+Sicilies, one of Europe's most industrialized countries, became one of
+the poorest regions in Europe.^{[[#cite_note-97][[97]]]}
+
+The aforementioned factors, along with a failed land reform, resulted in
+a never-before-seen wave of Sicilians emigrating, first to the
+[[/wiki/United_States][United States]] between the 1880s and the 1920s,
+later to Northern Italy, and from the 1960s onwards also to
+[[/wiki/Belgium][Belgium]], [[/wiki/France][France]],
+[[/wiki/Germany][Germany]], [[/wiki/Switzerland][Switzerland]], as well
+as [[/wiki/Australia][Australia]] and [[/wiki/South_America][South
+America]].
+
+Today, Sicily is the Italian region with the highest number of
+[[/wiki/Expatriate][expatriates]]: as of 2017, 750,000 Sicilians, 14.4%
+of the island's population, lived abroad.^{[[#cite_note-98][[98]]]} For
+lack of employment, every year many Sicilians, especially young
+graduates, still leave the island to seek jobs
+abroad.^{[[#cite_note-99][[99]]]} Today, an estimated 10 million people
+of Sicilian origins live around the world.
+
+*** Largest
+cities[[[/w/index.php?title=Sicily&action=edit&section=19][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: largest-citiesedit
+    :END:
+
+See also: [[/wiki/List_of_communes_of_Sicily][List of communes of
+Sicily]]
+
+These are the ten largest cities of Sicily:^{[[#cite_note-100][[100]]]}
+
+| Rank | Name                                   | Pop. (2017) | Area (km^{2}) | Pop. per km^{2} |
+| 1    | [[/wiki/Palermo][Palermo]]             | 668,405     | 159           | 4,207           |
+| 2    | [[/wiki/Catania][Catania]]             | 311,620     | 181           | 1,723           |
+| 3    | [[/wiki/Messina][Messina]]             | 234,293     | 212           | 1,107           |
+| 4    | [[/wiki/Syracuse,_Sicily][Syracuse]]   | 121,605     | 204           | 596             |
+| 5    | [[/wiki/Marsala][Marsala]]             | 82,802      | 242           | 343             |
+| 6    | [[/wiki/Gela][Gela]]                   | 74,858      | 277           | 270             |
+| 7    | [[/wiki/Ragusa,_Sicily][Ragusa]]       | 73,638      | 442           | 166             |
+| 8    | [[/wiki/Trapani][Trapani]]             | 67,923      | 272           | 250             |
+| 9    | [[/wiki/Vittoria,_Sicily][Vittoria]]   | 64,212      | 181           | 354             |
+| 10   | [[/wiki/Caltanissetta][Caltanissetta]] | 62,317      | 416           | 150             |
+
+*** Religion[[[/w/index.php?title=Sicily&action=edit&section=20][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: religionedit
+    :END:
+
+See also: [[/wiki/Italo-Albanian_Catholic_Church][Italo-Albanian
+Catholic Church]], [[/wiki/History_of_the_Jews_in_Sicily][History of the
+Jews in Sicily]], and
+[[/wiki/History_of_Islam_in_southern_Italy][History of Islam in southern
+Italy]]
+
+[[/wiki/File:Sicilia_Noto1_tango7174.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/7/7b/Sicilia_Noto1_tango7174.jpg/220px-Sicilia_Noto1_tango7174.jpg]]]]
+
+[[/wiki/File:Sicilia_Noto1_tango7174.jpg][]]
+
+[[/wiki/Noto_Cathedral][Noto Cathedral]]
+
+As in most Italian regions, [[/wiki/Roman_Catholicism][Roman
+Catholicism]] is the predominant religious denomination in Sicily, and
+the church still plays an important role in the lives of most people.
+There is also a notable small minority of Eastern-rite
+[[/wiki/Byzantine_Catholics][Byzantine Catholics]] which has a mixed
+congregation of ethnic [[/wiki/Albanians][Albanians]]; it is operated by
+the [[/wiki/Italo-Albanian_Catholic_Church][Italo-Albanian Catholic
+Church]]. Most people still attend church weekly or at least for
+religious festivals, and many people get married in churches. There was
+a wide presence of Jews in Sicily for at least 1,400 years and possibly
+for more than 2,000 years. Some scholars believe that the Sicilian Jewry
+are partial ancestors of the [[/wiki/Ashkenazi_Jews][Ashkenazi
+Jews]].^{[[#cite_note-101][[101]]]} However, much of the Jewish
+community faded away when they were
+[[/wiki/Expulsion_of_the_Jews_from_Sicily][expelled from the island]]
+in 1492. [[/wiki/Islam][Islam]] was present during the
+[[/wiki/Emirate_of_Sicily][Emirate of Sicily]], although Muslims were
+also expelled. Today, mostly due to immigration to the island, there are
+also several religious minorities, such as Jehovah's Witnesses,
+[[/wiki/Hinduism][Hinduism]], Islam, Judaism, and
+[[/wiki/Sikhism][Sikhism]]. There are also a fair number of
+[[/wiki/Evangelicalism][evangelical]] Christians who live on the island.
+
+** Politics[[[/w/index.php?title=Sicily&action=edit&section=21][edit]]]
+   :PROPERTIES:
+   :CUSTOM_ID: politicsedit
+   :END:
+
+Main article: [[/wiki/Politics_of_Sicily][Politics of Sicily]]
+
+The politics of Sicily takes place in a framework of a
+[[/wiki/Presidential_system][presidential]]
+[[/wiki/Representative_democracy][representative democracy]], whereby
+the President of Regional Government is the
+[[/wiki/Head_of_government][head of government]], and of a pluriform
+[[/wiki/Multi-party_system][multi-party system]].
+[[/wiki/Executive_power][Executive power]] is exercised by the Regional
+Government. [[/wiki/Legislative_power][Legislative power]] is vested in
+both the government and the [[/wiki/Sicilian_Regional_Assembly][Sicilian
+Regional Assembly]]. The capital of Sicily is
+[[/wiki/Palermo][Palermo]].
+
+Traditionally, Sicily gives center-right results during
+elections.^{[[#cite_note-102][[102]]]} From 1943 to 1951 there was also
+a [[/wiki/Separatism][separatist]] political party called
+[[/wiki/Sicilian_Independence_Movement][Sicilian Independence Movement]]
+(/Movimento Indipendentista Siciliano/, MIS). Its best electoral result
+was in the [[/wiki/Italian_general_election,_1946][1946 general
+election]], when MIS obtained 0.7% of national votes (8.8% of votes in
+Sicily), and four seats. However, the movement lost all its seats
+following the [[/wiki/Italian_general_election,_1948][1948 general
+election]] and the 1951 regional election. Even though it has never been
+formally disbanded, today the movement is no longer part of the
+[[/wiki/Politics_of_Sicily][politics of Sicily]]. After
+[[/wiki/World_War_II][World War II]] Sicily became a stronghold of the
+[[/wiki/Christian_Democracy_(Italy)][Christian Democracy]], in
+opposition to the [[/wiki/Italian_Communist_Party][Italian Communist
+Party]]. The [[/wiki/Italian_Communist_Party][Communists]] and their
+successors (the [[/wiki/Democratic_Party_of_the_Left][Democratic Party
+of the Left]], the [[/wiki/Democrats_of_the_Left][Democrats of the
+Left]] and the present-day [[/wiki/Democratic_Party_(Italy)][Democratic
+Party]]) had never won in the region until
+[[/wiki/Sicilian_regional_election,_2012][2012]]. Sicily is now governed
+by a center-right coalition. [[/wiki/Nello_Musumeci][Nello Musumeci]] is
+the current President since 2017.
+
+*** Administrative
+divisions[[[/w/index.php?title=Sicily&action=edit&section=22][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: administrative-divisionsedit
+    :END:
+
+[[/wiki/File:Provinces_of_Sicily_map.png][[[//upload.wikimedia.org/wikipedia/commons/thumb/a/a6/Provinces_of_Sicily_map.png/300px-Provinces_of_Sicily_map.png]]]]
+
+[[/wiki/File:Provinces_of_Sicily_map.png][]]
+
+Provinces of Sicily
+
+Administratively, Sicily is divided into nine provinces, each with a
+capital city of the same name as the province. Small surrounding islands
+are also part of various Sicilian provinces: the
+[[/wiki/Aeolian_Islands][Aeolian Islands]] (Messina), isle of
+[[/wiki/Ustica][Ustica]] (Palermo), [[/wiki/Aegadian_Islands][Aegadian
+Islands]] (Trapani), isle of [[/wiki/Pantelleria][Pantelleria]]
+(Trapani) and [[/wiki/Pelagian_Islands][Pelagian Islands]] (Agrigento).
+
+| Province                                           | Area\\   | Population^{[[#cite_note-103][[103]]]} | Density\\         | Number of communes |
+|                                                    | (km^{2}) |                                        | (Pop. per km^{2}) |                    |
+| [[/wiki/Province_of_Agrigento][Agrigento]]         | 3,042    | 453,594                                | 149.1             | 43                 |
+| [[/wiki/Province_of_Caltanissetta][Caltanissetta]] | 2,128    | 271,168                                | 127.4             | 22                 |
+| [[/wiki/Province_of_Catania][Catania]]             | 3,552    | 1,090,620                              | 307.0             | 58                 |
+| [[/wiki/Province_of_Enna][Enna]]                   | 2,562    | 172,159                                | 67.2              | 20                 |
+| [[/wiki/Province_of_Messina][Messina]]             | 3,247    | 652,742                                | 201.0             | 108                |
+| [[/wiki/Province_of_Palermo][Palermo]]             | 4,992    | 1,249,744                              | 250.3             | 82                 |
+| [[/wiki/Province_of_Ragusa][Ragusa]]               | 1,614    | 318,980                                | 197.6             | 12                 |
+| [[/wiki/Province_of_Siracusa][Siracusa]]           | 2,109    | 403,559                                | 191.3             | 21                 |
+| [[/wiki/Province_of_Trapani][Trapani]]             | 2,460    | 436,240                                | 177.3             | 24                 |
+
+** Economy[[[/w/index.php?title=Sicily&action=edit&section=23][edit]]]
+   :PROPERTIES:
+   :CUSTOM_ID: economyedit
+   :END:
+
+See also: [[/wiki/Economy_of_Italy][Economy of Italy]]
+
+[[/wiki/File:Olives_(9520845387).jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/b/bb/Olives_%289520845387%29.jpg/220px-Olives_%289520845387%29.jpg]]]]
+
+[[/wiki/File:Olives_(9520845387).jpg][]]
+
+Olive groves
+
+Thanks to the regular growth of the last years, Sicily is the eighth
+largest regional economy of Italy in terms of total GDP (see
+[[/wiki/List_of_Italian_regions_by_GDP_(PPP)][List of Italian regions by
+GDP]]). A series of reforms and investments on agriculture such as the
+introduction of modern irrigation systems have made this important
+industry competitive.^{[[#cite_note-104][[104]]]} In the 1970s there was
+a growth of the [[/wiki/Industrial_sector][industrial sector]] through
+the creation of some factories.^{[[#cite_note-105][[105]]]} In recent
+years the importance of the [[/wiki/Service_industry][service industry]]
+has grown for the opening of several shopping malls and for modest
+growth of financial and telecommunication
+activities.^{[[#cite_note-106][[106]]]} Tourism is an important source
+of wealth for the island thanks to its natural and historical heritage.
+Today Sicily is investing a large amount of money on structures of the
+[[/wiki/Hospitality_industry][hospitality industry]], in order to make
+tourism more competitive.^{[[#cite_note-107][[107]]]} However, Sicily
+continues to have a GDP per capita below the Italian average and higher
+unemployment than the rest of Italy.^{[[#cite_note-108][[108]]]} This
+difference is mostly caused by the negative influence of
+[[/wiki/The_Mafia][the Mafia]] that is still active in some areas
+although it is much weaker than in the past.^{[[#cite_note-109][[109]]]}
+
+*** Agriculture[[[/w/index.php?title=Sicily&action=edit&section=24][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: agricultureedit
+    :END:
+
+[[/wiki/File:Buffa_Vergine_Marsala_Wine.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/7/70/Buffa_Vergine_Marsala_Wine.jpg/170px-Buffa_Vergine_Marsala_Wine.jpg]]]]
+
+[[/wiki/File:Buffa_Vergine_Marsala_Wine.jpg][]]
+
+A sample of [[/wiki/Marsala_wine][Marsala]], a
+[[/wiki/Denominazione_di_origine_controllata][DOC]] wine produced in the
+city of [[/wiki/Marsala][Marsala]]
+
+Sicily has long been noted for its fertile soil due to volcanic
+eruptions. The local agriculture is also helped by the pleasant climate
+of the island. The main agricultural products are wheat,
+[[/wiki/Diamante_citron][citrons]], oranges
+/([[/wiki/Blood_orange][Arancia Rossa di Sicilia IGP]])/, lemons,
+tomatoes /([[/wiki/Pomodoro_di_Pachino][Pomodoro di Pachino IGP]])/,
+[[/wiki/Olive][olives]], [[/wiki/Olive_oil][olive oil]],
+[[/wiki/Artichoke][artichokes]], [[/wiki/Opuntia_ficus-indica][prickly
+pear]] /(Fico d'India dell'[[/wiki/Mount_Etna][Etna]] DOP)/,
+[[/wiki/Almond][almonds]], [[/wiki/Grape][grapes]],
+[[/wiki/Pistachio][pistachios]] /(Pistacchio di
+[[/wiki/Bronte,_Sicily][Bronte]] DOP)/ and wine. Cattle and sheep are
+raised. The cheese productions are particularly important thanks to the
+[[/wiki/Ragusano_cheese][Ragusano DOP]] and the
+[[/wiki/Pecorino_Siciliano][Pecorino Siciliano DOP]].
+[[/wiki/Ragusa,_Italy][Ragusa]] is noted for its [[/wiki/Honey][honey]]
+(/Miele Ibleo/) and chocolate (/[[/wiki/Cioccolato_di_Modica][Cioccolato
+di Modica]] IGP/)
+productions.^{[[#cite_note-110][[110]]][[#cite_note-111][[111]]][[#cite_note-112][[112]]][[#cite_note-insicilia-113][[113]]][[#cite_note-114][[114]]]}
+
+Sicily is the third largest wine producer in Italy (the world's largest
+wine producer) after [[/wiki/Veneto][Veneto]] and
+[[/wiki/Emilia_Romagna][Emilia Romagna]].^{[[#cite_note-115][[115]]]}
+The region is known mainly for fortified [[/wiki/Marsala_wine][Marsala
+wines]]. In recent decades the wine industry has improved, new
+winemakers are experimenting with less-known native varieties, and
+Sicilian wines have become better
+known.^{[[#cite_note-Bottlenotes-116][[116]]]} The best known local
+variety is [[/wiki/Nero_d%27Avola][Nero d'Avola]], named for a small
+town not far from [[/wiki/Syracuse,_Sicily][Syracuse]]; the best wines
+made with these grapes come from [[/wiki/Noto][Noto]], a famous old city
+close to Avola. Other important native varieties are
+[[/wiki/Nerello][Nerello Mascalese]] used to make the
+[[/wiki/Etna_DOC][Etna Rosso DOC wine]], [[/wiki/Frappato][Frappato]]
+that is a component of the [[/wiki/Frappato][Cerasuolo di Vittoria DOCG
+wine]], [[/wiki/Muscat_of_Alexandria][Moscato di Pantelleria]] (also
+known as /Zibibbo/) used to make different
+[[/wiki/Pantelleria][Pantelleria]] wines,
+[[/wiki/Malvasia#Italian_varieties][Malvasia di Lipari]] used for the
+[[/wiki/Malvasia#Italian_varieties][Malvasia di Lipari DOC wine]] and
+[[/wiki/Catarratto][Catarratto]] mostly used to make the white wine
+[[/wiki/Alcamo_wine][Alcamo DOC]]. Furthermore, in Sicily high quality
+wines are also produced using non-native varieties like
+[[/wiki/Syrah][Syrah]], [[/wiki/Chardonnay][Chardonnay]] and
+[[/wiki/Merlot][Merlot]].^{[[#cite_note-117][[117]]]}
+
+Sicily is also known for its liqueurs, such as the
+[[/wiki/Amaro_Averna][Amaro Averna]] produced in
+[[/wiki/Caltanissetta][Caltanissetta]] and the local
+[[/wiki/Limoncello][limoncello]].
+
+Fishing is another fundamental resource for Sicily. There are important
+[[/wiki/Tuna][tuna]], [[/wiki/Sardine][sardine]],
+[[/wiki/Swordfish][swordfish]] and [[/wiki/European_anchovy][European
+anchovy]] fisheries. [[/wiki/Mazara_del_Vallo][Mazara del Vallo]] is the
+largest fishing centre in Sicily and one of the most important in
+Italy.^{[[#cite_note-esploriamo.com-118][[118]]]}
+
+*** Industry and
+manufacturing[[[/w/index.php?title=Sicily&action=edit&section=25][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: industry-and-manufacturingedit
+    :END:
+
+[[/wiki/File:Palermo-Harbour-bjs-3.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/2/20/Palermo-Harbour-bjs-3.jpg/220px-Palermo-Harbour-bjs-3.jpg]]]]
+
+[[/wiki/File:Palermo-Harbour-bjs-3.jpg][]]
+
+[[/wiki/Palermo][Palermo]] shipyards
+
+[[/wiki/File:TrivelleRagusaS1.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/a/a8/TrivelleRagusaS1.jpg/220px-TrivelleRagusaS1.jpg]]]]
+
+[[/wiki/File:TrivelleRagusaS1.jpg][]]
+
+Oilfields near [[/wiki/Ragusa,_Italy][Ragusa]]
+
+Improvements in Sicily's road system have helped to promote industrial
+development. The region has three important
+[[/wiki/Industrial_district][industrial districts]]:
+
+- /[[/wiki/Catania][Catania]] Industrial District/, where there are
+  several [[/wiki/Food_industries][food industries]] and one of the best
+  European [[/wiki/Electronics_industry][electronics industry]] centres
+  called /Etna Valley/ (in honour of the best known
+  [[/wiki/Silicon_Valley][Silicon Valley]]) which contains offices and
+  factories of international companies such as
+  [[/wiki/STMicroelectronics][STMicroelectronics]] and
+  [[/wiki/Numonyx][Numonyx]];^{[[#cite_note-esploriamo.com-118][[118]]][[#cite_note-119][[119]]]}
+- /[[/wiki/Syracuse,_Sicily][Syracuse]] Petrochemical District/ with
+  [[/wiki/Chemical_industry][chemical industries]],
+  [[/wiki/Oil_refineries][oil refineries]] and important
+  [[/wiki/Power_stations][power stations]] (as the innovative
+  [[/wiki/Archimede_combined_cycle_power_plant][Archimede combined cycle
+  power plant]]);^{[[#cite_note-120][[120]]]}
+- the latest /[[/wiki/Enna][Enna]] Industrial District/ in which there
+  are [[/wiki/Food_industries][food
+  industries]].^{[[#cite_note-121][[121]]]}
+
+In [[/wiki/Palermo][Palermo]] there are important
+[[/wiki/Shipyards][shipyards]] (such as
+[[/wiki/Fincantieri][Fincantieri]]),
+[[/wiki/Mechanical_engineering][mechanical]] factories of famous Italian
+companies as [[/wiki/Ansaldo_Breda][Ansaldo Breda]], publishing and
+textile industries. [[/wiki/Chemical_industry][Chemical industries]] are
+also in the [[/wiki/Province_of_Messina][Province of Messina]]
+([[/wiki/Milazzo][Milazzo]]) and in the
+[[/wiki/Province_of_Caltanissetta][Province of Caltanissetta]]
+([[/wiki/Gela][Gela]]).^{[[#cite_note-insicilia-113][[113]]]} There are
+petroleum, natural gas and [[/wiki/Asphalt][asphalt]] fields in the
+Southeast (mostly near [[/wiki/Ragusa,_Italy][Ragusa]]) and massive
+deposits of [[/wiki/Halite][halite]] in Central
+Sicily.^{[[#cite_note-122][[122]]]} The
+[[/wiki/Province_of_Trapani][Province of Trapani]] is one of the largest
+[[/wiki/Sea_salt][sea salt]] producers in
+Italy.^{[[#cite_note-123][[123]]]}
+
+*** Statistics[[[/w/index.php?title=Sicily&action=edit&section=26][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: statisticsedit
+    :END:
+**** GDP
+growth[[[/w/index.php?title=Sicily&action=edit&section=27][edit]]]
+     :PROPERTIES:
+     :CUSTOM_ID: gdp-growthedit
+     :END:
+A table showing Sicily's different GDP (nominal and per capita) growth
+between 2000 and
+2008:^{[[#cite_note-Dati_Istat_-_Tavole_regionali-124][[124]]][[#cite_note-125][[125]]]}
+
+|                            | 2000   | 2001   | 2002   | 2003   | 2004   | 2005   | 2006   | 2008   |
+| *Gross Domestic Product*\\ | 67,204 | 70,530 | 72,855 | 75,085 | 77,327 | 80,358 | 82,938 | 88,328 |
+| (Millions of Euros)        |        |        |        |        |        |        |        |        |
+| *GDP (PPP) per capita*\\   | 13,479 | 14,185 | 14,662 | 15,053 | 15,440 | 16,023 | 16,531 | 17,533 |
+| (Euro)                     |        |        |        |        |        |        |        |        |
+
+**** Economic
+sectors[[[/w/index.php?title=Sicily&action=edit&section=28][edit]]]
+     :PROPERTIES:
+     :CUSTOM_ID: economic-sectorsedit
+     :END:
+After the table which shows Sicily's GDP
+growth,^{[[#cite_note-Dati_Istat_-_Tavole_regionali-124][[124]]]} this
+table shows the sectors of the Sicilian economy in 2006:
+
+| Economic activity                                                              | GDP\\      | % sector\\ | % sector\\ |
+|                                                                                | € millions | (Sicily)   | (Italy)    |
+| Agriculture, farming, fishing                                                  | 2,923.3    | 3.52%      | 1.84%      |
+| Industry                                                                       | 7,712.9    | 9.30%      | 18.30%     |
+| Constructions                                                                  | 4,582.1    | 5.52%      | 5.41%      |
+| Commerce, hotels and restaurants, transport, services and (tele)communications | 15,159.7   | 18.28%     | 20.54%     |
+| Financial activity and real estate                                             | 17,656.1   | 21.29%     | 24.17%     |
+| *Other economic activities*                                                    | 24,011.5   | 28.95%     | 18.97%     |
+| VAT and other forms of taxes                                                   | 10,893.1   | 13.13%     | 10.76%     |
+| *GDP of Sicily*                                                                | *82,938.6* |            |            |
+
+**** Unemployment
+rate[[[/w/index.php?title=Sicily&action=edit&section=29][edit]]]
+     :PROPERTIES:
+     :CUSTOM_ID: unemployment-rateedit
+     :END:
+The unemployment rate stood at 21.5% in 2018 and was one of the highest
+in Italy and
+Europe.^{[[#cite_note-126][[126]]][[#cite_note-127][[127]]]}
+
+| Year              | 2006  | 2007  | 2008  | 2009  | 2010  | 2011  | 2012  | 2013  | 2014  | 2015  | 2016  | 2017  | 2018  |
+| Unemployment rate | 13.4% | 12.9% | 13.7% | 13.8% | 14.6% | 14.3% | 18.4% | 21.0% | 22.2% | 21.4% | 22.1% | 21.5% | 21.5% |
+
+** Transport[[[/w/index.php?title=Sicily&action=edit&section=30][edit]]]
+   :PROPERTIES:
+   :CUSTOM_ID: transportedit
+   :END:
+*** Roads[[[/w/index.php?title=Sicily&action=edit&section=31][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: roadsedit
+    :END:
+
+[[/wiki/File:Autostrada_A20_Torregrotta.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/c/cb/Autostrada_A20_Torregrotta.jpg/220px-Autostrada_A20_Torregrotta.jpg]]]]
+
+[[/wiki/File:Autostrada_A20_Torregrotta.jpg][]]
+
+The [[/wiki/Autostrada_A20_(Italy)][A20 Messina-Palermo motorway]] near
+[[/wiki/Torregrotta][Torregrotta]]
+
+[[/wiki/File:Alstom_Cityway_Tram_Messina_06T.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/d/dc/Alstom_Cityway_Tram_Messina_06T.jpg/220px-Alstom_Cityway_Tram_Messina_06T.jpg]]]]
+
+[[/wiki/File:Alstom_Cityway_Tram_Messina_06T.jpg][]]
+
+[[/wiki/Trams_in_Messina][Messina tramway system]]
+
+Highways have been built and expanded in the last four decades. The most
+prominent Sicilian roads are the motorways (known as /autostrade/) in
+the north of the island. Much of the motorway network is elevated on
+pillars due to the island's mountainous
+terrain.^{[[#cite_note-128][[128]]][[#cite_note-129][[129]]][[#cite_note-130][[130]]][[#cite_note-131][[131]]]}
+Other main roads in Sicily are the /Strade Statali/, such as the SS.113
+that connects [[/wiki/Trapani][Trapani]] to Messina (via Palermo), the
+SS.114 Messina-[[/wiki/Syracuse,_Sicily][Syracuse]] (via Catania) and
+the SS.115 Syracuse-Trapani (via [[/wiki/Ragusa,_Italy][Ragusa]],
+[[/wiki/Gela][Gela]] and [[/wiki/Agrigento][Agrigento]]).
+
+| Sign                                                                                                                                                                                                                                            | Motorway                                                                                        | Length              | Toll                                                                                                                                                                                                | Services                                                                                                                                                                                                                                                                                                                                         |
+| [[/wiki/File:Autostrada_A18_Italia.svg][[[//upload.wikimedia.org/wikipedia/commons/thumb/c/ce/Autostrada_A18_Italia.svg/25px-Autostrada_A18_Italia.svg.png]]]]                                                                                  | [[/wiki/Autostrada_A18_(Italy)][A18 Messina-Catania]]                                           | 76 km (47 mi)       | [[/wiki/File:Italian_traffic_signs_-_stazione.svg][[[//upload.wikimedia.org/wikipedia/commons/thumb/1/10/Italian_traffic_signs_-_stazione.svg/20px-Italian_traffic_signs_-_stazione.svg.png]]]] Yes | [[/wiki/File:Zeichen_361-51_-_Tankstelle_auch_mit_bleifreiem_Benzin_(600x600),_StVO_1992.svg][[[//upload.wikimedia.org/wikipedia/commons/thumb/4/49/Zeichen_361-51_-_Tankstelle_auch_mit_bleifreiem_Benzin_%28600x600%29%2C_StVO_1992.svg/20px-Zeichen_361-51_-_Tankstelle_auch_mit_bleifreiem_Benzin_%28600x600%29%2C_StVO_1992.svg.png]]]] Yes |
+| [[/wiki/File:Italian_traffic_signs_-_raccordo_autostradale_15.svg][[[//upload.wikimedia.org/wikipedia/commons/thumb/a/a7/Italian_traffic_signs_-_raccordo_autostradale_15.svg/40px-Italian_traffic_signs_-_raccordo_autostradale_15.svg.png]]]] | [[/wiki/Autostrada_RA15_(Italy)][RA15 Catania's Bypass (West)]]                                 | 24 km (15 mi)       | Free                                                                                                                                                                                                | [[/wiki/File:Zeichen_361-51_-_Tankstelle_auch_mit_bleifreiem_Benzin_(600x600),_StVO_1992.svg][[[//upload.wikimedia.org/wikipedia/commons/thumb/4/49/Zeichen_361-51_-_Tankstelle_auch_mit_bleifreiem_Benzin_%28600x600%29%2C_StVO_1992.svg/20px-Zeichen_361-51_-_Tankstelle_auch_mit_bleifreiem_Benzin_%28600x600%29%2C_StVO_1992.svg.png]]]] Yes |
+| [[/wiki/File:Italian_traffic_signs_-_Autostrada_CT-SR.svg][[[//upload.wikimedia.org/wikipedia/commons/thumb/3/34/Italian_traffic_signs_-_Autostrada_CT-SR.svg/40px-Italian_traffic_signs_-_Autostrada_CT-SR.svg.png]]]]                         | [[/wiki/Autostrada_Catania-Siracusa][Motorway Catania-Siracusa]]                                | 25 km (16 mi)       | Free                                                                                                                                                                                                | No                                                                                                                                                                                                                                                                                                                                               |
+| [[/wiki/File:Autostrada_A18_Italia.svg][[[//upload.wikimedia.org/wikipedia/commons/thumb/c/ce/Autostrada_A18_Italia.svg/25px-Autostrada_A18_Italia.svg.png]]]]                                                                                  | [[/wiki/Autostrada_A18_(Italy)][A18 Siracusa-Rosolini]]                                         | 40 km (25 mi)       | Free                                                                                                                                                                                                | No                                                                                                                                                                                                                                                                                                                                               |
+| [[/wiki/File:Autostrada_A19_Italia.svg][[[//upload.wikimedia.org/wikipedia/commons/thumb/0/00/Autostrada_A19_Italia.svg/25px-Autostrada_A19_Italia.svg.png]]]]                                                                                  | [[/wiki/Autostrada_A19_(Italy)][A19 Palermo-Catania]]                                           | 199 km (124 mi)     | Free                                                                                                                                                                                                | [[/wiki/File:Zeichen_361-51_-_Tankstelle_auch_mit_bleifreiem_Benzin_(600x600),_StVO_1992.svg][[[//upload.wikimedia.org/wikipedia/commons/thumb/4/49/Zeichen_361-51_-_Tankstelle_auch_mit_bleifreiem_Benzin_%28600x600%29%2C_StVO_1992.svg/20px-Zeichen_361-51_-_Tankstelle_auch_mit_bleifreiem_Benzin_%28600x600%29%2C_StVO_1992.svg.png]]]] Yes |
+| [[/wiki/File:Autostrada_A20_Italia.svg][[[//upload.wikimedia.org/wikipedia/commons/thumb/a/a6/Autostrada_A20_Italia.svg/25px-Autostrada_A20_Italia.svg.png]]]]                                                                                  | [[/wiki/Autostrada_A20_(Italy)][A20 Palermo-Messina]]                                           | 181 km (112 mi)     | [[/wiki/File:Italian_traffic_signs_-_stazione.svg][[[//upload.wikimedia.org/wikipedia/commons/thumb/1/10/Italian_traffic_signs_-_stazione.svg/20px-Italian_traffic_signs_-_stazione.svg.png]]]] Yes | [[/wiki/File:Zeichen_361-51_-_Tankstelle_auch_mit_bleifreiem_Benzin_(600x600),_StVO_1992.svg][[[//upload.wikimedia.org/wikipedia/commons/thumb/4/49/Zeichen_361-51_-_Tankstelle_auch_mit_bleifreiem_Benzin_%28600x600%29%2C_StVO_1992.svg/20px-Zeichen_361-51_-_Tankstelle_auch_mit_bleifreiem_Benzin_%28600x600%29%2C_StVO_1992.svg.png]]]] Yes |
+| [[/wiki/File:Autostrada_A29_Italia.svg][[[//upload.wikimedia.org/wikipedia/commons/thumb/5/5b/Autostrada_A29_Italia.svg/25px-Autostrada_A29_Italia.svg.png]]]]                                                                                  | [[/wiki/Autostrada_A29_(Italy)][A29 Palermo-Mazara del Vallo]]                                  | 119 km (74 mi)      | Free                                                                                                                                                                                                | No                                                                                                                                                                                                                                                                                                                                               |
+| [[/wiki/File:Autostrada_A29dir_Italia.svg][[[//upload.wikimedia.org/wikipedia/commons/thumb/2/29/Autostrada_A29dir_Italia.svg/25px-Autostrada_A29dir_Italia.svg.png]]]]                                                                         | [[/wiki/Autostrada_A29_(Italy)#A29dir_Diramazione_Alcamo-Birgi][A29dir Alcamo-Trapani/Marsala]] | 38 km (24 mi) and\\ | Free                                                                                                                                                                                                | No                                                                                                                                                                                                                                                                                                                                               |
+|                                                                                                                                                                                                                                                 |                                                                                                 | 44 km (27 mi)       |                                                                                                                                                                                                     |                                                                                                                                                                                                                                                                                                                                                  |
+
+*** Railways[[[/w/index.php?title=Sicily&action=edit&section=32][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: railwaysedit
+    :END:
+
+[[/wiki/File:Punta_Raisi_staz_ferr_treni.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/e/e5/Punta_Raisi_staz_ferr_treni.jpg/220px-Punta_Raisi_staz_ferr_treni.jpg]]]]
+
+[[/wiki/File:Punta_Raisi_staz_ferr_treni.jpg][]]
+
+Two trains inside [[/wiki/Punta_Raisi_railway_station][Punta Raisi
+railway station]] within [[/wiki/Palermo_International_Airport][Palermo
+International Airport]]
+
+[[/wiki/File:Palermo_Tramway_System_Map.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/8/89/Palermo_Tramway_System_Map.jpg/220px-Palermo_Tramway_System_Map.jpg]]]]
+
+[[/wiki/File:Palermo_Tramway_System_Map.jpg][]]
+
+[[/wiki/Palermo][Palermo]], AMAT tramway system map
+
+[[/wiki/File:L%27elettrotreno_M.88-08_alla_stazione_di_Giovanni_XXIII.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/c/cf/L%27elettrotreno_M.88-08_alla_stazione_di_Giovanni_XXIII.jpg/220px-L%27elettrotreno_M.88-08_alla_stazione_di_Giovanni_XXIII.jpg]]]]
+
+[[/wiki/File:GiovanniXXIII-metro.jpg][]]
+
+[[/wiki/Catania_Metro][Catania Metro]]
+
+The first railway in Sicily was opened in 1863 (Palermo-Bagheria) and
+today all of the Sicilian provinces are served by a network of railway
+services, linking to most major cities and towns; this service is
+operated by [[/wiki/Trenitalia][Trenitalia]]. Of the 1,378 km (856 mi)
+of railway tracks in use, over 60% has been
+[[/wiki/Railway_electrification_system][electrified]] whilst the
+remaining 583 km (362 mi) are serviced by
+[[/wiki/Dieselisation][diesel]] engines. 88% of the lines (1.209 km) are
+single-track and only 169 km (105 mi) are double-track serving the two
+main routes, Messina-Palermo ([[/wiki/Tyrrhenian_Sea][Tyrrhenian]]) and
+Messina-Catania-Syracuse ([[/wiki/Ionian_Sea][Ionian]]), which are the
+main lines of this region. Of the
+[[/wiki/Narrow-gauge_railway][narrow-gauge railways]] the
+[[/wiki/Ferrovia_Circumetnea][Ferrovia Circumetnea]] is the only one
+that still operates, going round [[/wiki/Mount_Etna][Mount Etna]]. From
+the major cities of Sicily, there are services to
+[[/wiki/Naples][Naples]], [[/wiki/Rome][Rome]] and
+[[/wiki/Milan][Milan]]; this is achieved by the trains being loaded onto
+[[/wiki/Ferries][ferries]] which cross the
+Strait.^{[[#cite_note-132][[132]]]}
+
+In [[/wiki/Catania][Catania]] there is an
+[[/wiki/Rapid_transit][underground railway]] service
+([[/wiki/Metropolitana_di_Catania][metropolitana di Catania]]); in
+[[/wiki/Palermo][Palermo]] the national railway operator
+[[/wiki/Trenitalia][Trenitalia]] operates a
+[[/wiki/Commuter_rail][commuter rail]]
+([[/wiki/Palermo_metropolitan_railway_service][Palermo metropolitan
+railway service]]), the Sicilian Capital is also served by 4 AMAT
+(Comunal Public Transport Operator) tramlines;
+[[/wiki/Messina][Messina]] is served by a
+[[/wiki/Trams_in_Messina][tramline]].
+
+*** Airports[[[/w/index.php?title=Sicily&action=edit&section=33][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: airportsedit
+    :END:
+
+Main article: [[/wiki/List_of_airports_in_Sicily][List of airports in
+Sicily]]
+
+[[/wiki/File:Aeroporto_di_Catania_-_Catania_Airport.JPG][[[//upload.wikimedia.org/wikipedia/en/thumb/5/50/Aeroporto_di_Catania_-_Catania_Airport.JPG/220px-Aeroporto_di_Catania_-_Catania_Airport.JPG]]]]
+
+[[/wiki/File:Aeroporto_di_Catania_-_Catania_Airport.JPG][]]
+
+[[/wiki/Catania%E2%80%93Fontanarossa_Airport][Catania International
+Airport]]
+
+Mainland Sicily has several airports that serve numerous Italian and
+European destinations and some extra-European.
+
+- [[/wiki/Catania-Fontanarossa_Airport][Catania-Fontanarossa Airport]],
+  located on the east coast, is the busiest on the island (and one of
+  the busiest in all of Italy).
+- [[/wiki/Palermo_International_Airport][Palermo International
+  Airport]], which is also a substantially large airport with many
+  national and international flights.
+- [[/wiki/Trapani-Birgi_Airport][Trapani-Birgi Airport]], a
+  military-civil joint-use airport (third for traffic on the island).
+  Recently the airport has seen an increase in traffic thanks to a
+  [[/wiki/Low-cost_carrier][low-cost carrier]].
+- [[/wiki/Comiso_Airport][Comiso-Ragusa Airport]], has recently been
+  refurbished and re-converted from military use to a civil airport. It
+  was opened to commercial traffic and general aviation on 30 May 2013.
+- [[/wiki/Palermo-Boccadifalco_Airport][Palermo-Boccadifalco Airport]]
+  is the old airport of Palermo and is currently used for
+  [[/wiki/General_aviation][general aviation]] and as a base for the
+  [[/wiki/Guardia_di_Finanza][Guardia di Finanza]] and
+  [[/wiki/Police_helicopter][police helicopters]].
+- [[/wiki/Naval_Air_Station_Sigonella][NAS Sigonella Airport]], it is an
+  Italian Air Force and US Navy installation.
+- [[/wiki/Lampedusa_Airport][Lampedusa Airport]].
+- [[/wiki/Pantelleria_Airport][Pantelleria Airport]].
+
+*** Ports[[[/w/index.php?title=Sicily&action=edit&section=34][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: portsedit
+    :END:
+
+[[/wiki/File:Archimarina.JPG][[[//upload.wikimedia.org/wikipedia/commons/thumb/1/15/Archimarina.JPG/220px-Archimarina.JPG]]]]
+
+[[/wiki/File:Archimarina.JPG][]]
+
+The port of [[/wiki/Catania][Catania]]
+
+By sea, Sicily is served by several ferry routes and cargo ports, and in
+all major cities, cruise ships dock on a regular basis.
+
+- Mainland Italy: Ports connecting to the mainland are
+  [[/wiki/Messina][Messina]] (route to [[/wiki/Villa_San_Giovanni][Villa
+  San Giovanni]] and [[/wiki/Salerno][Salerno]]), the busiest passenger
+  port in Italy, [[/wiki/Palermo][Palermo]] (routes to
+  [[/wiki/Genoa][Genoa]], [[/wiki/Civitavecchia][Civitavecchia]] and
+  [[/wiki/Naples][Naples]]) and [[/wiki/Catania][Catania]] (route to
+  [[/wiki/Naples][Naples]]).
+- Sicily's small surrounding islands: The port of
+  [[/wiki/Milazzo][Milazzo]] serves the [[/wiki/Aeolian_Islands][Aeolian
+  Islands]], the ports of [[/wiki/Trapani][Trapani]] and
+  [[/wiki/Marsala][Marsala]] the [[/wiki/Aegadian_Islands][Aegadian
+  Islands]] and the port of [[/wiki/Porto_Empedocle][Porto Empedocle]]
+  the [[/wiki/Pelagie_Islands][Pelagie Islands]]. From Palermo there is
+  a service to the island of [[/wiki/Ustica][Ustica]] and to
+  [[/wiki/Sardinia][Sardinia]].
+- International connections: From Palermo and Trapani there are weekly
+  services to [[/wiki/Tunisia][Tunisia]] and there is also a daily
+  service between [[/wiki/Malta][Malta]] and
+  [[/wiki/Port_of_Pozzallo][Pozzallo]].^{[[#cite_note-133][[133]]][[#cite_note-134][[134]]]}
+- Commercial and cargo ports: The port of
+  [[/wiki/Augusta,_Sicily][Augusta]] is the fifth-largest cargo port in
+  Italy and handles tonnes of goods. Other major cargo ports are
+  Palermo, Catania, Trapani, [[/wiki/Port_of_Pozzallo][Pozzallo]] and
+  [[/wiki/Termini_Imerese][Termini Imerese]].
+- Touristic ports: Several ports along the Sicilian coast are in the
+  service of private boats that need to moor on the island. The main
+  ports for this traffic are in [[/wiki/Marina_di_Ragusa][Marina di
+  Ragusa]], [[/wiki/Riposto][Riposto]],
+  [[/w/index.php?title=Portorosa&action=edit&redlink=1][Portorosa]],
+  [[/wiki/Syracuse,_Sicily][Syracuse]], [[/wiki/Cefal%C3%B9][Cefalù]]
+  and [[/wiki/Sciacca][Sciacca]]. In Sicily, Palermo is also a major
+  centre for boat rental, with or without crew, in the Mediterranean.
+- Fishing ports: Like all islands, Sicily also has many fishing ports.
+  The most important is in [[/wiki/Mazara_del_Vallo][Mazara del Vallo]]
+  followed by [[/wiki/Castellamare_del_Golfo][Castellamare del Golfo]],
+  [[/wiki/Licata][Licata]], [[/wiki/Scoglitti][Scoglitti]] and
+  [[/wiki/Portopalo_di_Capo_Passero][Portopalo di Capo Passero]].
+
+*** Planned
+bridge[[[/w/index.php?title=Sicily&action=edit&section=35][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: planned-bridgeedit
+    :END:
+
+Main article: [[/wiki/Strait_of_Messina_Bridge][Strait of Messina
+Bridge]]
+
+Plans for a bridge linking Sicily to the mainland have been discussed
+since 1865. Throughout the last decade, plans were developed for a road
+and rail link to the mainland via what would be the world's longest
+[[/wiki/Suspension_bridge][suspension bridge]], the
+[[/wiki/Strait_of_Messina_Bridge][Strait of Messina Bridge]]. Planning
+for the project has experienced several false starts over the past few
+years. On 6 March 2009, [[/wiki/Silvio_Berlusconi][Silvio Berlusconi]]'s
+government declared that the construction works for the Messina Bridge
+will begin on 23 December 2009, and announced a pledge of €1.3 billion
+as a contribution to the bridge's total cost, estimated at
+€6.1 billion.^{[[#cite_note-135][[135]]]} The plan has been criticized
+by environmental associations and some local Sicilians and Calabrians,
+concerned with its environmental impact, economical sustainability and
+even possible infiltrations by organized
+crime.^{[[#cite_note-136][[136]]][[#cite_note-137][[137]]]}
+
+** Tourism[[[/w/index.php?title=Sicily&action=edit&section=36][edit]]]
+   :PROPERTIES:
+   :CUSTOM_ID: tourismedit
+   :END:
+
+[[/wiki/File:Spiaggia_Isola_dei_Coniglio_Lampedusa.JPG][[[//upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Spiaggia_Isola_dei_Coniglio_Lampedusa.JPG/220px-Spiaggia_Isola_dei_Coniglio_Lampedusa.JPG]]]]
+
+[[/wiki/File:Spiaggia_Isola_dei_Coniglio_Lampedusa.JPG][]]
+
+[[/wiki/Lampedusa][Lampedusa]], [[/wiki/Pelagie_Islands][Pelagie
+Islands]]
+
+Sicily's sunny, dry climate, scenery, cuisine, history, and architecture
+attract many tourists from mainland Italy and abroad. The tourist season
+peaks in the summer months, although people visit the island all year
+round. [[/wiki/Mount_Etna][Mount Etna]], the beaches, the archaeological
+sites, and major cities such as [[/wiki/Palermo][Palermo]],
+[[/wiki/Catania][Catania]], [[/wiki/Syracuse,_Sicily][Syracuse]] and
+[[/wiki/Ragusa,_Sicily][Ragusa]] are the favourite tourist destinations,
+but the old town of [[/wiki/Taormina][Taormina]] and the neighbouring
+seaside resort of [[/wiki/Giardini_Naxos][Giardini Naxos]] draw visitors
+from all over the world, as do the [[/wiki/Aeolian_Islands][Aeolian
+Islands]], [[/wiki/Erice][Erice]],
+[[/wiki/Castellammare_del_Golfo][Castellammare del Golfo]],
+[[/wiki/Cefal%C3%B9][Cefalù]], [[/wiki/Agrigento][Agrigento]], the
+[[/wiki/Pelagie_Islands][Pelagie Islands]] and
+[[/wiki/Capo_d%27Orlando][Capo d'Orlando]]. The last features some of
+the best-preserved temples of the ancient Greek period. Many
+Mediterranean cruise ships stop in Sicily, and many wine tourists also
+visit the island.
+
+Some scenes of several Hollywood and [[/wiki/Cinecitt%C3%A0][Cinecittà]]
+films were shot in Sicily. This increased the attraction of Sicily as a
+tourist destination.^{[[#cite_note-138][[138]]]}
+
+*** UNESCO World Heritage
+Sites[[[/w/index.php?title=Sicily&action=edit&section=37][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: unesco-world-heritage-sitesedit
+    :END:
+
+[[/wiki/File:Mosaic_in_Villa_Romana_del_Casale,_by_Jerzy_Strzelecki,_13.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/2/27/Mosaic_in_Villa_Romana_del_Casale%2C_by_Jerzy_Strzelecki%2C_13.jpg/220px-Mosaic_in_Villa_Romana_del_Casale%2C_by_Jerzy_Strzelecki%2C_13.jpg]]]]
+
+[[/wiki/File:Mosaic_in_Villa_Romana_del_Casale,_by_Jerzy_Strzelecki,_13.jpg][]]
+
+One of the mosaics in Villa Romana del Casale
+
+There are seven [[/wiki/UNESCO_World_Heritage_Sites][UNESCO World
+Heritage Sites]] on Sicily. By the order of inscription:
+
+- *[[/wiki/Valle_dei_Templi][Valle dei Templi]]* (1997) is one of the
+  most outstanding examples of [[/wiki/Magna_Graecia][Greater Greece]]
+  art and architecture, and is one of the main attractions of Sicily as
+  well as a national monument of Italy. The site is located in
+  [[/wiki/Agrigento][Agrigento]].^{[[#cite_note-139][[139]]]}
+- *[[/wiki/Villa_Romana_del_Casale][Villa Romana del Casale]]* (1997) is
+  a [[/wiki/Roman_villa][Roman villa]] built in the first quarter of the
+  4th century and located about 3 km (2 mi) outside the town of
+  [[/wiki/Piazza_Armerina][Piazza Armerina]]. It contains the richest,
+  largest and most complex collection of Roman mosaics in the
+  world.^{[[#cite_note-Wilson-140][[140]]]}
+- *[[/wiki/Aeolian_Islands][Aeolian Islands]]* (2000) are a
+  [[/wiki/Volcano][volcanic]] [[/wiki/Archipelago][archipelago]] in the
+  [[/wiki/Tyrrhenian_Sea][Tyrrhenian Sea]], named after the demigod of
+  the winds [[/wiki/Aeolus][Aeolus]]. The Aeolian Islands are a tourist
+  destination in the summer, and attract up to 200,000 visitors
+  annually.^{[[#cite_note-141][[141]]]}
+- *[[/wiki/Val_di_Noto][Late Baroque Towns of the Val di Noto]]* (2002)
+  "represent the culmination and final flowering of
+  [[/wiki/Baroque][Baroque]] art in Europe".^{[[#cite_note-142][[142]]]}
+  It includes several towns: [[/wiki/Caltagirone][Caltagirone]],
+  [[/wiki/Militello_in_Val_di_Catania][Militello in Val di Catania]],
+  [[/wiki/Catania][Catania]], [[/wiki/Modica][Modica]],
+  [[/wiki/Noto][Noto]], [[/wiki/Palazzolo_Acreide][Palazzolo Acreide]],
+  [[/wiki/Ragusa,_Italy][Ragusa]] and [[/wiki/Scicli][Scicli]].
+- *[[/wiki/Necropolis_of_Pantalica][Necropolis of Pantalica]]* (2005) is
+  a large [[/wiki/Necropolis][necropolis]] in Sicily with over 5,000
+  tombs dating from the 13th to the 7th centuries BC.
+  [[/wiki/Syracuse,_Sicily][Syracuse]] is notable for its rich Greek
+  history, culture, amphitheatres and architecture. They are situated in
+  south-eastern Sicily.
+- *[[/wiki/Mount_Etna][Mount Etna]]* (2013) is one of the most active
+  volcanoes in the world and is in an almost constant state of activity
+  and generated myths, legends and naturalistic observation from Greek,
+  Celts and Roman classic and medieval
+  times.^{[[#cite_note-143][[143]]]}
+- *Arab-Norman [[/wiki/Palermo][Palermo]] and the cathedral churches of
+  [[/wiki/Cefal%C3%B9][Cefalù]] and [[/wiki/Monreale][Monreale]]*;
+  includes a series of nine civil and religious structures dating from
+  the era of the Norman kingdom of Sicily
+  (1130--1194)^{[[#cite_note-144][[144]]]}
+
+[[/wiki/File:Cathedral_of_San_Giorgio_in_Modica.JPG][[[//upload.wikimedia.org/wikipedia/commons/thumb/0/00/Cathedral_of_San_Giorgio_in_Modica.JPG/220px-Cathedral_of_San_Giorgio_in_Modica.JPG]]]]
+
+[[/wiki/File:Cathedral_of_San_Giorgio_in_Modica.JPG][]]
+
+Cathedral of San Giorgio in Modica
+
+**** Tentative
+Sites[[[/w/index.php?title=Sicily&action=edit&section=38][edit]]]
+     :PROPERTIES:
+     :CUSTOM_ID: tentative-sitesedit
+     :END:
+
+[[/wiki/File:Sicilia_Taormina4_tango7174.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/5/51/Sicilia_Taormina4_tango7174.jpg/220px-Sicilia_Taormina4_tango7174.jpg]]]]
+
+[[/wiki/File:Sicilia_Taormina4_tango7174.jpg][]]
+
+[[/wiki/Taormina][Taormina]]'s central square at sunset
+
+- [[/wiki/Taormina][Taormina and Isola
+  Bella]];^{[[#cite_note-145][[145]]]}
+- [[/wiki/Motya][Motya]] and [[/wiki/Marsala][Libeo Island]]: The
+  Phoenician-Punic Civilisation in Italy;^{[[#cite_note-146][[146]]]}
+- [[/wiki/Scala_dei_Turchi][Scala dei
+  Turchi]];^{[[#cite_note-147][[147]]]}
+- [[/wiki/Strait_of_Messina][Strait of
+  Messina]].^{[[#cite_note-148][[148]]]}
+
+*** Archeological
+sites[[[/w/index.php?title=Sicily&action=edit&section=39][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: archeological-sitesedit
+    :END:
+Because many different cultures settled, dominated or invaded the
+island, Sicily has a huge variety of
+[[/wiki/Archaeological_sites][archaeological sites]]. Also, some of the
+most notable and best preserved temples and other structures of the
+Greek world are located in
+Sicily.^{[/[[/wiki/Wikipedia:Citation_needed][citation needed]]/]}. Here
+is a short list of the major archaeological sites:
+
+- Sicels/Sicans/Elymians/Greeks: [[/wiki/Segesta][Segesta]],
+  [[/wiki/Eryx_(Sicily)][Eryx]], [[/wiki/Ispica][Cava Ispica]],
+  [[/wiki/Thapsos][Thapsos]], [[/wiki/Pantalica][Pantalica]];
+- Greeks: [[/wiki/Syracuse,_Sicily][Syracuse]],
+  [[/wiki/Agrigento][Agrigento]], [[/wiki/Segesta][Segesta]],
+  [[/wiki/Selinunte][Selinunte]], [[/wiki/Gela][Gela]],
+  [[/wiki/Kamarina,_Sicily][Kamarina]], [[/wiki/Himera][Himera]],
+  [[/wiki/Megara_Hyblaea][Megara Hyblaea]],
+  [[/wiki/Naxos_(Sicily)][Naxos]], [[/wiki/Heraclea_Minoa][Heraclea
+  Minoa]];
+- Phoenicians: [[/wiki/Motya][Motya]], [[/wiki/Soluntum][Soluntum]],
+  [[/wiki/Marsala][Marsala]], [[/wiki/Palermo][Palermo]];
+- Romans: [[/wiki/Piazza_Armerina][Piazza Armerina]],
+  [[/wiki/Centuripe][Centuripe]], [[/wiki/Taormina][Taormina]],
+  [[/wiki/Palermo][Palermo]];
+- Arabs: [[/wiki/Palermo][Palermo]], [[/wiki/Mazara_del_Vallo][Mazara
+  del Vallo]].
+
+The excavation and restoration of one of Sicily's best known
+archaeological sites, the [[/wiki/Valle_dei_Templi][Valley of the
+Temples]] in Agrigento, was at the direction of the archaeologist
+[[/wiki/Domenico_Lo_Faso_Pietrasanta][Domenico Antonio Lo Faso
+Pietrasanta]], Fifth Duke of [[/wiki/Serradifalco][Serradifalco]], known
+in archaeological circles simply as /"Serradifalco"/. He also oversaw
+the restoration of ancient sites at [[/wiki/Segesta][Segesta]],
+[[/wiki/Selinunte][Selinunte]], [[/wiki/Syracuse,_Sicily][Siracusa]] and
+[[/wiki/Taormina][Taormina]].
+
+*** Castles[[[/w/index.php?title=Sicily&action=edit&section=40][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: castlesedit
+    :END:
+In Sicily there are hundreds of castles, the most relevant are:
+
+[[/wiki/File:CastelloUrsino1CT.JPG][[[//upload.wikimedia.org/wikipedia/commons/thumb/b/ba/CastelloUrsino1CT.JPG/220px-CastelloUrsino1CT.JPG]]]]
+
+[[/wiki/File:CastelloUrsino1CT.JPG][]]
+
+[[/wiki/Castello_Ursino][Castello Ursino]] in [[/wiki/Catania][Catania]]
+
+[[/wiki/File:Palermo-Zisa-bjs2007-01.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/2/2a/Palermo-Zisa-bjs2007-01.jpg/220px-Palermo-Zisa-bjs2007-01.jpg]]]]
+
+[[/wiki/File:Palermo-Zisa-bjs2007-01.jpg][]]
+
+[[/wiki/Zisa,_Palermo][Zisa Castle]] in [[/wiki/Palermo][Palermo]]
+
+[[/wiki/File:Castello_di_Alcamo_0024.JPG][[[//upload.wikimedia.org/wikipedia/commons/thumb/6/6d/Castello_di_Alcamo_0024.JPG/220px-Castello_di_Alcamo_0024.JPG]]]]
+
+[[/wiki/File:Castello_di_Alcamo_0024.JPG][]]
+
+[[/wiki/Castle_of_the_Counts_of_Modica_(Alcamo)][Castle of the Counts of
+Modica (Alcamo)]] in [[/wiki/Alcamo][Alcamo]]
+
+[[/wiki/File:Castello_Donnafugata,_Ragusa.JPG][[[//upload.wikimedia.org/wikipedia/commons/thumb/c/ce/Castello_Donnafugata%2C_Ragusa.JPG/220px-Castello_Donnafugata%2C_Ragusa.JPG]]]]
+
+[[/wiki/File:Castello_Donnafugata,_Ragusa.JPG][]]
+
+Castello di Donnafugata near [[/wiki/Ragusa,_Italy][Ragusa]]
+
+| Province                                          | Castles                                                                           | Commune                                              |
+| [[/wiki/Province_of_Caltanissetta][Caltanisetta]] | Castello Manfredonico                                                             | [[/wiki/Mussomeli][Mussomeli]]                       |
+|                                                   | U Cannuni                                                                         | [[/wiki/Mazzarino,_Sicily][Mazzarino]]               |
+|                                                   | Castelluccio di Gela                                                              | [[/wiki/Gela][Gela]]                                 |
+| [[/wiki/Province_of_Catania][Catania]]            | [[/wiki/Castello_Ursino][Castello Ursino]]                                        | [[/wiki/Catania][Catania]]                           |
+|                                                   | Castello Normanno                                                                 | [[/wiki/Adrano][Adrano]]                             |
+|                                                   | Castello Normanno                                                                 | [[/wiki/Patern%C3%B2][Paternò]]                      |
+|                                                   | Castello di Aci                                                                   | [[/wiki/Aci_Castello][Aci Castello]]                 |
+| [[/wiki/Province_of_Enna][Enna]]                  | [[/wiki/Castello_di_Lombardia][Castello di Lombardia]]                            | [[/wiki/Enna][Enna]]                                 |
+| [[/wiki/Province_of_Messina][Messina]]            | Forte dei Centri                                                                  | [[/wiki/Messina][Messina]]                           |
+|                                                   | Castello di Milazzo                                                               | [[/wiki/Milazzo][Milazzo]]                           |
+|                                                   | Castello di Federico II                                                           | [[/wiki/Montalbano_Elicona][Montalbano Elicona]]     |
+|                                                   | Castello di Sant'Alessio Siculo                                                   | [[/wiki/Sant%27Alessio_Siculo][Sant'Alessio Siculo]] |
+|                                                   | Castello di Pentefur                                                              | [[/wiki/Savoca][Savoca]]                             |
+|                                                   | [[/wiki/Schis%C3%B2_Castle][Castello di Schisò]]                                  | [[/wiki/Giardini_Naxos][Giardini Naxos]]             |
+| [[/wiki/Province_of_Palermo][Palermo]]            | [[/wiki/Zisa,_Palermo][Zisa, Palermo]]                                            | [[/wiki/Palermo][Palermo]]                           |
+|                                                   | [[/wiki/Castello_di_Caccamo][Castello di Caccamo]]                                | [[/wiki/Caccamo][Caccamo]]                           |
+|                                                   | Castello di Carini                                                                | [[/wiki/Carini][Carini]]                             |
+|                                                   | Castello dei Ventimiglia                                                          | [[/wiki/Castelbuono][Castelbuono]]                   |
+| [[/wiki/Province_of_Ragusa][Ragusa]]              | Castello di Donnafugata                                                           | [[/wiki/Ragusa,_Italy][Ragusa]]                      |
+|                                                   | Torre Cabrera                                                                     | [[/wiki/Pozzallo][Pozzallo]]                         |
+|                                                   | Castello Dei Conti                                                                | [[/wiki/Modica][Modica]]                             |
+| [[/wiki/Province_of_Syracuse][Syracuse]]          | [[/wiki/Castello_Maniace][Castello Maniace]]                                      | [[/wiki/Syracuse,_Sicily][Syracuse]]                 |
+| [[/wiki/Province_of_Trapani][Trapani]]            | Castello di Venere                                                                | [[/wiki/Erice][Erice]]                               |
+|                                                   | [[/wiki/Castle_of_the_Counts_of_Modica_(Alcamo)][Castle of the Counts of Modica]] | [[/wiki/Alcamo][Alcamo]]                             |
+|                                                   | [[/wiki/Castle_of_Calatubo][Castle of Calatubo]]                                  | [[/wiki/Alcamo][Alcamo]]                             |
+
+*** Coastal
+towers[[[/w/index.php?title=Sicily&action=edit&section=41][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: coastal-towersedit
+    :END:
+The
+[[/w/index.php?title=Coastal_towers_in_Sicily&action=edit&redlink=1][Coastal
+towers in Sicily]] (/Torri costiere della Sicilia/) are 218 old
+[[/wiki/Watchtowers][watchtowers]] along the coast. In Sicily, the first
+coastal towers date back to 1313 and 1345 of the Aragonese monarchy.
+From 1360 the threat came from the south, from
+[[/wiki/North_Africa][North Africa]] to [[/wiki/Maghreb][Maghreb]],
+mainly to [[/wiki/Barbary_pirates][Barbary pirates]] and corsairs of
+[[/wiki/Barbary_Coast][Barbary Coast]]. In 1516, the Turks settled in
+[[/wiki/Algiers][Algiers]], and from 1520, the corsair
+[[/wiki/Hayreddin_Barbarossa][Hayreddin Barbarossa]] under the command
+of [[/wiki/Ottoman_Empire][Ottoman Empire]], operated from that harbor.
+
+Most existing towers were built on architectural designs of the
+Florentine architect [[/wiki/Camillo_Camilliani][Camillo Camilliani]]
+from [1583] to 1584 and involved the coastal periple of Sicily. The
+typology changed completely in '800, because of the new higher fire
+volumes of cannon vessels, the towers were built on the type of
+[[/wiki/Martello_towers][Martello towers]] that the British built in the
+UK and elsewhere in the British Empire. The decline of Mediterranean
+piracy caused by the [[/wiki/Second_Barbary_War][Second Barbary War]]
+led to a smaller number of coastal towers built during the 19th
+Century.^{[[#cite_note-149][[149]]]}
+
+- 
+
+  [[/wiki/File:Torre-Capo-Rama-bjs.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/8/80/Torre-Capo-Rama-bjs.jpg/120px-Torre-Capo-Rama-bjs.jpg]]]]
+
+  Torre-Capo-Rama ([[/wiki/Terrasini][Terrasini]])
+
+- 
+
+  [[/wiki/File:Altavilla_Milicia_BW_2012-10-08_18-04-22_b.JPG][[[//upload.wikimedia.org/wikipedia/commons/thumb/2/25/Altavilla_Milicia_BW_2012-10-08_18-04-22_b.JPG/120px-Altavilla_Milicia_BW_2012-10-08_18-04-22_b.JPG]]]]
+
+  Torre di ([[/wiki/Altavilla_Milicia][Altavilla Milicia]])
+
+- 
+
+  [[/wiki/File:Torre_dello_Spalmatore_-_Ustica.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/b/b7/Torre_dello_Spalmatore_-_Ustica.jpg/120px-Torre_dello_Spalmatore_-_Ustica.jpg]]]]
+
+  Torre Spalmatore ([[/wiki/Ustica][Ustica]])
+
+- 
+
+  [[/wiki/File:D7A_1568_bis_Torre_Pozzillo.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/6/60/D7A_1568_bis_Torre_Pozzillo.jpg/120px-D7A_1568_bis_Torre_Pozzillo.jpg]]]]
+
+  Torre Pozzillo ([[/wiki/Cinisi][Cinisi]])
+
+- 
+
+  [[/wiki/File:Ligny_Tower_-_Trapani.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Ligny_Tower_-_Trapani.jpg/120px-Ligny_Tower_-_Trapani.jpg]]]]
+
+  [[/wiki/Ligny_Tower][Ligny Tower]] - ([[/wiki/Trapani][Trapani]])
+
+- 
+
+  [[/wiki/File:Trapani.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/c/c4/Trapani.jpg/120px-Trapani.jpg]]]]
+
+  Torre Nubia ([[/wiki/Paceco][Paceco]])
+
+- 
+
+  [[/wiki/File:Torre_di_Manfria_(Gela).jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/6/66/Torre_di_Manfria_%28Gela%29.jpg/90px-Torre_di_Manfria_%28Gela%29.jpg]]]]
+
+  Torre [[/wiki/Manfria][Manfria]] ([[/wiki/Gela][Gela]])
+
+- 
+
+  [[/wiki/File:Torre_Cabrera,_Marina_di_Ragusa.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/6/60/Torre_Cabrera%2C_Marina_di_Ragusa.jpg/120px-Torre_Cabrera%2C_Marina_di_Ragusa.jpg]]]]
+
+  [[/wiki/Torre_Cabrera_(Marina_di_Ragusa)][Torre Cabrera (Marina di
+  Ragusa)]] ([[/wiki/Marina_di_Ragusa][Marina di Ragusa]])
+
+- 
+
+  [[/wiki/File:Pozzallo-TorreCabrera.JPG][[[//upload.wikimedia.org/wikipedia/commons/thumb/1/10/Pozzallo-TorreCabrera.JPG/120px-Pozzallo-TorreCabrera.JPG]]]]
+
+  [[/wiki/Torre_Cabrera_(Pozzallo)][Torre Cabrera (Pozzallo)]]
+  ([[/wiki/Pozzallo][Pozzallo]])
+
+- 
+
+  [[/wiki/File:Vignazzi_Tower.JPG][[[//upload.wikimedia.org/wikipedia/commons/thumb/0/07/Vignazzi_Tower.JPG/90px-Vignazzi_Tower.JPG]]]]
+
+  [[/wiki/Vignazza_Tower][Vignazza Tower]]
+  ([[/wiki/Giardini_Naxos][Giardini Naxos]])
+
+** Culture[[[/w/index.php?title=Sicily&action=edit&section=42][edit]]]
+   :PROPERTIES:
+   :CUSTOM_ID: cultureedit
+   :END:
+
+See also: [[/wiki/List_of_museums_in_Sicily][List of museums in Sicily]]
+
+#+begin_quote
+  To have seen Italy without having seen Sicily is to not have seen
+  Italy at all, for Sicily is the clue to everything.
+
+  --- [[/wiki/Johann_Wolfgang_von_Goethe][Goethe]]^{[[#cite_note-150][[150]]][/[[/wiki/Wikipedia:NOTRS][better source needed]]/]}
+#+end_quote
+
+[[/wiki/File:Antonello_da_Messina_-_Virgin_Annunciate_-_Galleria_Regionale_della_Sicilia,_Palermo.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/8/83/Antonello_da_Messina_-_Virgin_Annunciate_-_Galleria_Regionale_della_Sicilia%2C_Palermo.jpg/220px-Antonello_da_Messina_-_Virgin_Annunciate_-_Galleria_Regionale_della_Sicilia%2C_Palermo.jpg]]]]
+
+[[/wiki/File:Antonello_da_Messina_-_Virgin_Annunciate_-_Galleria_Regionale_della_Sicilia,_Palermo.jpg][]]
+
+[[/wiki/Virgin_Annunciate_(Antonello_da_Messina,_Palermo)][/Virgin
+Annunciate/]], [[/wiki/Antonello_da_Messina][Antonello da Messina]]
+
+Sicily has long been associated with [[/wiki/The_arts][the arts]]; many
+poets, writers, [[/wiki/Philosophy][philosophers]], intellectuals,
+architects and painters have roots on the island. The history of
+prestige in this field can be traced back to Greek philosopher
+[[/wiki/Archimedes][Archimedes]], a [[/wiki/Syracuse,_Sicily][Syracuse]]
+native who has gone on to become renowned as one of the greatest
+mathematicians of all time.^{[[#cite_note-151][[151]]]}
+[[/wiki/Gorgias][Gorgias]] and [[/wiki/Empedocles][Empedocles]] are two
+other highly noted early Sicilian-Greek philosophers, while the
+Syracusan-Greek [[/wiki/Epicharmus_of_Kos][Epicharmus]] is held to be
+the inventor of
+comedy.^{[[#cite_note-152][[152]]][[#cite_note-153][[153]]]}
+
+*** Art and
+architecture[[[/w/index.php?title=Sicily&action=edit&section=43][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: art-and-architectureedit
+    :END:
+
+[[/wiki/File:Siracuse_Palazzo_Beneventano_del_Bosco_010_2305.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/0/07/Siracuse_Palazzo_Beneventano_del_Bosco_010_2305.jpg/220px-Siracuse_Palazzo_Beneventano_del_Bosco_010_2305.jpg]]]]
+
+[[/wiki/File:Siracuse_Palazzo_Beneventano_del_Bosco_010_2305.jpg][]]
+
+Palazzo Beneventano del Bosco, Syracuse, Sicilian Baroque
+
+[[/wiki/Terracotta][Terracotta]] [[/wiki/Ceramics_(art)][ceramics]] from
+the island are well known, the art of ceramics on Sicily goes back to
+the original ancient peoples named the [[/wiki/Sicani][Sicanians]], it
+was then perfected during the period of Greek colonisation and is still
+prominent and distinct to this day.^{[[#cite_note-154][[154]]]}
+Nowadays, [[/wiki/Caltagirone][Caltagirone]] is one of the most
+important centres in Sicily for the artistic production of ceramics and
+terra-cotta sculptures. Famous painters include
+[[/wiki/Renaissance][Renaissance]] artist
+[[/wiki/Antonello_da_Messina][Antonello da Messina]],
+[[/wiki/Bruno_Caruso][Bruno Caruso]], [[/wiki/Renato_Guttuso][Renato
+Guttuso]] and Greek born [[/wiki/Giorgio_de_Chirico][Giorgio de
+Chirico]] who is commonly dubbed the "father of
+[[/wiki/Surrealist_art][Surrealist art]]" and founder of the
+[[/wiki/Metaphysical_art][metaphysical art]]
+movement.^{[[#cite_note-155][[155]]]} The most noted architects are
+[[/wiki/Filippo_Juvarra][Filippo Juvarra]] (one of the most important
+figures of the Italian [[/wiki/Baroque][Baroque]]) and
+[[/wiki/Ernesto_Basile][Ernesto Basile]].
+
+**** Sicilian
+Baroque[[[/w/index.php?title=Sicily&action=edit&section=44][edit]]]
+     :PROPERTIES:
+     :CUSTOM_ID: sicilian-baroqueedit
+     :END:
+
+Main article: [[/wiki/Sicilian_Baroque][Sicilian Baroque]]
+
+[[/wiki/File:Sicilia_Siracusa1_tango7174.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/3/36/Sicilia_Siracusa1_tango7174.jpg/220px-Sicilia_Siracusa1_tango7174.jpg]]]]
+
+[[/wiki/File:Sicilia_Siracusa1_tango7174.jpg][]]
+
+[[/wiki/Syracuse,_Sicily][Syracuse]] Cathedral
+
+The [[/wiki/Sicilian_Baroque][Sicilian Baroque]] has a unique
+architectural identity. [[/wiki/Noto][Noto]],
+[[/wiki/Caltagirone][Caltagirone]], [[/wiki/Catania][Catania]],
+[[/wiki/Ragusa,_Italy][Ragusa]], [[/wiki/Modica][Modica]],
+[[/wiki/Scicli][Scicli]] and particularly [[/wiki/Acireale][Acireale]]
+contain some of Italy's best examples of
+[[/wiki/Baroque_architecture][Baroque architecture]], carved in the
+local red [[/wiki/Sandstone][sandstone]]. Noto provides one of the best
+examples of the Baroque architecture brought to Sicily. The Baroque
+style in Sicily was largely confined to buildings erected by the church,
+and [[/wiki/Palazzo][palazzi]] built as private residences for the
+Sicilian aristocracy.^{[[#cite_note-156][[156]]]} The earliest examples
+of this style in Sicily lacked individuality and were typically
+heavy-handed pastiches of buildings seen by Sicilian visitors to Rome,
+[[/wiki/Florence][Florence]], and [[/wiki/Naples][Naples]]. However,
+even at this early stage, provincial architects had begun to incorporate
+certain vernacular features of Sicily's older architecture. By the
+middle of the 18th century, when Sicily's Baroque architecture was
+noticeably different from that of the mainland, it typically included at
+least two or three of the following features, coupled with a unique
+freedom of design that is more difficult to characterize in words.
+
+*** Music and
+film[[[/w/index.php?title=Sicily&action=edit&section=45][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: music-and-filmedit
+    :END:
+
+See also: [[/wiki/Music_of_Sicily][Music of Sicily]]
+
+[[/wiki/File:Palermo_teatro_massimo.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/d/df/Palermo_teatro_massimo.jpg/220px-Palermo_teatro_massimo.jpg]]]]
+
+[[/wiki/File:Palermo_teatro_massimo.jpg][]]
+
+[[/wiki/Teatro_Massimo][Teatro Massimo]], [[/wiki/Palermo][Palermo]]
+
+[[/wiki/Palermo][Palermo]] hosts the [[/wiki/Teatro_Massimo][Teatro
+Massimo]] which is the largest [[/wiki/Opera_house][opera house]] in
+Italy and the third largest in all of
+Europe.^{[[#cite_note-157][[157]]]} In [[/wiki/Catania][Catania]] there
+is another important [[/wiki/Opera_house][opera house]], the
+[[/wiki/Teatro_Massimo_Bellini][Teatro Massimo Bellini]] with 1,200
+seats, which is considered one of the best European
+[[/wiki/Opera_houses][opera houses]] for its acoustics. Sicily's
+composers vary from [[/wiki/Vincenzo_Bellini][Vincenzo Bellini]],
+[[/wiki/Sigismondo_d%27India][Sigismondo d'India]],
+[[/wiki/Giovanni_Pacini][Giovanni Pacini]] and
+[[/wiki/Alessandro_Scarlatti][Alessandro Scarlatti]], to contemporary
+composers such as [[/wiki/Salvatore_Sciarrino][Salvatore Sciarrino]] and
+[[/wiki/Silvio_Amato][Silvio Amato]].
+
+[[/wiki/File:Vincenzo_bellini.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/5/5a/Vincenzo_bellini.jpg/150px-Vincenzo_bellini.jpg]]]]
+
+[[/wiki/File:Vincenzo_bellini.jpg][]]
+
+[[/wiki/Vincenzo_Bellini][Vincenzo Bellini]]
+
+[[/wiki/File:Alessandro_Scarlatti.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/b/b3/Alessandro_Scarlatti.jpg/150px-Alessandro_Scarlatti.jpg]]]]
+
+[[/wiki/File:Alessandro_Scarlatti.jpg][]]
+
+[[/wiki/Alessandro_Scarlatti][Alessandro Scarlatti]]
+
+Many award-winning and acclaimed films of Italian cinema have been
+filmed in Sicily, amongst the most noted of which are:
+[[/wiki/Luchino_Visconti][Visconti]]'s /"[[/wiki/La_Terra_Trema][La
+Terra Trema]]"/ and /"[[/wiki/Il_Gattopardo][Il Gattopardo]]"/,
+[[/wiki/Pietro_Germi][Pietro Germi]]'s
+/"[[/wiki/Divorce,_Italian_Style][Divorzio all'Italiana]]/" and
+/"[[/wiki/Seduced_and_Abandoned][Sedotta e Abbandonata]]/".
+
+*** Literature[[[/w/index.php?title=Sicily&action=edit&section=46][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: literatureedit
+    :END:
+
+See also: [[/wiki/Italian_Literature][Italian Literature]] and
+[[/wiki/Sicilian_School][Sicilian School]]
+
+[[/wiki/File:Luigi_Pirandello_1934.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/b/b1/Luigi_Pirandello_1934.jpg/150px-Luigi_Pirandello_1934.jpg]]]]
+
+[[/wiki/File:Luigi_Pirandello.jpg][]]
+
+[[/wiki/Luigi_Pirandello][Luigi Pirandello]]
+
+The golden age of Sicilian poetry began in the early 13th century with
+the [[/wiki/Sicilian_School][Sicilian School]] of
+[[/wiki/Giacomo_da_Lentini][Giacomo da Lentini]], which was highly
+influential on [[/wiki/Italian_literature][Italian literature]]. Some of
+the most noted figures among writers and poets are
+[[/wiki/Luigi_Pirandello][Luigi Pirandello]]
+([[/wiki/Nobel_Prize_in_Literature][Nobel laureate, 1934]]),
+[[/wiki/Salvatore_Quasimodo][Salvatore Quasimodo]]
+([[/wiki/Nobel_Prize_in_Literature][Nobel laureate, 1959]]),
+[[/wiki/Giovanni_Verga][Giovanni Verga]] (the father of the /Italian
+[[/wiki/Verismo_(literature)][Verismo]]/),
+[[/wiki/Domenico_Tempio][Domenico Tempio]],
+[[/wiki/Giovanni_Meli][Giovanni Meli]], [[/wiki/Luigi_Capuana][Luigi
+Capuana]], [[/wiki/Mario_Rapisardi][Mario Rapisardi]],
+[[/wiki/Federico_de_Roberto][Federico de Roberto]],
+[[/wiki/Leonardo_Sciascia][Leonardo Sciascia]],
+[[/wiki/Vitaliano_Brancati][Vitaliano Brancati]],
+[[/wiki/Giuseppe_Tomasi_di_Lampedusa][Giuseppe Tomasi di Lampedusa]],
+[[/wiki/Elio_Vittorini][Elio Vittorini]],
+[[/wiki/Vincenzo_Consolo][Vincenzo Consolo]] and
+[[/wiki/Andrea_Camilleri][Andrea Camilleri]] (noted for his novels and
+short stories with the fictional character
+[[/wiki/Salvo_Montalbano][Inspector Salvo Montalbano]] as protagonist).
+On the political side notable philosophers include
+[[/wiki/Gaetano_Mosca][Gaetano Mosca]] and
+[[/wiki/Giovanni_Gentile][Giovanni Gentile]] who wrote
+/[[/wiki/The_Doctrine_of_Fascism][The Doctrine of Fascism]]/. In terms
+of academic reflection, the historical and aesthetic richness as well as
+the multi-layered heterogeneity of Sicilian literature and culture have
+been first grasped methodologically and coined with the term of
+[[/wiki/Transculturation][transculturality]] by
+[[/wiki/Germans][German]] scholar of [[/wiki/Italian_studies][Italian
+studies]] [[/wiki/Dagmar_Reichardt][Dagmar Reichardt]] who, after having
+published an extensive study on the literary work of
+[[/w/index.php?title=Giuseppe_Bonaviri&action=edit&redlink=1][Giuseppe
+Bonaviri]],^{[[#cite_note-158][[158]]]} was awarded the International
+[[/wiki/Premio_Flaiano][Premio Flaiano]] ("Italianistica") for a
+trilingual (English, Italian, German) collection about the
+[[/wiki/Europe][European]] [[/wiki/Liminality][liminality]] of Sicily,
+Sicilian literature and Sicilian Studies.^{[[#cite_note-159][[159]]]}
+
+*** Language[[[/w/index.php?title=Sicily&action=edit&section=47][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: languageedit
+    :END:
+
+Main article: [[/wiki/Sicilian_language][Sicilian language]]
+
+Today in Sicily most people are bilingual and speak both Italian and
+[[/wiki/Sicilian_language][Sicilian]], a distinct and historical
+[[/wiki/Romance_languages][Romance language]]. Some of the
+[[/wiki/Sicilian_language][Sicilian]] words are [[/wiki/Loan_word][loan
+words]] from [[/wiki/Greek_language][Greek]],
+[[/wiki/Catalan_language][Catalan]], French,
+[[/wiki/Arabic_language][Arabic]], Spanish and other
+languages.^{[[#cite_note-160][[160]]]} Dialects related to Sicilian are
+also spoken in [[/wiki/Calabria][Calabria]] and
+[[/wiki/Apulia][Salento]]; it had a significant influence on the
+[[/wiki/Maltese_language][Maltese language]]. However the use of
+[[/wiki/Sicilian_language][Sicilian]] is limited to informal contexts
+(mostly in family) and in a majority of cases it is replaced by the
+so-called /regional Italian of Sicily/, an
+[[/wiki/Regional_Italian][Italian dialect]] that is a kind of mix
+between Italian and Sicilian.^{[[#cite_note-161][[161]]]}
+
+Sicilian was an early influence in the development of the first Italian
+standard, although its use remained confined to an intellectual elite.
+This was a literary language in Sicily created under the auspices of
+[[/wiki/Frederick_II,_Holy_Roman_Emperor][Frederick II]] and his court
+of notaries, or /Magna Curia/, which, headed by
+[[/wiki/Giacomo_da_Lentini][Giacomo da Lentini]], also gave birth to the
+[[/wiki/Sicilian_School][Sicilian School]], widely inspired by
+troubadour literature. Its linguistic and poetic heritage was later
+assimilated into the Florentine by [[/wiki/Dante_Alighieri][Dante
+Alighieri]], the father of modern Italian who, in his
+/[[/wiki/De_vulgari_eloquentia][De vulgari eloquentia]]/, claims that
+"In effect, this vernacular seems to deserve higher praise than the
+others since all the poetry written by Italians can be called
+Sicilian".^{[[#cite_note-162][[162]]]} It is in this language that
+appeared the first [[/wiki/Sonnet][sonnet]], whose invention is
+attributed to Giacomo da Lentini himself.
+
+*** Science[[[/w/index.php?title=Sicily&action=edit&section=48][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: scienceedit
+    :END:
+[[/wiki/Catania][Catania]] has one of the four laboratories of the
+[[/wiki/Istituto_Nazionale_di_Fisica_Nucleare][Istituto Nazionale di
+Fisica Nucleare]] (National Institute for Nuclear Physics) in which
+there is a [[/wiki/Cyclotron][cyclotron]] that uses
+[[/wiki/Proton][protons]] both for [[/wiki/Nuclear_physics][nuclear
+physics]] experiments and for particle therapy to treat cancer
+([[/wiki/Proton_therapy][proton
+therapy]]).^{[[#cite_note-163][[163]]][[#cite_note-164][[164]]]}
+[[/wiki/Noto][Noto]] has one of the largest
+[[/wiki/Radio_telescope][radio telescopes]] in Italy that performs
+geodetic and astronomical observations.^{[[#cite_note-165][[165]]]}
+There are [[/wiki/Observatories][observatories]] in
+[[/wiki/Palermo][Palermo]] and [[/wiki/Catania][Catania]], managed by
+the [[/wiki/Istituto_Nazionale_di_Astrofisica][Istituto Nazionale di
+Astrofisica]] (National Institute for Astrophysics). In the /Observatory
+of Palermo/ the astronomer [[/wiki/Giuseppe_Piazzi][Giuseppe Piazzi]]
+discovered the first and the largest [[/wiki/Asteroid][asteroid]] to be
+identified [[/wiki/Ceres_(dwarf_planet)][Ceres]] (today considered a
+[[/wiki/Dwarf_planet][dwarf planet]]) on 1 January
+1801;^{[[#cite_note-166][[166]]]} [[/wiki/Catania][Catania]] has two
+observatories, one of which is situated on [[/wiki/Mount_Etna][Mount
+Etna]] at 1,800 metres (5,900
+[[/wiki/Foot_(unit)][feet]]).^{[[#cite_note-167][[167]]]}
+
+[[/wiki/Syracuse,_Sicily][Syracuse]] is also an experimental centre for
+the solar technologies through the creation of the project
+[[/wiki/Archimede_solar_power_plant][Archimede solar power plant]] that
+is the first [[/wiki/Concentrated_solar_power][concentrated solar power
+plant]] to use [[/wiki/Molten_salt][molten salt]] for heat transfer and
+storage which is integrated with a
+[[/wiki/Combined-cycle][combined-cycle]] gas facility. All the plant is
+owned and operated by
+[[/wiki/Enel][Enel]].^{[[#cite_note-168][[168]]][[#cite_note-169][[169]]]}
+The touristic town of [[/wiki/Erice][Erice]] is also an important
+science place thanks to the
+[[/wiki/Ettore_Majorana_Foundation_and_Centre_for_Scientific_Culture][Ettore
+Majorana Foundation and Centre for Scientific Culture]] which embraces
+123 schools from all over the world, covering all branches of science,
+offering courses, seminars, workshops, and annual meetings. It was
+founded by the physicist [[/wiki/Antonino_Zichichi][Antonino Zichichi]]
+in honour of another scientist of the island,
+[[/wiki/Ettore_Majorana][Ettore Majorana]] known for the
+[[/wiki/Majorana_equation][Majorana equation]] and
+[[/wiki/Majorana_fermion][Majorana
+fermions]].^{[[#cite_note-170][[170]]]} Sicily's famous scientists
+include also [[/wiki/Stanislao_Cannizzaro][Stanislao Cannizzaro]]
+(chemist), [[/wiki/Giovanni_Battista_Hodierna][Giovanni Battista
+Hodierna]] and [[/wiki/Niccol%C3%B2_Cacciatore][Niccolò Cacciatore]]
+(astronomers).
+
+[[/wiki/File:Ripresa_notturna_della_Facolta_di_Ingegneria_Messina.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/7/7a/Ripresa_notturna_della_Facolta_di_Ingegneria_Messina.jpg/220px-Ripresa_notturna_della_Facolta_di_Ingegneria_Messina.jpg]]]]
+
+[[/wiki/File:Ripresa_notturna_della_Facolta_di_Ingegneria_Messina.jpg][]]
+
+Department of Engineering, [[/wiki/University_of_Messina][University of
+Messina]]
+
+*** Education[[[/w/index.php?title=Sicily&action=edit&section=49][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: educationedit
+    :END:
+Sicily has four universities:
+
+- The [[/wiki/University_of_Catania][University of Catania]] dates back
+  to 1434 and it is the oldest university in Sicily. Nowadays it hosts
+  12 faculties and over 62,000 students and it offers undergraduate and
+  postgraduate programs. [[/wiki/Catania][Catania]] hosts also the
+  /[[/wiki/Scuola_superiore_di_Catania][Scuola Superiore]]/, an
+  [[/wiki/Academic_institution][academic institution]] linked to the
+  University of Catania, aiming for excellence in
+  education.^{[[#cite_note-171][[171]]]}
+- The [[/wiki/University_of_Palermo][University of Palermo]] is the
+  island's second-oldest university. It was officially founded in 1806,
+  although historical records indicate that medicine and law have been
+  taught there since the late 15th century. The
+  [[/wiki/Orto_botanico_di_Palermo][Orto botanico di Palermo]] (Palermo
+  botanical gardens) is home to the university's Department of Botany
+  and is also open to visitors.
+- The [[/wiki/University_of_Messina][University of Messina]], founded in
+  1548 by [[/wiki/Ignatius_of_Loyola][Ignatius of Loyola]]. It is
+  organized in 11 Faculties.
+- The [[/wiki/Kore_University_of_Enna][Kore University of Enna]] founded
+  in 1995, it is the latest Sicilian university and the first university
+  founded in Sicily after the [[/wiki/Italian_Unification][Italian
+  Unification]].
+
+*** Cuisine[[[/w/index.php?title=Sicily&action=edit&section=50][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: cuisineedit
+    :END:
+
+Main articles: [[/wiki/Sicilian_cuisine][Sicilian cuisine]] and
+[[/wiki/Sicilian_pizza][Sicilian pizza]]
+
+[[/wiki/File:Cannoli_siciliani.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/9/99/Cannoli_siciliani.jpg/220px-Cannoli_siciliani.jpg]]]]
+
+[[/wiki/File:Cannoli_siciliani.jpg][]]
+
+[[/wiki/Cannoli][Cannoli]], a popular pastry associated with Sicilian
+cuisine
+
+The island has a long history of producing a variety of noted cuisines
+and wines, to the extent that Sicily is sometimes nicknamed /God's
+Kitchen/ because of this.^{[[#cite_note-172][[172]]]} Every part of
+Sicily has its speciality (e.g. Cassata is typical of Palermo although
+available everywhere in Sicily, as is Granita). The ingredients are
+typically rich in taste while remaining affordable to the general
+public.^{[[#cite_note-173][[173]]]} The savoury dishes of Sicily are
+viewed to be [[/wiki/Healthy_diet][healthy]], using fresh vegetables and
+fruits, such as tomatoes, [[/wiki/Artichoke][artichokes]],
+[[/wiki/Olive][olives]] (including [[/wiki/Olive_oil][olive oil]]),
+[[/wiki/Citrus][citrus]], [[/wiki/Apricot][apricots]],
+[[/wiki/Aubergines][aubergines]], onions, [[/wiki/Bean][beans]],
+[[/wiki/Raisin][raisins]] commonly coupled with seafood, freshly caught
+from the surrounding coastlines, including [[/wiki/Tuna][tuna]],
+[[/wiki/Sea_bream][sea bream]], [[/wiki/European_seabass][sea bass]],
+[[/wiki/Cuttlefish][cuttlefish]], [[/wiki/Swordfish][swordfish]],
+[[/wiki/Sardine][sardines]], and
+others.^{[[#cite_note-piras-174][[174]]]}
+
+[[/wiki/File:Arancini_002.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/e/ee/Arancini_002.jpg/220px-Arancini_002.jpg]]]]
+
+[[/wiki/File:Arancini_002.jpg][]]
+
+[[/wiki/Arancini][Arancini]], rice balls fried in breadcrumbs
+
+The most well-known part of Sicilian cuisine is the rich sweet dishes
+including [[/wiki/Ice_cream][ice creams]] and
+[[/wiki/Pastry][pastries]]. [[/wiki/Cannoli][Cannoli]] (singular:
+/cannolo/), a tube-shaped shell of fried pastry dough filled with a
+sweet filling usually containing [[/wiki/Ricotta][ricotta]], is strongly
+associated with Sicily worldwide.^{[[#cite_note-authentic-175][[175]]]}
+Biancomangiare, biscotti ennesi (cookies native to
+[[/wiki/Enna][Enna]]), braccilatte (a Sicilian version of
+[[/wiki/Doughnut][doughnuts]]), [[/wiki/Buccellato][buccellato]],
+[[/wiki/Ciarduna][ciarduna]], [[/wiki/Pignolo_(macaroon)][pignoli]],
+[[/wiki/Biscotti_Regina][Biscotti Regina]],
+[[/wiki/Giurgiulena][giurgiulena]], [[/wiki/Frutta_martorana][frutta
+martorana]], [[/wiki/Cassata][cassata]], [[/wiki/Pignolata][pignolata]],
+[[/wiki/Granita][granita]], [[/wiki/Cuccidati][cuccidati]] (a variety of
+fig cookie; also known as buccellati) and [[/wiki/Cucc%C3%ACa][cuccìa]]
+are some notable sweet dishes.^{[[#cite_note-authentic-175][[175]]]}
+
+Like the cuisine of the rest of southern Italy, pasta plays an important
+part in Sicilian cuisine, as does rice; for example with
+[[/wiki/Arancini][arancini]].^{[[#cite_note-176][[176]]]} As well as
+using some other cheeses, Sicily has spawned some of its own, using both
+cow's and sheep's milk, such as [[/wiki/Pecorino_Siciliano][pecorino]]
+and [[/wiki/Caciocavallo][caciocavallo]].^{[[#cite_note-177][[177]]]}
+Spices used include [[/wiki/Saffron][saffron]],
+[[/wiki/Nutmeg][nutmeg]], [[/wiki/Clove][clove]],
+[[/wiki/Black_pepper][pepper]], and [[/wiki/Cinnamon][cinnamon]], which
+were introduced by the Arabs. [[/wiki/Parsley][Parsley]] is used
+abundantly in many dishes. Although Sicilian cuisine is commonly
+associated with sea food, meat dishes, including [[/wiki/Goose][goose]],
+[[/wiki/Domestic_sheep][lamb]], goat, rabbit, and
+[[/wiki/Turkey_meat][turkey]], are also found in Sicily. It was the
+[[/wiki/Normans][Normans]] and [[/wiki/Hohenstaufen][Swabians]] who
+first introduced a fondness for meat dishes to the
+island.^{[[#cite_note-178][[178]]]} Some varieties of wine are produced
+from vines that are relatively unique to the island, such as the
+[[/wiki/Nero_d%27Avola][Nero d'Avola]] made near the baroque of town of
+[[/wiki/Noto][Noto]].^{[[#cite_note-179][[179]]]}
+
+*** Sports[[[/w/index.php?title=Sicily&action=edit&section=51][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: sportsedit
+    :END:
+
+[[/wiki/File:Giuseppe_Gibilisco_Berlin_2009.JPG][[[//upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Giuseppe_Gibilisco_Berlin_2009.JPG/220px-Giuseppe_Gibilisco_Berlin_2009.JPG]]]]
+
+[[/wiki/File:Giuseppe_Gibilisco_Berlin_2009.JPG][]]
+
+[[/wiki/Giuseppe_Gibilisco][Giuseppe Gibilisco]],
+[[/wiki/Pole_vaulting][pole vaulter]] from
+[[/wiki/Syracuse,_Sicily][Syracuse]],
+[[/wiki/2003_World_Championships_in_Athletics][2003 World Champion]] and
+bronze
+[[/wiki/Athletics_at_the_2004_Summer_Olympics_%E2%80%93_Men%27s_pole_vault][Olympic]]
+medalist
+
+The most popular sport in Sicily is
+[[/wiki/Association_football][football]], which came to the fore in the
+late 19th century under the influence of the English. Some of the oldest
+football clubs in Italy are from Sicily: the three most successful are
+[[/wiki/U.S._Citt%C3%A0_di_Palermo][Palermo]],
+[[/wiki/Calcio_Catania][Catania]], and
+[[/wiki/A.C.R._Messina][Messina]], which have played 29, 17 and 5
+seasons in the [[/wiki/Serie_A][Serie A]] respectively. No club from
+Sicily has ever won Serie A, but football is still deeply embedded in
+local culture and all over Sicily most towns have a representative
+team.^{[[#cite_note-derbysicil-180][[180]]]}
+
+Palermo and Catania have a heated rivalry and compete in the
+[[/wiki/Derby_di_Sicilia][Sicilian derby]] together. Palermo is the only
+team in Sicily to have played on the European stage, in the
+[[/wiki/UEFA_Cup][UEFA Cup]]. In the island, the most noted footballer
+is [[/wiki/Salvatore_Schillaci][Salvatore Schillaci]], who won the
+[[/wiki/FIFA_World_Cup_awards][Golden Boot]] at the
+[[/wiki/1990_FIFA_World_Cup][1990 FIFA World Cup]] with
+[[/wiki/Italy_national_football_team][Italy]].^{[[#cite_note-derbysicil-180][[180]]]}
+Other noted players include [[/wiki/Giuseppe_Furino][Giuseppe Furino]],
+[[/wiki/Pietro_Anastasi][Pietro Anastasi]],
+[[/wiki/Francesco_Coco][Francesco Coco]],
+[[/wiki/Christian_Rigan%C3%B2][Christian Riganò]], and
+[[/wiki/Roberto_Galia][Roberto
+Galia]].^{[[#cite_note-derbysicil-180][[180]]]} There have also been
+some noted managers from the island, such as
+[[/wiki/Carmelo_Di_Bella][Carmelo Di Bella]] and
+[[/wiki/Franco_Scoglio][Franco Scoglio]].
+
+Although football is the most popular sport in Sicily, the island also
+has participants in other fields. [[/wiki/Amatori_Catania][Amatori
+Catania]] have competed in the top Italian national
+[[/wiki/Rugby_union][rugby union]] league called [[/wiki/Top12][National
+Championship of Excellence]]. They have even participated at the
+European level in the [[/wiki/European_Challenge_Cup][European Challenge
+Cup]]. Competing in the basketball variation of
+[[/wiki/Serie_A_(basketball)][Serie A]] is
+[[/wiki/Orlandina_Basket][Orlandina Basket]] from
+[[/wiki/Capo_d%27Orlando][Capo d'Orlando]] in the
+[[/wiki/Province_of_Messina][province of Messina]], where the sport has
+a reasonable following. Various other sports that are played to some
+extent include volleyball, [[/wiki/Team_handball][handball]], and
+[[/wiki/Water_polo][water polo]]. Previously, in
+[[/wiki/Motorsport][motorsport]], Sicily held the prominent
+[[/wiki/Targa_Florio][Targa Florio]] sports car race that took place in
+the Madonie Mountains, with the start-finish line in
+[[/wiki/Cerda][Cerda]].^{[[#cite_note-targa-181][[181]]]} The event was
+started in 1906 by Sicilian industrialist and automobile enthusiast
+[[/wiki/Vincenzo_Florio][Vincenzo Florio]], and ran until it was
+canceled due to safety concerns
+in 1977.^{[[#cite_note-targa-181][[181]]]}
+
+From 28 September to 9 October 2005 [[/wiki/Trapani][Trapani]] was the
+location of Acts 8 and 9 of the [[/wiki/Louis_Vuitton_Cup][Louis Vuitton
+Cup]]. This sailing race featured, among other entrants, all boats that
+took part in the 2007 [[/wiki/America%27s_Cup][America's Cup]].
+
+*** Popular
+culture[[[/w/index.php?title=Sicily&action=edit&section=52][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: popular-cultureedit
+    :END:
+
+[[/wiki/File:Sicilian_animated_crib.JPG][[[//upload.wikimedia.org/wikipedia/commons/thumb/5/55/Sicilian_animated_crib.JPG/220px-Sicilian_animated_crib.JPG]]]]
+
+[[/wiki/File:Sicilian_animated_crib.JPG][]]
+
+Sicilian /arrotino/ at a living [[/wiki/Nativity_scene][nativity scene]]
+wearing traditional Sicilian clothing
+
+[[/wiki/File:Trapani_Misteri.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/7/75/Trapani_Misteri.jpg/220px-Trapani_Misteri.jpg]]]]
+
+[[/wiki/File:Trapani_Misteri.jpg][]]
+
+The "[[/wiki/Misteri_di_Trapani][Misteri]]", a Religious festival in
+[[/wiki/Trapani][Trapani]]
+
+[[/wiki/File:Carnival_at_Acireale.JPG][[[//upload.wikimedia.org/wikipedia/commons/thumb/4/4b/Carnival_at_Acireale.JPG/220px-Carnival_at_Acireale.JPG]]]]
+
+[[/wiki/File:Carnival_at_Acireale.JPG][]]
+
+A [[/wiki/Carnival][carnival]] float in [[/wiki/Acireale][Acireale]]
+
+Each town and city has its own patron saint, and the
+[[/wiki/Feast_day][feast days]] are marked by colourful processions
+through the streets with marching bands and displays of fireworks.
+
+Sicilian religious festivals also include the /presepe vivente/ (living
+[[/wiki/Nativity_scene][nativity scene]]), which takes place at
+Christmas time. Deftly combining religion and folklore, it is a
+constructed mock 19th-century Sicilian village, complete with a nativity
+scene, and has people of all ages dressed in the costumes of the period,
+some impersonating the Holy Family, and others working as artisans of
+their particular assigned trade. It is normally concluded on
+[[/wiki/Epiphany_(holiday)][Epiphany]], often highlighted by the arrival
+of the [[/wiki/Magi][magi]] on horseback.
+
+Oral tradition plays a large role in Sicilian folklore. Many stories
+passed down from generation to generation involve a character named
+"[[/wiki/Giuf%C3%A0][Giufà]]". Anecdotes from this character's life
+preserve Sicilian culture as well as convey moral messages.
+
+Sicilians also enjoy outdoor festivals, held in the local square or
+/piazza/ where live music and dancing are performed on stage, and food
+fairs or /sagre/ are set up in booths lining the square. These offer
+various local specialties, as well as typical Sicilian food. Normally
+these events are concluded with fireworks. A noted /sagra/ is the /Sagra
+del Carciofo/ or /[[/wiki/Artichoke][Artichoke]] Festival/, which is
+held annually in [[/wiki/Ramacca][Ramacca]] in April. The most important
+traditional event in Sicily is the [[/wiki/Carnival][carnival]]. Famous
+carnivals are in [[/wiki/Acireale][Acireale]],
+[[/wiki/Misterbianco][Misterbianco]], [[/wiki/Regalbuto][Regalbuto]],
+[[/wiki/Patern%C3%B2][Paternò]], [[/wiki/Sciacca][Sciacca]],
+[[/wiki/Termini_Imerese][Termini Imerese]].
+
+[[/wiki/File:Pupi,_Catania.JPG][[[//upload.wikimedia.org/wikipedia/commons/thumb/0/06/Pupi%2C_Catania.JPG/220px-Pupi%2C_Catania.JPG]]]]
+
+[[/wiki/File:Pupi,_Catania.JPG][]]
+
+The [[/wiki/Marionettes][marionettes]] used in the
+[[/wiki/Opera_dei_Pupi][Opera dei Pupi]]
+
+The *[[/wiki/Opera_dei_Pupi][Opera dei Pupi]]* (Opera of the Puppets;
+[[/wiki/Sicilian_language][Sicilian]]: Òpira dî pupi) is a
+[[/wiki/Marionette][marionette]] theatrical representation of Frankish
+romantic poems such as the [[/wiki/Song_of_Roland][Song of Roland]] or
+/[[/wiki/Orlando_furioso][Orlando furioso]]/ that is one of the
+characteristic cultural traditions of Sicily. The sides of donkey carts
+are decorated with intricate, painted scenes; these same tales are
+enacted in traditional [[/wiki/Puppet_theatre][puppet theatres]]
+featuring hand-made marionettes of wood. The opera of the puppets and
+the Sicilian tradition of /cantastorî/ (singers of tales) are rooted in
+the Provençal [[/wiki/Troubadour][troubadour]] tradition in Sicily
+during the reign of [[/wiki/Frederick_II,_Holy_Roman_Emperor][Frederick
+II, Holy Roman Emperor]], in the first half of the 13th century. A great
+place to see this marionette art is the puppet theatres of
+[[/wiki/Palermo][Palermo]]. The Sicilian marionette theatre Opera dei
+Pupi was proclaimed in 2001 and inscribed in 2008 in the
+[[/wiki/UNESCO_Intangible_Cultural_Heritage_Lists][UNESCO Intangible
+Cultural Heritage Lists]].^{[[#cite_note-182][[182]]]}
+
+Today, there are only a few troupes that maintain the tradition. They
+often perform for tourists. However, there are no longer the great
+historical families of marionettists, such as the Greco of
+[[/wiki/Palermo][Palermo]]; the [[/wiki/Gaspare_Canino][Canino]] of
+[[/wiki/Partinico][Partinico]] and [[/wiki/Alcamo][Alcamo]]; Crimi,
+Trombetta and Napoli of [[/wiki/Catania][Catania]], Pennisi and Macri of
+[[/wiki/Acireale][Acireale]], Profeta of [[/wiki/Licata][Licata]],
+Gargano and Grasso of [[/wiki/Agrigento][Agrigento]]. One can, however,
+admire the richest collection of marionettes at the Museo Internazionale
+delle Marionette Antonio Pasqualino and at the
+[[/wiki/Museo_Etnografico_Siciliano_Giuseppe_Pitr%C3%A8][Museo
+Etnografico Siciliano Giuseppe Pitrè]] in Palermo. Other elaborate
+marionettes are on display at the Museo Civico Vagliasindi in
+[[/wiki/Randazzo][Randazzo]].
+
+*** Traditional
+items[[[/w/index.php?title=Sicily&action=edit&section=53][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: traditional-itemsedit
+    :END:
+
+[[/wiki/File:Sicilian_Cart_Agrigento.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/d/d8/Sicilian_Cart_Agrigento.jpg/220px-Sicilian_Cart_Agrigento.jpg]]]]
+
+[[/wiki/File:Sicilian_Cart_Agrigento.jpg][]]
+
+A traditional [[/wiki/Sicilian_cart][Sicilian cart]]
+
+The [[/wiki/Sicilian_cart][Sicilian cart]] is an ornate, colourful style
+of a horse or donkey-drawn cart native to Sicily. Sicilian wood carver
+[[/w/index.php?title=George_Petralia&action=edit&redlink=1][George
+Petralia]] states that horses were mostly used in the city and flat
+plains, while donkeys or mules were more often used in rough terrain for
+hauling heavy loads.^{[[#cite_note-183][[183]]]} The cart has two wheels
+and is primarily handmade out of wood with iron components.
+
+The Sicilian [[/wiki/Coppola_(cap)][coppola]] is a traditional kind of
+[[/wiki/Flat_cap][flat cap]] typically worn by men in Sicily. First used
+by English nobles during the late 18th century, the /tascu/ began being
+used in Sicily in the early 20th century as a [[/wiki/Flat_cap][driving
+cap]], usually worn by car drivers. The /coppola/ is usually made in
+[[/wiki/Tweed_(cloth)][tweed]]. Today it is widely regarded as a
+definitive symbol of Sicilian heritage.^{[[#cite_note-184][[184]]]}
+
+*** Flag and
+emblem[[[/w/index.php?title=Sicily&action=edit&section=54][edit]]]
+    :PROPERTIES:
+    :CUSTOM_ID: flag-and-emblemedit
+    :END:
+
+[[/wiki/File:2009-03-22_03-29_Sizilien_683_Agrigent,_Parco_Valle_dei_Templi_Agrigento,_Museo_Archaeologico.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/9/9e/2009-03-22_03-29_Sizilien_683_Agrigent%2C_Parco_Valle_dei_Templi_Agrigento%2C_Museo_Archaeologico.jpg/220px-2009-03-22_03-29_Sizilien_683_Agrigent%2C_Parco_Valle_dei_Templi_Agrigento%2C_Museo_Archaeologico.jpg]]]]
+
+[[/wiki/File:2009-03-22_03-29_Sizilien_683_Agrigent,_Parco_Valle_dei_Templi_Agrigento,_Museo_Archaeologico.jpg][]]
+
+[[/wiki/Triskelion][Triskelion]] painted on
+[[/wiki/Ancient_Greek_art][Ancient Greek]] vase,
+[[/wiki/Agrigento][Agrigento]]
+
+[[/wiki/File:The_triskelion_symbol_of_Sicily.jpg][[[//upload.wikimedia.org/wikipedia/commons/thumb/d/dc/The_triskelion_symbol_of_Sicily.jpg/220px-The_triskelion_symbol_of_Sicily.jpg]]]]
+
+[[/wiki/File:The_triskelion_symbol_of_Sicily.jpg][]]
+
+The Triskelion symbol of Sicily
+
+Main articles: [[/wiki/Triskelion#Sicily][Triskelion § Sicily]], and
+[[/wiki/Flag_of_Sicily][Flag of Sicily]]
+
+The [[/wiki/Flag_of_Sicily][Flag of Sicily]], regarded as a regional
+icon, was first adopted in 1282, after the
+[[/wiki/Sicilian_Vespers][Sicilian Vespers]] of
+[[/wiki/Palermo][Palermo]]. It is characterised by the presence of the
+[[/wiki/Triskelion][triskeles]] in the middle, depicting the head of
+[[/wiki/Medusa][Medusa]] and three wheat ears representing the extreme
+fertility of the land of
+Sicily.^{[[#cite_note-Radicini,_Ninni_2014-185][[185]]][/[[/wiki/Wikipedia:Citation_needed][additional
+citation(s) needed]]/]} In early mythology, when Medusa was slain and
+beheaded by Perseus, the Medusa head was placed in the centre of
+Athena's shield.^{[[#cite_note-186][[186]]]} Palermo and Corleone were
+the first two cities to found a confederation against the
+[[/wiki/Capetian_House_of_Anjou][Angevin]] rule. The triskeles symbol
+came to be on the Sicilian flag in 1943 during
+[[/wiki/World_War_II][World War II]] when
+[[/wiki/Andrea_Finocchiaro_Aprile][Andrea Finocchiaro Aprile]] led an
+independence movement, in collaboration with the allies. Their plan was
+to help Sicily become independent and form a free republic. The colours,
+likewise introduced in the 1940s, respectively represent the cities of
+[[/wiki/Palermo][Palermo]] and [[/wiki/Corleone][Corleone]]. The
+separatist behind the movement used a yellow and red flag with the
+Trinacria in the center of it. When [[/wiki/World_War_II][World War II]]
+ended, Sicily was recognized as an autonomous region in the Italian
+Republic.
+
+The flag became the official public flag of the /Regione Siciliana/ in
+January 2000, after the passing of an apposite regional law which
+advocates its use on public buildings, schools and city halls along with
+the national [[/wiki/Flag_of_Italy][Italian flag]] and the
+[[/wiki/Flag_of_EU][European]] one.
+
+Familiar as an ancient symbol of the region, the
+[[/wiki/Triskelion][Triskelion]] is also featured on Greek coins of
+[[/wiki/Syracuse,_Sicily][Syracuse]], such as coins of
+[[/wiki/Agathocles][Agathocles]] (317--289 BC).The symbol dates back to
+when Sicily was part of [[/wiki/Magna_Graecia][Magna Graecia]], the
+colonial extension of [[/wiki/Greece][Greece]] beyond the
+[[/wiki/Aegean_Sea][Aegean]].^{[[#cite_note-naples-187][[187]]]} The
+triskelion was revived, as a [[/wiki/Neoclassicism][neoclassic]] -- and
+non-[[/wiki/House_of_Bourbon][Bourbon]] -- emblem for the new Napoleonic
+Kingdom of the [[/wiki/Two_Sicilies][Two Sicilies]], by
+[[/wiki/Joachim_Murat][Joachim Murat]] in 1808. In the case of Sicily,
+the triskelion symbol is said to represent the three
+[[/wiki/Cape_(geography)][capes]] ([[/wiki/Headland][headlands]] or
+[[/wiki/Promontory][promontories]] of the island of Sicily, namely:
+[[/wiki/Punta_del_Faro][Pelorus]] (Peloro, Tip of Faro, Messina:
+North-East); [[/wiki/Capo_Passero][Pachynus]] (Passero, Syracuse:
+South); and [[/wiki/Marsala][Lilybæum]] (Lilibeo, Cape Boeo, Marsala:
+West), which form three points of a
+triangle.^{[[#cite_note-Radicini,_Ninni_2014-185][[185]]]}
+
+** See also[[[/w/index.php?title=Sicily&action=edit&section=55][edit]]]
+   :PROPERTIES:
+   :CUSTOM_ID: see-alsoedit
+   :END:
+
+- [[/wiki/List_of_islands_of_Italy][List of islands of Italy]]
+- [[/wiki/List_of_people_from_Sicily][List of people from Sicily]]
+
+** References[[[/w/index.php?title=Sicily&action=edit&section=56][edit]]]
+   :PROPERTIES:
+   :CUSTOM_ID: referencesedit
+   :END:
+
+1.   *[[#cite_ref-1][^]]*
+     [[http://demo.istat.it/bilmens2019gen/index.html]["Statistiche
+     demografiche ISTAT"]]. Demo.istat.it.
+2.   *[[#cite_ref-2][^]]*
+     [[http://demo.istat.it/str2007/query.php?lingua=ita&Rip=S5&Reg=R19&Pro=P000&Com=&paese=A9999&submit=Tavola]["Statistiche
+     demografiche ISTAT"]]. Demo.istat.it. Retrieved 23 April 2010.
+3.   ^ [[#cite_ref-ec.europa.eu_3-0][^{/*a*/}]]
+     [[#cite_ref-ec.europa.eu_3-1][^{/*b*/}]]
+     [[https://ec.europa.eu/eurostat/documents/2995521/10474907/1-05032020-AP-EN.pdf/81807e19-e4c8-2e53-c98a-933f5bf30f58]["Regional
+     GDP per capita ranged from 30% to 263% of the EU average in 2018"]]
+     (Press release). ec.europa.eu. Retrieved 1 September 2020.
+4.   *[[#cite_ref-GlobalDataLab_4-0][^]]*
+     [[https://hdi.globaldatalab.org/areadata/shdi/]["Sub-national HDI
+     -- Area Database -- Global Data Lab"]]. /hdi.globaldatalab.org/.
+     Retrieved 13 September 2018.
+5.   *[[#cite_ref-5][^]]*
+     [[https://www.volcano.group.cam.ac.uk/2012/10/01/etna-aeolian-islands-2012/]["Etna
+     & Aeolian Islands 2012 -- Cambridge Volcanology"]].
+6.   *[[#cite_ref-6][^]]* Maric, Vesna (2008).
+     [[https://books.google.com/books?id=G2lJJZdUqwwC&q=sicily+12000+BC&pg=PA27][/Sicily.
+     Ediz. Inglese/]]. /google.it/.
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/9781740599696][9781740599696]].
+7.   *[[#cite_ref-7][^]]* Bain, Keith; Bramblett, Reid; Bruyn, Pippa de;
+     Nadeau, Barbie Latza; Fink, William (7 August 2006).
+     [[https://books.google.com/books?id=VTdTby1dqhMC&q=sicily+12000+BC&pg=PA544][/Pauline
+     Frommer's Italy/]]. /google.it/.
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/9780471778608][9780471778608]].
+8.   *[[#cite_ref-8][^]]* Pasquale Hamel -- L' invenzione del regno.
+     Dalla conquista normanna alla fondazione del Regnum Siciliae
+     (1061--1154)
+9.   *[[#cite_ref-9][^]]*
+     [[https://www.treccani.it/enciclopedia/sicilia_res-51b7c2ab-973b-11e5-8844-00271042e8d9]["Sicilia
+     nell'Enciclopedia Treccani"]]. /www.treccani.it/ (in Italian).
+     Retrieved 22 December 2020.
+10.  *[[#cite_ref-10][^]]*
+     [[http://www.britannica.com/EBchecked/topic/542800/Sicily][Britannica
+     -- Travel & Geography -- Sicily]] Italian Sicilia -- retrieved 11
+     May 2010.
+11.  *[[#cite_ref-11][^]]*
+     [[http://pti.regione.sicilia.it/portal/page/portal/PIR_PORTALE/PIR_LaStrutturaRegionale/PIR_AssessoratoEconomia/PIR_DipBilancioTesoro/PIR_ServizioStatistica/PIR_7486913.46118292/PIR_2651725.930937735/PIR_7954579.572264052/01_Territory.pdf]["Territory
+     and Environment"]] (PDF). Official page of the Region of Sicily.
+     Retrieved 25 March 2013. Cite journal requires =|journal==
+     ([[/wiki/Help:CS1_errors#missing_periodical][help]])
+12.  *[[#cite_ref-12][^]]*
+     [[https://web.archive.org/web/20130315140624/http://www.italiatourismonline.com/en/regions/15-sicily]["Regioni
+     d'Italia: Sicily"]]. Italia Tourism Online. Archived from
+     [[http://www.italiatourismonline.com/en/regions/15-sicily][the
+     original]] on 15 March 2013. Retrieved 25 March 2013. Cite journal
+     requires =|journal==
+     ([[/wiki/Help:CS1_errors#missing_periodical][help]])
+13.  ^ [[#cite_ref-frommers_13-0][^{/*a*/}]]
+     [[#cite_ref-frommers_13-1][^{/*b*/}]] Porter, Darwin; Prince,
+     Danforth (2009).
+     [[https://books.google.com/books?id=vZDLw0nOnfsC&pg=PA26][/Frommer's
+     Sicily/]]. Frommer's. p. 268.
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-0-470-39899-9][978-0-470-39899-9]].
+14.  *[[#cite_ref-14][^]]* Barberi, F.; Civetta, L.; Gasparini, P.;
+     Innocenti, F.; Scandone, R.; Villari, L. (1 May 1974).
+     [[https://www.sciencedirect.com/science/article/abs/pii/0012821X74900727]["Evolution
+     of a section of the Africa-Europe plate boundary: Paleomagnetic and
+     volcanological evidence from Sicily"]]. /Earth and Planetary
+     Science Letters/. *22* (2): 123--132.
+     [[/wiki/Bibcode_(identifier)][Bibcode]]:[[https://ui.adsabs.harvard.edu/abs/1974E&PSL..22..123B][1974E&PSL..22..123B]].
+     [[/wiki/Doi_(identifier)][doi]]:[[https://doi.org/10.1016%2F0012-821X%2874%2990072-7][10.1016/0012-821X(74)90072-7]].
+     [[/wiki/ISSN_(identifier)][ISSN]] [[//www.worldcat.org/issn/0012-821X][0012-821X]].
+15.  *[[#cite_ref-15][^]]* Thomaidis, Konstantinos; Troll, Valentin R.;
+     Deegan, Frances M.; Freda, Carmela; Corsaro, Rosa A.; Behncke,
+     Boris; Rafailidis, Savvas (2021).
+     [[https://onlinelibrary.wiley.com/doi/abs/10.1111/gto.12362]["A
+     message from the 'underground forge of the gods': history and
+     current eruptions at Mt Etna"]]. /Geology Today/. *37* (4):
+     141--149.
+     [[/wiki/Doi_(identifier)][doi]]:[[https://doi.org/10.1111%2Fgto.12362][10.1111/gto.12362]].
+     [[/wiki/ISSN_(identifier)][ISSN]] [[//www.worldcat.org/issn/1365-2451][1365-2451]].
+     [[/wiki/S2CID_(identifier)][S2CID]] [[https://api.semanticscholar.org/CorpusID:238802288][238802288]].
+16.  *[[#cite_ref-16][^]]*
+     [[http://www.osservatorioacque.it/dati/ANNALI/A_1999/PI_80.HTML]["Agenzia
+     Regionale per i Rifiuti e le Acque"]]. Osservatorio delle Acque.
+     Retrieved 14 October 2010.
+17.  *[[#cite_ref-17][^]]*
+     [[https://wmo.asu.edu/content/europe-highest-temperature]["WMO
+     Region VI (Europe, Continent only): Highest Temperature"]]. World
+     Meteorological Organization. Retrieved 18 December 2016.
+18.  *[[#cite_ref-18][^]]* Trabia, Carlo (2002).
+     [[http://www.bestofsicily.com/mag/art51.htm]["A Sicilian
+     Desert?"]]. Best of Sicily Magazine.
+19.  *[[#cite_ref-19][^]]*
+     [[https://web.archive.org/web/20061018214824/http://www.barillaus.com/Chestnut_Dinner__Intro.aspx]["Chestnut
+     Dinner in the Mountains of Italy"]]. /Barilla online/. 2005.
+     Archived from
+     [[http://www.barillaus.com/Chestnut_Dinner__Intro.aspx][the
+     original]] on 18 October 2006. Retrieved 22 December 2006.
+20.  *[[#cite_ref-20][^]]*
+     [[http://www.insicilia.org/flora-vegetali-fauna-animali-sicilia/80.htm][Sicilia,
+     flora e fauna-Specie vegetali e animali in Sicilia]].
+     Insicilia.org. Retrieved on 18 December 2012.
+21.  *[[#cite_ref-21][^]]*
+     [[http://www.best-italian-wine.com/best-beach-in-Sicily.html][''Riserva
+     dello Zingaro''|]]. Best-italian-wine.com. Retrieved on 18
+     December 2012.
+22.  *[[#cite_ref-22][^]]* Cassell's Latin Dictionary, Marchant, J.R.V,
+     & Charles, Joseph F., (Eds.), Revised Edition, 1928
+23.  *[[#cite_ref-23][^]]* "Sicilian Culture: The Folklore, Legends &
+     Traditions: Trinacria." Sicilian Culture: The Folklore, Legends &
+     Traditions: Trinacria. N.p., n.d. Web. 9 November 2014. "Sicily."
+     Sicily. N.p., n.d. Web. 10 November 2014.
+24.  *[[#cite_ref-24][^]]*
+     [[https://web.archive.org/web/20131231001248/http://www.experiencefestival.com/a/Sicily_-_History/id/5462681]["Sicily:
+     Encyclopedia II -- Sicily -- History"]]. Experience Festival. 7
+     October 2007. Archived from
+     [[http://www.experiencefestival.com/a/Sicily_-_History/id/5462681][the
+     original]] on 31 December 2013. Retrieved 18 March 2016.
+25.  *[[#cite_ref-25][^]]*
+     [[https://books.google.com/books?id=A7kGAAAAQAAJ&q=segre+sicano&pg=PA11]["Aapologetico
+     de la literatura española contra los opiniones"]]. Ensayo
+     historico. 7 October 2007.
+26.  *[[#cite_ref-26][^]]* Fine, John Van Antwerp (1983).
+     [[https://archive.org/details/ancientgreeks00john][/The Ancient
+     Greeks: A Critical History/]]. Harvard University Press.
+     p. [[https://archive.org/details/ancientgreeks00john/page/72][72]].
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/9780674033146][9780674033146]].
+     "most scholars now believe that the sicans and Sicels, as well as
+     the."
+27.  ^ [[#cite_ref-sicanian_27-0][^{/*a*/}]]
+     [[#cite_ref-sicanian_27-1][^{/*b*/}]]
+     [[#cite_ref-sicanian_27-2][^{/*c*/}]]
+     [[http://www.bestofsicily.com/mag/art141.htm]["Sicilian Peoples:
+     The Sicanians"]]. Best of Sicily. 7 October 2007.
+28.  *[[#cite_ref-28][^]]*
+     [[http://www.britannica.com/eb/article-9067615/Sicani]["Sicani"]].
+     /Britannica.com/. 7 October 2007.
+29.  *[[#cite_ref-Piccolo-dolmens_29-0][^]]* Piccolo, Salvatore;
+     Darvill, Timothy (2013).
+     [[https://www.worldcat.org/search?qt=wikipedia&q=isbn%3A9780956510624][/Ancient
+     Stones, The Prehistoric Dolmens of Sicily/]]. Thornham/Norfolk:
+     Brazen Head Publishing.
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/9780956510624][9780956510624]].
+     Retrieved 17 October 2013.
+30.  *[[#cite_ref-30][^]]* Piccolo, Salvatore; Woodhouse, Jean (2013).
+     [[https://books.google.com/books?id=4i6JmwEACAAJ][/Ancient Stones:
+     The Prehistoric Dolmens of Sicily/]].
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/9780956510624][9780956510624]].
+31.  ^ [[#cite_ref-catholi_31-0][^{/*a*/}]]
+     [[#cite_ref-catholi_31-1][^{/*b*/}]]
+     [[#cite_ref-catholi_31-2][^{/*c*/}]] Herbermann, Charles, ed.
+     (1913).
+     [[https://en.wikisource.org/wiki/Catholic_Encyclopedia_(1913)/Sicily]["Sicily" ]].
+     /[[/wiki/Catholic_Encyclopedia][Catholic Encyclopedia]]/. New York:
+     Robert Appleton Company.
+32.  *[[#cite_ref-32][^]]* E. Zuppardo-S.Piccolo, /Terra Mater: sulle
+     sponde del Gela greco/, Betania Ed., Caltanissetta 2005
+33.  ^ [[#cite_ref-knowital_33-0][^{/*a*/}]]
+     [[#cite_ref-knowital_33-1][^{/*b*/}]]
+     [[#cite_ref-knowital_33-2][^{/*c*/}]]
+     [[https://web.archive.org/web/20030801195242/http://knowital.com/history/sicily/sicily-history.html]["History
+     of Sicily"]]. knowital.com. 7 October 2007. Archived from
+     [[http://knowital.com/history/sicily/sicily-history.html][the
+     original]] on 1 August 2003.
+34.  *[[#cite_ref-34][^]]*
+     [[http://italiansrus.com/articles/temples.htm]["Valley of the
+     Temples"]]. Italiansrus.com. 7 October 2007.
+35.  *[[#cite_ref-35][^]]*
+     [[https://www.livius.org/su-sz/syracuse/siege.html]["Siege of
+     Syracuse"]]. Livius.org. 7 October 2007.
+36.  *[[#cite_ref-36][^]]* Miles, Richard (2010). /Carthage Must Be
+     Destroyed: The Rise and Fall of an Ancient Civilization/. New York:
+     Viking.
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-0-143-12129-9][978-0-143-12129-9]].
+37.  *[[#cite_ref-hutch_37-0][^]]*
+     [[https://web.archive.org/web/20081202051716/http://encyclopedia.farlex.com/Sicily]["Sicily"]].
+     [[/wiki/Hutchinson_Encyclopedia][Hutchinson Encyclopedia]]. 7
+     October 2007. Archived from
+     [[http://encyclopedia.farlex.com/Sicily][the original]] on 2
+     December 2008.
+38.  *[[#cite_ref-38][^]]* Miles, Richard (2010). /Carthage Must Be
+     Destroyed/. New York: Viking.
+39.  *[[#cite_ref-39][^]]*
+     [[https://web.archive.org/web/20071218214904/http://www.10000bc.tv/]["Sensational
+     Sicily"]]. 10000BC.tv. 7 October 2007. Archived from
+     [[http://www.10000bc.tv/][the original]] on 18 December 2007.
+     [[https://web.][Alt URL]]
+40.  *[[#cite_ref-40][^]]* Stockton, David (1971).
+     [[https://books.google.com/books?id=][JqsqlajAPCoC&q=in+verrem+cicero+verres&pg=PA43
+     /Cicero: A Political Biography/]] Check =|url== value
+     ([[/wiki/Help:CS1_errors#bad_url][help]]). Oxford University Press.
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-0-19-872033-1][978-0-19-872033-1]].
+41.  ^ [[#cite_ref-earlymediev_41-0][^{/*a*/}]]
+     [[#cite_ref-earlymediev_41-1][^{/*b*/}]]
+     [[http://www.bestofsicily.com/history2.htm]["Early & Medieval
+     History"]]. BestofSicily.com. 7 October 2007.
+42.  ^ [[#cite_ref-jpriv_42-0][^{/*a*/}]]
+     [[#cite_ref-jpriv_42-1][^{/*b*/}]]
+     [[#cite_ref-jpriv_42-2][^{/*c*/}]] Privitera, John (2002).
+     [[https://archive.org/details/sicilyillustrate00priv][/Sicily: An
+     Illustrated History/]]. Hippocrene Books.
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-0-7818-0909-2][978-0-7818-0909-2]].
+43.  *[[#cite_ref-43][^]]* J.B. Bury, History of the Later Roman Empire,
+     1958 edition, p. 254
+44.  *[[#cite_ref-44][^]]* Bury, p. 327.
+45.  *[[#cite_ref-45][^]]* Bury, pp. 410, 425.
+46.  *[[#cite_ref-46][^]]*
+     [[http://www.britannica.com/eb/article-9026834/Theodoric#949802.hook]["Theodoric"]].
+     /[[/wiki/Encyclop%C3%A6dia_Britannica][Encyclopædia Britannica]]/.
+     7 October 2007.
+47.  *[[#cite_ref-47][^]]* Frassetto, Michael (2003), /Encyclopedia of
+     Barbarian Europe: Society in Transformation/. Santa Barbara, CA, p.
+     335: ABC-CLIO.
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-1-57607-263-9][978-1-57607-263-9]].
+48.  *[[#cite_ref-48][^]]* Hearder, Harry (25 January 1991).
+     [[https://archive.org/details/italyshorthistor00hear][/Italy: A
+     Short History/]]. Cambridge University Press.
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-0-521-33719-9][978-0-521-33719-9]].
+49.  ^ [[#cite_ref-hisnet_49-0][^{/*a*/}]]
+     [[#cite_ref-hisnet_49-1][^{/*b*/}]]
+     [[https://web.archive.org/web/20071102223028/http://www.historynet.com/magazines/military_history/3025271.html]["Gothic
+     War: Byzantine Count Belisarius Retakes Rome"]]. Historynet.com. 7
+     October 2007. Archived from
+     [[http://www.historynet.com/magazines/military_history/3025271.html][the
+     original]] on 2 November 2007.
+50.  *[[#cite_ref-50][^]]* [[/wiki/Alexander_Kazhdan][Kazhdan,
+     Alexander]], ed. (1991).
+     [[/wiki/Oxford_Dictionary_of_Byzantium][/Oxford Dictionary of
+     Byzantium/]]. Oxford University Press. p. 1892.
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-0-19-504652-6][978-0-19-504652-6]].
+51.  *[[#cite_ref-51][^]]* Davis-Secord, Sarah (2017). "Sicily in the
+     Early Medieval Mediterranean". /Where Three Worlds Met: Sicily in
+     the Early Medieval Mediterranean/. Ithaca: Cornell University
+     Press. p. 79.
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/9781501704642][9781501704642]].
+     [[/wiki/JSTOR_(identifier)][JSTOR]] [[//www.jstor.org/stable/10.7591/j.ctt1qv5qfp][10.7591/j.ctt1qv5qfp]].
+52.  ^ [[#cite_ref-travsyrac_52-0][^{/*a*/}]]
+     [[#cite_ref-travsyrac_52-1][^{/*b*/}]]
+     [[http://www.travelmapofsicily.com/syracuse.html]["Syracuse,
+     Sicily"]]. TravelMapofSicily.com. 7 October 2007.
+53.  *[[#cite_ref-53][^]]*
+     [[http://www.bestofsicily.com/mag/art165.htm]["Sicilian Peoples:
+     The Byzantines"]]. BestofSicily.com. 7 October 2007.
+54.  *[[#cite_ref-54][^]]* Treadgold. History of the Byzantine State,
+     pp. 354--355.
+55.  ^ [[#cite_ref-stan_55-0][^{/*a*/}]]
+     [[#cite_ref-stan_55-1][^{/*b*/}]] [[#cite_ref-stan_55-2][^{/*c*/}]]
+     [[#cite_ref-stan_55-3][^{/*d*/}]]
+     [[https://web.archive.org/web/20070609094555/http://archaeology.stanford.edu/MountPolizzo/handbookPDF/MPHandbook5.pdf]["Brief
+     history of Sicily"]] (PDF). Archaeology.Stanford.edu. 7
+     October 2007. Archived from
+     [[http://archaeology.stanford.edu/MountPolizzo/handbookPDF/MPHandbook5.pdf][the
+     original]] (PDF) on 9 June 2007.
+56.  *[[#cite_ref-56][^]]* Raphael Patai, /[[/wiki/The_Jewish_Mind][The
+     Jewish Mind]]/, Scribners, 1977, p. 155--6
+57.  ^
+     [[#cite_ref-Boise_State_University_Sicily_under_the_ormans_57-0][^{/*a*/}]]
+     [[#cite_ref-Boise_State_University_Sicily_under_the_ormans_57-1][^{/*b*/}]]
+     [[https://web.archive.org/web/20091001173814/http://www.boisestate.edu/courses/crusades/Europe/italy/02.shtml]["Italy
+     during the Crusades -- Sicily under the Normans"]] -- History of
+     the Crusades -- Boise State University -- Retrieved 15 July 2011.
+58.  ^ [[#cite_ref-initalymag_58-0][^{/*a*/}]]
+     [[#cite_ref-initalymag_58-1][^{/*b*/}]]
+     [[https://web.archive.org/web/20160727225426/http://www.initaly.com/regions/sicily/chronol.htm]["Chronological
+     -- Historical Table of Sicily"]]. In Italy Magazine. 7
+     October 2007. Archived from
+     [[http://www.initaly.com/regions/sicily/chronol.htm][the original]]
+     on 27 July 2016. Retrieved 12 December 2007.
+59.  *[[#cite_ref-59][^]]* Johns, Jeremy (2002). /Arabic Administration
+     in Norman Sicily: The Royal Diwan/. Cambridge studies in Islamic
+     civilization. Cambridge, England: Cambridge University Press.
+     pp. [[https://books.google.com/books?id=pXXYfJ9woRwC&pg=PA249][249--250]].
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-0-521-81692-2][978-0-521-81692-2]].
+60.  *[[#cite_ref-60][^]]* Takayama, Hiroshi (1993). /The Administration
+     of the Norman Kingdom of Sicily/. Leiden, the Netherlands: E.J.
+     Brill.
+     p. [[https://books.google.com/books?id=aXZe71Z4nEkC&pg=PA123][123]].
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-90-04-09920-3][978-90-04-09920-3]].
+61.  *[[#cite_ref-malta_61-0][^]]*
+     [[http://www.aboutmalta.com/history/time-Line.htm]["Classical and
+     Medieval Malta (60--1530)"]]. AboutMalta.com. 7 October 2007.
+62.  *[[#cite_ref-62][^]]* [[/wiki/John_Julius_Norwich][Norwich, John
+     Julius]] (1992). /The Normans in Sicily: The Normans in the South
+     1016--1130 and the Kingdom in the Sun 1130--1194/. Penguin Global.
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-0-14-015212-8][978-0-14-015212-8]].
+63.  ^ [[#cite_ref-Advanced_Studies_in_Cultural_History_63-0][^{/*a*/}]]
+     [[#cite_ref-Advanced_Studies_in_Cultural_History_63-1][^{/*b*/}]]
+     [[http://www.interamericaninstitute.org/norman_sicily.htm]["Norman
+     Sicily of the 12th Century"]] -- Inter-American Institute for
+     Advanced Studies in Cultural History -- Retrieved 15 July 2011.
+64.  ^ [[#cite_ref-Loud,_G._A._2007_494_64-0][^{/*a*/}]]
+     [[#cite_ref-Loud,_G._A._2007_494_64-1][^{/*b*/}]] Loud, G. A.
+     (2007). [[https://archive.org/details/latinchurchnorma00loud][/The
+     Latin Church in Norman Italy/]]. Cambridge University Press.
+     p. [[https://archive.org/details/latinchurchnorma00loud/page/n512][494]].
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-0-521-25551-6][978-0-521-25551-6]].
+     "[[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/0-521-25551-1][0-521-25551-1]]"
+     "At the end of the twelfth-century  ... While in Apulia Greeks were
+     in a majority -- and indeed present in any numbers at all -- only
+     in the Salento peninsula in the extreme south, at the time of the
+     conquest they had an overwhelming preponderance in Lucaina and
+     central and southern Calabria, as well as comprising anything up to
+     a third of the population of Sicily, concentrated especially in the
+     north-east of the island, the Val Demone."
+65.  *[[#cite_ref-normansbestof_65-0][^]]*
+     [[http://www.bestofsicily.com/mag/art171.htm]["Sicilian Peoples:
+     The Normans"]]. BestofSicily.com. 7 October 2007.
+66.  ^ [[#cite_ref-dieli_66-0][^{/*a*/}]]
+     [[#cite_ref-dieli_66-1][^{/*b*/}]]
+     [[#cite_ref-dieli_66-2][^{/*c*/}]]
+     [[#cite_ref-dieli_66-3][^{/*d*/}]]
+     [[#cite_ref-dieli_66-4][^{/*e*/}]]
+     [[#cite_ref-dieli_66-5][^{/*f*/}]] Dieli, Art (8 July 2015).
+     [[http://www.dieli.net/SicilyPage/History/SicilianHist.html]["Sicilian
+     History: An Abbreviated Chronology"]]. Dieli.net.
+67.  *[[#cite_ref-67][^]]* Taylor, Julie (19 August 2003).
+     [[https://books.google.com/books?id=weluAAAAQBAJ][/Muslims in
+     Medieval Italy: The Colony at Lucera/]]. Lexington Books.
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/9780739157978][9780739157978]]
+     -- via Google Books.
+68.  *[[#cite_ref-68][^]]*
+     [[http://historymedren.about.com/library/weekly/aapmaps4.htm][The
+     Spread of the Black Death through Europe]]. Medieval History.
+69.  *[[#cite_ref-69][^]]*
+     "[[http://news.bbc.co.uk/2/low/europe/2381585.stm][Italy's
+     earthquake history]]". BBC News. 31 October 2002.
+70.  *[[#cite_ref-70][^]]* Rees Davies,
+     [[https://www.bbc.co.uk/history/british/empire_seapower/white_slaves_02.shtml][British
+     Slaves on the Barbary Coast]], [[/wiki/BBC][BBC]], 1 July 2003
+71.  *[[#cite_ref-71][^]]*
+     "/[[https://books.google.com/books?id=5q9zcB3JS40C&pg=PR14&dq&hl=en#v=onepage&q=&f=false][Christian
+     Slaves, Muslim Masters: White Slavery in the Mediterranean, the
+     Barbary Coast and Italy, 1500--1800]]/". Robert Davis (2004)
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/1-4039-4551-9][1-4039-4551-9]]
+72.  *[[#cite_ref-72][^]]*
+     [[http://www.heraldica.org/topics/france/utrecht.htm]["The Treaties
+     of Utrecht (1713)"]]. Heraldica.org. 7 October 2007.
+73.  *[[#cite_ref-73][^]]*
+     [[https://web.archive.org/web/20030804170901/http://www.realcasadiborbone.it/uk/archiviostorico/cs_04.htm]["Charles
+     of Bourbon -- the restorer of the Kingdom of Naples"]].
+     RealCasaDiBorbone.it. 7 October 2007. Archived from
+     [[http://www.realcasadiborbone.it/uk/archiviostorico/cs_04.htm][the
+     original]] on 4 August 2003.
+74.  *[[#cite_ref-74][^]]*
+     [[http://www.clash-of-steel.co.uk/pages/battle_details.php?battle=CAMPOTENES01]["Campo
+     Tenese"]]. Clash-of-Steel.co.uk. 7 October 2007.
+75.  *[[#cite_ref-75][^]]*
+     [[http://www.treccani.it/enciclopedia/regno-delle-due-sicilie/][Regno
+     Delle Due Sicilie nell'Enciclopedia Treccani]]. Treccani.it.
+     Retrieved on 18 December 2012.
+76.  ^ [[#cite_ref-modern_76-0][^{/*a*/}]]
+     [[#cite_ref-modern_76-1][^{/*b*/}]]
+     [[#cite_ref-modern_76-2][^{/*c*/}]]
+     [[https://web.archive.org/web/20101127225428/http://oah.org/pubs/magazine/migrations/townsend.html]["Italians
+     around the World: Teaching Italian Migration from a Transnational
+     Perspective"]]. OAH.org. 7 October 2007. Archived from
+     [[http://www.oah.org/pubs/magazine/migrations/townsend.html][the
+     original]] on 27 November 2010.
+77.  *[[#cite_ref-77][^]]*
+     [[http://www.britannica.com/EBchecked/topic/542800/Sicily][Sicily
+     (island, Italy) -- Britannica Online Encyclopaedia]].
+     Britannica.com. Retrieved on 18 December 2012.
+78.  *[[#cite_ref-78][^]]*
+     [[https://web.archive.org/web/20071018230534/http://www.geocities.com/capitolHill/rotunda/2209/Sicily.html]["Sicily"]].
+     Capitol Hill. 7 October 2007. Archived from
+     [[http://www.geocities.com/capitolHill/rotunda/2209/Sicily.html][the
+     original]] on 18 October 2007.
+79.  *[[#cite_ref-79][^]]*
+     [[http://www.britannica.com/eb/article-9033791/fascio-siciliano]["fascio
+     siciliano"]]. /[[/wiki/Encyclop%C3%A6dia_Britannica][Encyclopædia
+     Britannica]]/. 7 October 2007.
+80.  *[[#cite_ref-80][^]]*
+     "[[http://www.britannica.com/EBchecked/topic/1483443/Messina-earthquake-and-tsunami][Messina
+     earthquake and tsunami]]". Britannica Online Encyclopedia.
+81.  *[[#cite_ref-81][^]]*
+     [[https://web.archive.org/web/20071111034455/http://www.carabinieri.it/Internet/Arma/Ieri/Storia/Vista%2Bda/Fascicolo%2B22/01_Fascicolo%2B22.htm][Arma
+     dei Carabinieri -- Home -- L'Arma -- Ieri -- Storia -- Vista da --
+     Fascicolo 22]]. Carabinieri.it. Retrieved on 18 December 2012.
+82.  *[[#cite_ref-autogenerated1_82-0][^]]*
+     [[http://www.bestofsicily.com/history3.htm]["Modern Sicilian
+     History & Society"]]. BestofSicily.com.
+83.  *[[#cite_ref-83][^]]*
+     [[http://www.grifasi-sicilia.com/regione_sicilia_gbr.html]["Sicily
+     autonomy"]]. Grifasi-Sicilia.com. 7 October 2007.
+84.  *[[#cite_ref-84][^]]*
+     [[https://web.archive.org/web/20130524044958/http://www.storicamente.org/quadstor1/ch09.html]["Le
+     spinte e i ritorni": gli anni delle riforme per lo sviluppo in
+     Sicilia (1947--1967)"]]. /Storicamente.org/ (in Italian). Archived
+     from [[http://www.storicamente.org/quadstor1/ch09.html][the
+     original]] on 24 May 2013. Retrieved 18 December 2012.
+85.  *[[#cite_ref-85][^]]* [[http://www.scudit.net/mdfalcone.htm]["Due
+     eroi italiani -- Materiali didattici di Scuola d'Italiano Roma a
+     cura di Roberto Tartaglione"]]. /Scudit.net/ (in Italian). 11 April
+     2004. Retrieved 18 December 2012.
+86.  *[[#cite_ref-86][^]]*
+     [[http://www.britannica.com/eb/article-27778/Italy#319101.hook]["Italy
+     -- Land Reforms"]].
+     /[[/wiki/Encyclop%C3%A6dia_Britannica][Encyclopædia Britannica]]/.
+     7 October 2007.
+87.  *[[#cite_ref-87][^]]*
+     [[http://www.istat.it/it/sicilia/dati?q=gettable&dataset=DCCV_TAXDISOCCU&dim=120,6,1,0,28,12,3,0,0&lang=2&tr=0&te=1]["Sicilia"]].
+     /Istat.it/ (in Italian). Retrieved 18 December 2012.
+88.  *[[#cite_ref-88][^]]* Pantaleone, Wladimir (4 December 2018).
+     [[https://globalnews.ca/news/4727672/italy-police-arrest-alleged-new-mafia-boss-in-sicily/]["Italy
+     police arrest alleged new mafia boss in Sicily"]]. /Global News/.
+     Retrieved 22 June 2021.
+89.  *[[#cite_ref-89][^]]* Messia, Hada; Kent, Lauren (17 July 2019).
+     [[https://www.cnn.com/2019/07/17/europe/mafia-arrests-fbi-italy-intl/index.html]["19
+     mafia suspects arrested in joint transatlantic raids"]]. /CNN/.
+     Retrieved 22 June 2021.
+90.  *[[#cite_ref-90][^]]* Giuffrida, Angela (17 July 2019).
+     [[https://www.theguardian.com/world/2019/jul/17/fbi-mafia-arrests-us-italy-inzerillo-gambino]["FBI
+     and Italian police arrest 19 people in Sicily and US in mafia
+     investigation"]]. /The Guardian/. Retrieved 22 June 2021.
+91.  *[[#cite_ref-91][^]]*
+     [[http://demo.istat.it/str2014/query.php?lingua=ita&Rip=S5&Reg=R19&Pro=P000&Com=&paese=A9999&submit=Tavola]["Statistiche
+     demografiche ISTAT"]]. Demo.istat.it. Retrieved 29 May 2016.
+92.  *[[#cite_ref-92][^]]*
+     [[https://web.archive.org/web/20191019020626/http://www.demo.istat.it/bilmens2017gen/index.html]["Bilancio
+     demografico anno 2017 Regione: Sicilia"]]. demo.istat.it. 2017.
+     Archived from
+     [[http://www.demo.istat.it/bilmens2017gen/index.html][the
+     original]] on 19 October 2019. Retrieved 14 September 2017.
+93.  *[[#cite_ref-93][^]]*
+     [[http://www.camera.it/parlam/leggi/99482l.htm]["Legge 482"]].
+     /camera.it/.
+94.  *[[#cite_ref-94][^]]*
+     [[http://www.corriere.it/Primo_Piano/Cronache/2006/01_Gennaio/17/cattolici.shtml]["Corriere
+     della Sera -- Italia, quasi l'88% si proclama cattolico"]].
+     /corriere.it/.
+95.  *[[#cite_ref-95][^]]*
+     [[http://www.ilfattoquotidiano.it/2015/03/25/divario-nord-sud-tutto-inizio-con-lunita-ditalia-lincapacita-genetica-non-centra/1535817/]["Blog
+     | Divario Nord-Sud: tutto iniziò con l'Unità d'Italia. L'incapacità
+     'genetica' non c'entra"]]. /Il Fatto Quotidiano/. 25 March 2015.
+96.  *[[#cite_ref-96][^]]*
+     [[https://www.inuovivespri.it/2017/12/09/la-questione-meridionale-3-il-saccheggio-del-banco-delle-due-sicilie/]["La
+     questione meridionale 3/ Il saccheggio del Banco delle due
+     Sicilie"]]. 9 December 2017.
+97.  *[[#cite_ref-97][^]]*
+     [[http://www.morronedelsannio.com/sud/seconda.htm#para8]["Il Sud
+     prima dell'Unità"]]. /www.morronedelsannio.com/.
+98.  *[[#cite_ref-98][^]]*
+     [[http://www.qds.it/26323-disastro-sicilia-in-fuga-i-suoi-figli.htm]["Disastro
+     Sicilia: In fuga i suoi figli"]]. 31 October 2017.
+99.  *[[#cite_ref-99][^]]*
+     [[https://www.lasicilia.it/news/cronaca/12142/emigrazione-fuga-dalla-sicilia-ogni-anno-cancellato-un-paese-di-ventimila-abitanti.html]["Emigrazione,
+     fuga dalla Sicilia: Ogni anno cancellato un paese di ventimila
+     abitanti"]].
+100. *[[#cite_ref-100][^]]*
+     [[http://www.citypopulation.de/Italy-Sicilia.html]["Sicilia /
+     Sicily (Italy): Provinces, Major Cities & Communes -- Population
+     Statistics, Maps, Charts, Weather and Web Information"]].
+     /www.citypopulation.de/. Retrieved 28 April 2019.
+101. *[[#cite_ref-101][^]]* Nebel, A; Filon, D; Brinkmann, B; Majumder,
+     P; Faerman, M; Oppenheim, A (2001).
+     [[//www.ncbi.nlm.nih.gov/pmc/articles/PMC1274378]["The Y Chromosome
+     Pool of Jews as Part of the Genetic Landscape of the Middle
+     East"]]. /The American Journal of Human Genetics/. *69* (5):
+     1095--112.
+     [[/wiki/Doi_(identifier)][doi]]:[[https://doi.org/10.1086%2F324070][10.1086/324070]].
+     [[/wiki/PMC_(identifier)][PMC]] [[//www.ncbi.nlm.nih.gov/pmc/articles/PMC1274378][1274378]].
+     [[/wiki/PMID_(identifier)][PMID]] [[//pubmed.ncbi.nlm.nih.gov/11573163][11573163]].
+102. *[[#cite_ref-102][^]]* Peppe Cuva (12 May 2012).
+     [[https://archive.today/20130419105715/http://www.latestatanews.it/index.php?option=com_content&view=article&id=333:sicilia-lex-roccaforte-del-centro-destra&catid=8:politica&Itemid=11][Sicilia,
+     l'ex roccaforte del centro-destra]]. Latestatanews.it. Retrieved on
+     18 December 2012.
+103. *[[#cite_ref-103][^]]*
+     [[http://demo.istat.it/bilmens2011gen/index.html][Population May
+     2011, data from Demo Istat]]
+     [[https://web.archive.org/web/20110701194349/http://demo.istat.it/bilmens2011gen/index.html][Archived]]
+     1 July 2011 at the [[/wiki/Wayback_Machine][Wayback Machine]].
+     Demo.istat.it. Retrieved on 18 December 2012.
+104. *[[#cite_ref-104][^]]*
+     [[http://sicilyweb.com/economia/agricoltura.htm][Economia della
+     Sicilia: agricoltura]]. Sicilyweb.com. Retrieved on 18
+     December 2012.
+105. *[[#cite_ref-105][^]]*
+     [[http://www.ilsole24ore.com/art/commenti-e-idee/2011-02-23/lindustria-sicilia-cosi-antica-082349.shtml][L'industria
+     in Sicilia così antica e moderna]]. Il Sole 24 ORE (23 February
+     2011). Retrieved on 18 December 2012.
+106. *[[#cite_ref-106][^]]*
+     [[https://web.archive.org/web/20110320083101/http://www.treccani.it/enciclopedia/sicilia/][Sicilia:
+     Congiuntura economica]].Treccani.it. Retrieved on 19 December 2012.
+107. *[[#cite_ref-107][^]]*
+     [[http://www.strumentires.com/index.php?option=com_content&view=article&id=97:investire-nel-turismo-di-qualita-e-negli-eventi-in-sicilia&catid=4:economia-siciliana&Itemid=12][Investire
+     nel turismo di qualità e negli eventi in Sicilia]].
+     Strumentires.com. Retrieved on 18 December 2012.
+108. *[[#cite_ref-108][^]]* (in Italian)
+     [[http://www.istat.it/it/archivio/75111][Conti economici
+     regionali]]. Istat.it. Retrieved on 18 December 2012.
+109. *[[#cite_ref-109][^]]*
+     [[http://www.uonna.it/mafia-mappa-sicilia.htm][mafia in sicilia: la
+     mappa del viminale]]. Uonna.it. Retrieved on 18 December 2012.
+110. *[[#cite_ref-110][^]]*
+     [[http://www.sicilyontour.com/economia.htm][Sicilia: L'Economia]].
+     SicilyOnTour.com. Retrieved on 18 December 2012.
+111. *[[#cite_ref-111][^]]*
+     [[http://www.pistacchiodibronte.it/][Pistacchio di Bronte D.O.P]].
+     Pistacchiodibronte.it. Retrieved on 18 December 2012.
+112. *[[#cite_ref-112][^]]*
+     [[https://archive.today/20130218132519/http://www.tavolaegusto.it/index.php?option=com_content&view=article&id=781:fico-dindia-delletna-dop&catid=93:igpviniaceti&Itemid=58][Fico
+     d'India dell'Etna dop]]. Tavolaegusto.it. Retrieved on 18
+     December 2012.
+113. ^ [[#cite_ref-insicilia_113-0][^{/*a*/}]]
+     [[#cite_ref-insicilia_113-1][^{/*b*/}]]
+     [[http://www.insicilia.org/economia-sicilia/65.htm][economia-sicilia]].
+     insicilia.org. Retrieved on 19 December 2012.
+114. *[[#cite_ref-114][^]]*
+     [[https://web.archive.org/web/20120504004504/http://www.siciliaonline.it/index.php?option=com_content&view=article&id=112%3Amiele-ibleo&catid=42%3Aaltri-prodotti&Itemid=40][miele
+     ibleo]]. siciliaonline.it. Retrieved on 19 December 2012.
+115. *[[#cite_ref-115][^]]*
+     [[http://www.inumeridelvino.it/2011/05/produzione-vino-in-italia-nel-2010-fonte-istat.html][Produzione
+     vino in Italia nel 2010 -- fonte: ISTAT | I numeri del vino]].
+     Inumeridelvino.it (30 May 2011). Retrieved on 18 December 2012.
+116. *[[#cite_ref-Bottlenotes_116-0][^]]*
+     [[https://web.archive.org/web/20090822151242/http://www.bottlenotes.com/dailysip/regional-spotlight/sicily-fazio-marsala-nero-davola-damaschino]["Sicily:
+     An Island You Can't Refuse"]]. bottlenotes.com. 18 August 2009.
+     Archived from
+     [[http://www.bottlenotes.com/dailysip/regional-spotlight/sicily-fazio-marsala-nero-davola-damaschino][the
+     original]] on 22 August 2009. Retrieved 30 November 2009.
+117. *[[#cite_ref-117][^]]*
+     [[http://www.sicilyontour.com/i_vini_siciliani.htm][Vini
+     siciliani]]. sicilyontour.com. Retrieved on 19 December 2012.
+118. ^ [[#cite_ref-esploriamo.com_118-0][^{/*a*/}]]
+     [[#cite_ref-esploriamo.com_118-1][^{/*b*/}]] (in Italian)
+     [[https://web.archive.org/web/20120511014720/http://www.esploriamo.com/SICILIA/Sicilia_Economia.html][Economia
+     Regione Siciliana]]. Esploriamo.com. Retrieved on 18 December 2012.
+119. *[[#cite_ref-119][^]]* [[http://www.etnavalley.com/][Oggi la
+     chiamano Etna Valley: i progetti, le aziende, il lavoro nel
+     territorio di Catania]]
+     [[https://web.archive.org/web/20100527005056/http://www.etnavalley.com/][Archived]]
+     27 May 2010 at the [[/wiki/Wayback_Machine][Wayback Machine]].
+     Etnavalley.com (27 November 2012). Retrieved on 18 December 2012.
+120. *[[#cite_ref-120][^]]* [[http://sicilyweb.com/economia/][Economia
+     della Sicilia]]. Sicilyweb.com. Retrieved on 18 December 2012.
+121. *[[#cite_ref-121][^]]*
+     [[http://www.vivienna.it/2010/12/05/enna-il-nuovo-volto-dell%E2%80%99area-di-sviluppo-industriale/][Enna.
+     Il nuovo volto dell'Area di Sviluppo Industriale di Dittaino]].
+     Vivienna.it (22 March 1999). Retrieved on 18 December 2012.
+122. *[[#cite_ref-122][^]]*
+     [[http://www.sicilyontour.com/economia_2.htm][Sicilia:
+     L'Economia]]. SicilyOnTour.com. Retrieved on 18 December 2012.
+123. *[[#cite_ref-123][^]]*
+     [[http://www.sale-salute-benessere.it/it/articolo_1_1_199_sale/la-lavorazione-del-sale-a-trapani.html][La
+     lavorazione del Sale a Trapani, Area Sale]].
+     Sale-salute-benessere.it. Retrieved on 18 December 2012.
+124. ^ [[#cite_ref-Dati_Istat_-_Tavole_regionali_124-0][^{/*a*/}]]
+     [[#cite_ref-Dati_Istat_-_Tavole_regionali_124-1][^{/*b*/}]]
+     [[https://web.archive.org/web/20080309125317/http://www.istat.it/dati/dataset/20071004_00]["Dati
+     Istat -- Tavole regionali"]]. Istat.it. Archived from
+     [[http://www.istat.it/dati/dataset/20071004_00][the original]] on 9
+     March 2008. Retrieved 23 April 2010.
+125. *[[#cite_ref-125][^]]*
+     [[http://www.livesicilia.it/2009/07/16/in-sicilia-nel-2008-pil-a-07-per-cento/][Sicilia
+     nel 2008 PIL a '0.7%]]
+     [[https://web.archive.org/web/20120222231507/http://www.livesicilia.it/2009/07/16/in-sicilia-nel-2008-pil-a-07-per-cento/][Archived]]
+     22 February 2012 at the [[/wiki/Wayback_Machine][Wayback Machine]]
+     livesicilia.it
+126. *[[#cite_ref-126][^]]*
+     [[https://ec.europa.eu/eurostat/tgm/table.do?tab=table&init=1&language=en&pcode=tgs00010&plugin=1]["Unemployment
+     rate by NUTS 2 regions"]]. /ec.europa.eu/. Eurostat. Retrieved 19
+     September 2019.
+127. *[[#cite_ref-127][^]]*
+     [[http://dati.istat.it/Index.aspx?QueryId=20744]["Tasso di
+     disoccupazione - livello regionale"]]. /dati.istat.it/ (in
+     Italian). Retrieved 19 September 2019.
+128. *[[#cite_ref-128][^]]*
+     [[http://www.siciliaemoto.it/main.php?plc=a19palermocatania]["A 19
+     autostrada Palermo -- Catania"]]. SiciliaEMoto.it. 2 January 2008.
+129. *[[#cite_ref-129][^]]*
+     [[http://sicilia.indettaglio.it/ita/lineestradali/autostrade/a20/a20.html]["Autostrada
+     A20: Messina -- Palermo"]]. Sicilia.Indettaglio.it. 24
+     October 2007.
+130. *[[#cite_ref-130][^]]*
+     [[http://www.siciliaemoto.it/main.php?plc=a29palermotrapanimazara]["A
+     29 autostrada Palermo -- Trapani -- Mazara del Vallo"]].
+     SiciliaEMoto.it. 2 January 2008.
+131. *[[#cite_ref-131][^]]*
+     [[http://sicilia.indettaglio.it/ita/lineestradali/autostrade/a18/a18.html]["Autostrada:
+     A18 Messina -- Catania"]]. Sicilia.Indettaglio.it. 24 October 2007.
+132. *[[#cite_ref-132][^]]*
+     [[http://www.italyheaven.co.uk/sicily/transport.html]["Sicily
+     Travel and Transport"]]. ItalyHeaven.co.uk. 2 January 2008.
+133. *[[#cite_ref-133][^]]*
+     [[https://web.archive.org/web/20071114044904/http://it.geocities.com/traghetti2002/sicilia.html]["Traghetti
+     Sicily 2008"]]. Traghetti Guida. 2 January 2008. Archived from
+     [[http://it.geocities.com/traghetti2002/sicilia.html][the
+     original]] on 14 November 2007.
+134. *[[#cite_ref-134][^]]*
+     [[https://web.archive.org/web/20080812054941/http://www.virtuferries.com/index.aspx]["High
+     speed car/passenger ferry service"]]. VirtuFerries.com. 2
+     January 2008. Archived from
+     [[http://www.virtuferries.com/index.aspx][the original]] on 12
+     August 2008.
+135. *[[#cite_ref-135][^]]*
+     [[http://news.bbc.co.uk/2/hi/europe/7928949.stm][Italy revives
+     Sicily bridge plan from BBC News]]. Retrieved 8 March 2009.
+136. *[[#cite_ref-136][^]]* Hooper, John (2 January 2008).
+     [[https://www.theguardian.com/italy/story/0,,1920199,00.html]["Italian
+     MPs kill plan to bridge Sicily and mainland"]]. /Guardian.co.uk/.
+     London. Retrieved 30 March 2010.
+137. *[[#cite_ref-137][^]]* Kahn, Gabriel (10 April 2008).
+     [[https://www.wsj.com/articles/SB120777463250502755?mod=todays_us_nonsub_page_one&apl=y&r=769642]["No
+     Italian Job Takes Longer Than This Bridge"]]. /Wall Street
+     Journal/.
+138. *[[#cite_ref-138][^]]*
+     [[http://www.thegodfathertrilogy.com/gf1/gf1scene_sicily.html][The
+     Godfather. Sicilian Shooting* Locations]]. thegodfathertrilogy.com
+139. *[[#cite_ref-139][^]]*
+     [[https://whc.unesco.org/en/list/831]["Archaeological Area of
+     Agrigento -- UNESCO World Heritage Centre"]]. Whc.unesco.org. 7
+     December 1997. Retrieved 6 May 2009.
+140. *[[#cite_ref-Wilson_140-0][^]]* R. J. A. Wilson: /Piazza Armerina/.
+     In: Akiyama, Terakazu (Ed.): /The dictionary of Art. Vol. 24:
+     Pandolfini to Pitti./ Oxford 1998,
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/0-19-517068-7][0-19-517068-7]].
+141. *[[#cite_ref-141][^]]* [[https://whc.unesco.org/en/list/908]["Isole
+     Eolie (Aeolian Islands) -- UNESCO World Heritage Centre"]].
+     Whc.unesco.org. 30 November 2000. Retrieved 6 May 2009.
+142. *[[#cite_ref-142][^]]*
+     [[https://whc.unesco.org/archive/advisory_body_evaluation/1024rev.pdf][Noto
+     (Italy) -- No 1024rev]], ICOMOS, January 2002, Advisory Body
+     Evaluation, Unesco
+143. *[[#cite_ref-143][^]]*
+     [[http://www.italymagazine.com/news/mount-etna-becomes-world-heritage-site]["Mount
+     Etna Becomes a World Heritage Site"]]. Italy Magazine. 4 May 2013.
+     Cite journal requires =|journal==
+     ([[/wiki/Help:CS1_errors#missing_periodical][help]])
+144. *[[#cite_ref-144][^]]* Centre, UNESCO World Heritage.
+     [[https://whc.unesco.org/en/list/1487/]["Arab-Norman Palermo and
+     the Cathedral Churches of Cefalú and Monreale"]].
+145. *[[#cite_ref-145][^]]*
+     [[https://www.worldheritagesite.org/tentative/id/1164]["Taormina
+     and Isola Bella"]]. /World Heritage Site/.
+     [[https://web.archive.org/web/20190522180028/https://www.worldheritagesite.org/tentative/id/1164][Archived]]
+     from the original on 22 May 2019.
+146. *[[#cite_ref-146][^]]*
+     [[https://www.worldheritagesite.org/tentative/id/2029]["Mothia and
+     Libeo Island: The Phoenician-Punic Civilization in Italy"]]. /World
+     Heritage Site/.
+     [[https://web.archive.org/web/20190522181732/https://www.worldheritagesite.org/tentative/id/2029][Archived]]
+     from the original on 22 May 2019.
+147. *[[#cite_ref-147][^]]*
+     [[http://www.worldheritagesite.org/alltentative.html][All Tentative
+     Sites]]. World Heritage Site. Retrieved on 18 December 2012.
+148. *[[#cite_ref-148][^]]*
+     [[http://www.repubblica.it/cronaca/2015/04/18/news/_stretto_messina_sia_patrimonio_dell_umanita_nase_l_asse_tra_i_comuni_di_calabria_e_sicilia-112283979/][""Stretto
+     Messina sia patrimonio dell'Umanità". Nasce l'asse tra i comuni di
+     Calabria e Sicilia"]]. 18 April 2015.
+149. *[[#cite_ref-149][^]]* Kirk, Scott (2017).
+     [[https://www.academia.edu/35190827][/Sicilian Castles and Coastal
+     Towers/]]. Albuquerque: De Gruyter. pp. 318, 319--329. Retrieved 7
+     October 2019.
+150. *[[#cite_ref-150][^]]*
+     [[http://www.bestofsicily.com/mag/art149.htm]["Goethe in Sicily -
+     Best of Sicily Magazine"]]. /www.bestofsicily.com/.
+151. *[[#cite_ref-151][^]]* Calinger, Ronald S (1999). /A Contextual
+     History of Mathematics/. Prentice Hall.
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-0-02-318285-3][978-0-02-318285-3]].
+152. *[[#cite_ref-152][^]]* [[/wiki/Thomas_Noon_Talfourd][Talfourd,
+     Thomas Noon]] (1851).
+     [[https://archive.org/details/historygreeklit00blomgoog][/History
+     of Greek Literature/]]. University of Michigan.
+     p. [[https://archive.org/details/historygreeklit00blomgoog/page/n184][173]].
+     "invented comedy Epicharmus."
+153. *[[#cite_ref-153][^]]*
+     [[https://web.archive.org/web/20081207205659/http://www.greeknewsonline.com/modules.php?name=News&file=print&sid=3450]["Discovering
+     the Similarity of the Greek and Sicilian Spirit"]].
+     GreekNewsOnline.com. 2 January 2008. Archived from
+     [[http://www.greeknewsonline.com/modules.php?name=News&file=print&sid=3450][the
+     original]] on 7 December 2008.
+154. *[[#cite_ref-154][^]]*
+     [[http://www.bestofsicily.com/ceramic.htm]["Sicilian Ceramic
+     Art"]]. BestOfSicily.com. 2 January 2008.
+155. *[[#cite_ref-155][^]]* Thrall Soby, James (1969).
+     [[https://books.google.com/books?id=GtnYEBkmkIcC&q=%22father+of+surrealist+art%22&pg=PA93][/The
+     Early Chirico/]]. Ayer Co Pub.
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-0-405-00736-1][978-0-405-00736-1]].
+156. *[[#cite_ref-156][^]]* "Palazzo" /(pl. palazzi)/: is any large
+     building in a town, state or private (often much smaller than the
+     term /palace/ implies in the
+     [[/wiki/English-speaking_world][English-speaking world]]). While
+     /palazzo/ is the technically correct appellation and postal
+     address, no Sicilian aristocrat would ever use the word, instead
+     referring to his or her own house, however large, as "casa".
+     "Palazzo" followed by the family name was the term used by
+     officials, tradesmen, and delivery men. Gefen, p. 15.
+157. *[[#cite_ref-157][^]]*
+     [[https://web.archive.org/web/20120302153121/http://selectitaly.com/theater.php?product_id=6]["Teatro
+     Massimo in Palermo"]]. SelectItaly.com. 2 January 2008. Archived
+     from [[http://selectitaly.com/theater.php?product_id=6][the
+     original]] on 2 March 2012. Retrieved 18 March 2016.
+158. *[[#cite_ref-158][^]]* [[/wiki/Dagmar_Reichardt][Dagmar
+     Reichardt]], /Das phantastische Sizilien Giuseppe Bonaviris.
+     Ich-Erzähler und Raumdarstellung in seinem narrativen Werk/, edited
+     and with a foreword by Heinz Willi Wittschier, (Grundlagen der
+     Italianistik no. 2), Frankfurt a.M./Berlin/Bern et al.: Peter Lang,
+     2000,
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-3631362402][978-3631362402]].
+159. *[[#cite_ref-159][^]]* [[/wiki/Dagmar_Reichardt][Dagmar Reichardt]]
+     (Ed.), /L'Europa che comincia e finisce: la Sicilia. Approcci
+     transculturali alla letteratura siciliana. Beiträge zur
+     transkulturellen Annäherung an die sizilianische Literatur.
+     Contributions to a Transcultural Approach to Sicilian Literature/,
+     edited and with a preface by Dagmar Reichardt, in collaboration
+     with Anis Memon, Giovanni Nicoli and Ivana Paonessa, (Italien in
+     Geschichte und Gegenwart, no. 25), Frankfurt a.M./Berlin/Bern et
+     al.: Peter Lang, 2006,
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-3631549414][978-3631549414]].
+160. *[[#cite_ref-160][^]]*
+     [[https://web.archive.org/web/20050302100426/http://www.leoluca-criscione.net/HTM-DOCUMENTI/DIALetto-english%20version.htm]["The
+     Sicilian Language"]]. LeoLuca-Criscione.net. 7 October 2007.
+     Archived from
+     [[http://www.leoluca-criscione.net/HTM-DOCUMENTI/DIALetto-english%20version.htm][the
+     original]] on 2 March 2005.
+161. *[[#cite_ref-161][^]]*
+     [[https://web.archive.org/web/20121030180855/http://www3.istat.it/salastampa/comunicati/non_calendario/20070420_00/]["La
+     lingua italiana, i dialetti e le lingue straniere"]]. /istat.it/.
+     Archived from
+     [[http://www3.istat.it/salastampa/comunicati/non_calendario/20070420_00/][the
+     original]] on 30 October 2012.
+162. *[[#cite_ref-162][^]]* [[/wiki/Dante_Alighieri][Alighieri, Dante]]
+     (10 October 1996). /De vulgari eloquentia/. Cambridge University
+     Press.
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-0-521-40064-0][978-0-521-40064-0]].
+163. *[[#cite_ref-163][^]]*
+     [[http://www.policlinico.unict.it/Adroterapia/def.htm][Centro Di
+     Adroterapia Oculare]]
+     [[https://web.archive.org/web/20121122092913/http://www.policlinico.unict.it/adroterapia/def.htm][Archived]]
+     22 November 2012 at the [[/wiki/Wayback_Machine][Wayback Machine]].
+     Policlinico.unict.it. Retrieved on 18 December 2012.
+164. *[[#cite_ref-164][^]]* [[http://www.lns.infn.it/][LNS latest
+     news]]. Lns.infn.it (13 December 2012). Retrieved on 18
+     December 2012.
+165. *[[#cite_ref-165][^]]* [[http://www.noto.ira.inaf.it/][Noto VLBI
+     home page]]. Noto.ira.inaf.it. Retrieved on 18 December 2012.
+166. *[[#cite_ref-166][^]]* Hoskin, Michael (1999). /The Cambridge
+     Concise History of Astronomy/. Cambridge University press.
+     pp. 160--161.
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-0-521-57600-0][978-0-521-57600-0]].
+167. *[[#cite_ref-167][^]]* [[http://www.ct.astro.it/][Osservatorio
+     Astrofisico di Catania Homepage]]. Ct.astro.it. Retrieved on 18
+     December 2012.
+168. *[[#cite_ref-168][^]]*
+     [[http://www.enel.com/en-GB/innovation/project_technology/renewables_development/solar_power/archimede.aspx?it=-2%page=http%3a%2f%2fwww.enel.com%2fen-GB%2finnovation%2fproject_technology%2frenewables_development%2fsolar_power%2farchimede.aspx%3fit%3d-2%3fWT.mc_id%3d1707][Archimede]]
+     [[https://web.archive.org/web/20120224144722/http://www.enel.com/en-GB/innovation/project_technology/renewables_development/solar_power/archimede.aspx?it=-2%page=http:%2f%2fwww.enel.com%2fen-GB%2finnovation%2fproject_technology%2frenewables_development%2fsolar_power%2farchimede.aspx%3fit=-2%3fWT.mc_id=1707][Archived]]
+     24 February 2012 at the [[/wiki/Wayback_Machine][Wayback Machine]].
+     Enel.com. Retrieved on 18 December 2012.
+169. *[[#cite_ref-169][^]]*
+     [[https://www.theguardian.com/environment/2010/jul/22/first-molten-salt-solar-power][The
+     world's first molten salt concentrating solar power plant |
+     Environment | guardian.co.uk]]. Guardian (22 July 2010). Retrieved
+     on 18 December 2012.
+170. *[[#cite_ref-170][^]]* [[http://www.ccsem.infn.it/][Ettore Majorana
+     Foundation and Centre for Scientific Culture]]. Ccsem.infn.it (2
+     July 2012). Retrieved on 18 December 2012.
+171. *[[#cite_ref-171][^]]*
+     [[https://web.archive.org/web/20100908090945/http://www.scuolasuperiorecatania.it/include/cambialingua.php?idpagina=1&lingua=2]["/Scuola
+     Superiore di Catania/ -- Official site"]]. Archived from
+     [[http://www.scuolasuperiorecatania.it/include/cambialingua.php?idpagina=1&lingua=2][the
+     original]] on 8 September 2010.
+172. *[[#cite_ref-172][^]]*
+     [[http://info.limcollege.edu/faculty-blog/a-cosa-nostra-encounter-on-a-sicilian-vacation/]["A
+     Cosa Nostra Encounter on a Sicilian Vacation"]]. 6 June 2016.
+173. *[[#cite_ref-173][^]]*
+     [[https://web.archive.org/web/20080212090911/http://www.italianfoodforever.com/iff/articles.asp?id=55]["The
+     Foods of Sicily -- A Culinary Journey"]]. ItalianFoodForevter.com.
+     24 June 2007. Archived from
+     [[http://www.italianfoodforever.com/iff/articles.asp?id=55][the
+     original]] on 12 February 2008.
+174. *[[#cite_ref-piras_174-0][^]]* Piras, Claudia and Medagliani,
+     Eugenio (March 2007). /Culinaria Italy/. Konemann.
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-3-8331-3446-3][978-3-8331-3446-3]].
+175. ^ [[#cite_ref-authentic_175-0][^{/*a*/}]]
+     [[#cite_ref-authentic_175-1][^{/*b*/}]] Senna, Luciana (1 July
+     2005).
+     [[https://books.google.com/books?id=E7BYFRh5b7oC&q=buccellato+cannoli&pg=PA158][/Authentic
+     Sicily/]]. Touring Club of Italy.
+     [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-88-365-3403-6][978-88-365-3403-6]].
+176. *[[#cite_ref-176][^]]*
+     [[https://web.archive.org/web/20080113131834/http://fxcuisine.com/default.asp?Display=9]["Arancini,
+     the cult Sicilian dish"]]. FXCuisine.com. 24 June 2007. Archived
+     from [[http://fxcuisine.com/default.asp?Display=9][the original]]
+     on 13 January 2008.
+177. *[[#cite_ref-177][^]]*
+     [[http://www.bestofsicily.com/mag/art87.htm]["Sicilian Cheese"]].
+     BestofSicily.com. 24 June 2007.
+178. *[[#cite_ref-178][^]]*
+     [[http://www.bestofsicily.com/food.htm]["Sicilian Food and Wine"]].
+     BestofSicily.com. 24 June 2007.
+179. *[[#cite_ref-179][^]]* Maria, Anna.
+     [[http://www.annamariavolpi.com/page47.html]["Sicilian Fig
+     Cookies"]]. Anna Maria's Open Kitchen. Retrieved 29 March 2011.
+180. ^ [[#cite_ref-derbysicil_180-0][^{/*a*/}]]
+     [[#cite_ref-derbysicil_180-1][^{/*b*/}]]
+     [[#cite_ref-derbysicil_180-2][^{/*c*/}]] Bright, Richard (7 October
+     2007).
+     [[https://www.telegraph.co.uk/sport/main.jhtml?xml=/sport/2004/11/11/sfneur11.xml]["Sicilian
+     derby takes centre stage"]]. London: Telegraph.co.uk. Retrieved 30
+     March 2010.^{[/[[/wiki/Wikipedia:Link_rot][dead link]]/]}
+181. ^ [[#cite_ref-targa_181-0][^{/*a*/}]]
+     [[#cite_ref-targa_181-1][^{/*b*/}]]
+     [[https://web.archive.org/web/20101230060505/https://www.porsche.com/all/targaflorio/international.aspx]["Targa
+     Florio 1906--1977"]]. Porsche.com. 7 October 2007. Archived from
+     [[http://www.porsche.com/all/targaflorio/international.aspx][the
+     original]] on 30 December 2010. Retrieved 18 March 2016.
+182. *[[#cite_ref-182][^]]* UNESCO Culture Sector.
+     [[http://www.unesco.org/culture/ich/index.php?pg=00011&RL=00011]["El
+     teatro de marionetas siciliano Opera dei Puppi"]]. Retrieved 22
+     August 2010.
+183. *[[#cite_ref-183][^]]*
+     [[http://www.sicilianwoodcarver.com/]["George Petralia"]]. Sicilian
+     Wood Carver. Retrieved 9 April 2011.
+184. *[[#cite_ref-184][^]]*
+     [[https://web.archive.org/web/20080605150227/http://www.ontoeurope.com/cities/2005/Catania/06-05index.html]["Virgin
+     Express Inflight Magazine -- Catania"]]. Archived from
+     [[http://www.ontoeurope.com/cities/2005/Catania/06-05index.html][the
+     original]] on 5 June 2008.
+185. ^ [[#cite_ref-Radicini,_Ninni_2014_185-0][^{/*a*/}]]
+     [[#cite_ref-Radicini,_Ninni_2014_185-1][^{/*b*/}]] Radicini, Ninni.
+     "The Trinacria: History and Mythology | The Symbol of the Hellenic
+     Nature of Sicily | Article by Ninni Radicini." The Trinacria:
+     History and Mythology | The Symbol of the Hellenic Nature of Sicily
+     | Article by Ninni Radicini. N.p., n.d. Web. 09 Nov. 2014.
+186. *[[#cite_ref-186][^]]* Trabia, Carlo. "The Trinacria - Best of
+     Sicily Magazine." The Trinacria - Best of Sicily Magazine. N.p.,
+     n.d. Web. 09 Nov. 2014.
+187. *[[#cite_ref-naples_187-0][^]]* Matthews, Jeff (2005)
+     [[http://faculty.ed.umuc.edu/~jmatthew/naples/symbols.htm][Symbols
+     of Naples]]
+     [[https://web.archive.org/web/20091030202145/http://faculty.ed.umuc.edu/~jmatthew/naples/symbols.htm][Archived]]
+     30 October 2009 at the [[/wiki/Wayback_Machine][Wayback Machine]]
+
+** Further
+reading[[[/w/index.php?title=Sicily&action=edit&section=57][edit]]]
+   :PROPERTIES:
+   :CUSTOM_ID: further-readingedit
+   :END:
+
+- Alio, Jacqueline (2018) /Sicilian Studies: A Guide and Syllabus for
+  Educators/ (Trinacria Editions, New York,
+  [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-1-943-63918-2][978-1-943-63918-2]]).
+- Bonacini, Elisa (2007) /Il territorio calatino nella Sicilia imperiale
+  e tardoromana/ (British Archeological Reports, International
+  Series: 1694) Archaeopress, Oxford, England,
+  [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-1-4073-0136-5][978-1-4073-0136-5]],
+  in Italian with abstract in English
+- Chaney, Edward. (2000), "British and American Travellers in Sicily
+  from the eighth to the twentieth century", The Evolution of the Grand
+  Tour, Routledge.
+- Leighton, Robert (1999) /Sicily before History/ (Duckworth, London;
+  Cornell University Press, Ithaca).
+- Mendola, Louis; Alio, Jacqueline (2013) /The Peoples of Sicily: A
+  Multicultural Legacy/ (Trinacria Editions, New York,
+  [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-0-615-79694-9][978-0-615-79694-9]]).
+- Spadi, Fabio. (2001)
+  [[https://web.archive.org/web/20070322172132/http://iclq.oxfordjournals.org/cgi/reprint/50/2/411]["The
+  Bridge on the Strait of Messina: 'Lowering' the Right of Innocent
+  Passage?"]] /International and Comparative Law Quarterly/ 50: 411 ff.
+- "From Rome to Sicily: Plane or Train?"
+  [[http://travelqa.blogs.nytimes.com/tag/sicily/][Expert Travel Advice,
+  The New York Times, 7 February 2008]] The New York Times.
+- Attilio L. Vinci, /Magica Sicilia/, Campo, Alcamo
+  ([[/wiki/Trapani][Trapani]]), 2018.
+  [[/wiki/ISBN_(identifier)][ISBN]] [[/wiki/Special:BookSources/978-88-943699-1-5][978-88-943699-1-5]]
+- [[http://news.bbc.co.uk/2/hi/europe/7796096.stm]["Italy makes record
+  mafia seizure"]]. /BBC News/. 22 December 2008. Retrieved 23 April
+  2010.
+- [[https://web.archive.org/web/20160101133533/http://www.mafia-news.com/sicily-mafia-restoring-us-links/]["Sicily
+  Mafia restoring US links"]]. Mafia News. 29 February 2008. Archived
+  from [[http://www.mafia-news.com/sicily-mafia-restoring-us-links/][the
+  original]] on 1 January 2016. Retrieved 23 April 2010.
+- [[http://shop.getty.edu/products/sicily-art-and-invention-between-greece-and-rome-978-1606061336]["Sicily:
+  Art and Invention between Greece and Rome"]]. Getty
+  Publications, 2013.
+- /To Noto: or London to Sicily in a Ford/ (London, 1989) by
+  [[/wiki/Duncan_Fallowell][Duncan Fallowell]]
+
+** External
+links[[[/w/index.php?title=Sicily&action=edit&section=58][edit]]]
+   :PROPERTIES:
+   :CUSTOM_ID: external-linksedit
+   :END:
+| [[//upload.wikimedia.org/wikipedia/en/thumb/4/4a/Commons-logo.svg/30px-Commons-logo.svg.png]] | Wikimedia Commons has media related to [[https://commons.wikimedia.org/wiki/Category:Sicily][Sicily]]. |
+
+| [[//upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Wikivoyage-Logo-v3-icon.svg/40px-Wikivoyage-Logo-v3-icon.svg.png]] | Wikivoyage has a travel guide for /*[[https://en.wikivoyage.org/wiki/Sicily#Q1460][Sicily]]*/. |
+
+- [[//upload.wikimedia.org/wikipedia/commons/thumb/b/b0/Openstreetmap_logo.svg/16px-Openstreetmap_logo.svg.png]]
+  Geographic data related to
+  [[https://www.openstreetmap.org/relation/39152][Sicily]] at
+  [[/wiki/OpenStreetMap][OpenStreetMap]]
+- [[http://www.regione.sicilia.it/][Sicilian Region --- Official
+  website]] (in Italian)
+- [[http://www.wondersofsicily.com/][The Wonders of Sicily -- The
+  Cities, Architecture, Culture, History, People]]
+- [[https://www.worldhistory.org/article/1190.][Piccolo, Salvatore
+  (2018). /Bronze Age Sicily/. World History Encyclopedia.]]
+- Wilson, R.; Talbert, R.; Elliott, T.; Gillies, S.
+  [[https://web.archive.org/web/20120713212644/http://pleiades.stoa.org/places/462492]["Places:
+  462492 (Sicilia)"]]. Pleiades. Archived from
+  [[http://pleiades.stoa.org/places/462492][the original]] on 13 July
+  2012. Retrieved 8 March 2012.
+
+- [[/wiki/File:Terra.png][[[//upload.wikimedia.org/wikipedia/commons/thumb/f/f5/Terra.png/21px-Terra.png]]]][[/wiki/Portal:Geography][Geography
+  portal]]
+- [[/wiki/File:Ic%C3%B4ne_Ile.svg][[[//upload.wikimedia.org/wikipedia/commons/thumb/8/87/Ic%C3%B4ne_Ile.svg/21px-Ic%C3%B4ne_Ile.svg.png]]]][[/wiki/Portal:Islands][Islands
+  portal]]
+- [[/wiki/File:Flag_of_Italy.svg][[[//upload.wikimedia.org/wikipedia/en/thumb/0/03/Flag_of_Italy.svg/24px-Flag_of_Italy.svg.png]]]][[/wiki/Portal:Italy][Italy
+  portal]]
+
+| - [[/wiki/Template:Islands_of_Italy][v]]                                                  |  |                                                                                                                                                                                     |
+| - [[/wiki/Template_talk:Islands_of_Italy][t]]                                             |  |                                                                                                                                                                                     |
+| - [[https://en.wikipedia.org/w/index.php?title=Template:Islands_of_Italy&action=edit][e]] |  |                                                                                                                                                                                     |
+|                                                                                           |  |                                                                                                                                                                                     |
+| <<Islands_of_Italy_in_the_Mediterranean>>                                                 |  |                                                                                                                                                                                     |
+| [[/wiki/List_of_islands_of_Italy][Islands of Italy in the Mediterranean]]                 |  |                                                                                                                                                                                     |
+| - [[/wiki/Aegadian_Islands][Aegadian Islands]]                                            |  | - [[/wiki/File:Ic%C3%B4ne_Ile.svg][[[//upload.wikimedia.org/wikipedia/commons/thumb/8/87/Ic%C3%B4ne_Ile.svg/28px-Ic%C3%B4ne_Ile.svg.png]]]][[/wiki/Portal:Islands][Islands portal]] |
+| - [[/wiki/Aeolian_Islands][Aeolian Islands]]                                              |  |                                                                                                                                                                                     |
+| - [[/wiki/Asinara][Asinara]]                                                              |  |                                                                                                                                                                                     |
+| - [[/wiki/Barbana,_Italy][Barbana]]                                                       |  |                                                                                                                                                                                     |
+| - [[/wiki/Bergeggi_(island)][Bergeggi]]                                                   |  |                                                                                                                                                                                     |
+| - [[/wiki/Campanian_Archipelago][Campanian Archipelago]]                                  |  |                                                                                                                                                                                     |
+| - [[/wiki/Cheradi_Islands][Cheradi Islands]]                                              |  |                                                                                                                                                                                     |
+| - [[/wiki/Cyclopean_Isles][Cyclopean Isles]]                                              |  |                                                                                                                                                                                     |
+| - [[/wiki/Ferdinandea][Ferdinandea]]                                                      |  |                                                                                                                                                                                     |
+| - [[/wiki/Flegrean_Islands][Flegrean Islands]]                                            |  |                                                                                                                                                                                     |
+| - [[/wiki/Gallinara][Gallinara]]                                                          |  |                                                                                                                                                                                     |
+| - [[/wiki/Gaiola_Island][Gaiola]]                                                         |  |                                                                                                                                                                                     |
+| - [[/wiki/Grado,_Friuli-Venezia_Giulia][Grado]]                                           |  |                                                                                                                                                                                     |
+| - [[/wiki/Isola_Bella_(Sicily)][Isola Bella]]                                             |  |                                                                                                                                                                                     |
+| - [[/wiki/Maddalena_archipelago][Maddalena archipelago]]                                  |  |                                                                                                                                                                                     |
+| - [[/wiki/Mal_di_Ventre][Mal di Ventre]]                                                  |  |                                                                                                                                                                                     |
+| - [[/w/index.php?title=Molara_island&action=edit&redlink=1][Molara]]                      |  |                                                                                                                                                                                     |
+| - [[/wiki/Ortygia][Ortygia]]                                                              |  |                                                                                                                                                                                     |
+| - [[/wiki/Pantelleria][Pantelleria]]                                                      |  |                                                                                                                                                                                     |
+| - [[/wiki/Palmaria_(island)][Palmaria]]                                                   |  |                                                                                                                                                                                     |
+| - [[/wiki/Pelagie_Islands][Pelagie Islands]]                                              |  |                                                                                                                                                                                     |
+| - [[/wiki/Pontine_Islands][Pontine Islands]]                                              |  |                                                                                                                                                                                     |
+| - [[/w/index.php?title=Porto_Buso&action=edit&redlink=1][Porto Buso]]                     |  |                                                                                                                                                                                     |
+| - [[/wiki/Sant%27Andrea_Island][Sant'Andrea]]                                             |  |                                                                                                                                                                                     |
+| - [[/wiki/Sant%27Antioco][Sant'Antioco]]                                                  |  |                                                                                                                                                                                     |
+| - [[/wiki/San_Pietro_Island][San Pietrro]]                                                |  |                                                                                                                                                                                     |
+| - [[/w/index.php?title=San_Pietro_d%27Orio&action=edit&redlink=1][San Pietro d'Orio]]     |  |                                                                                                                                                                                     |
+| - [[/wiki/Sardinia][Sardinia]]                                                            |  |                                                                                                                                                                                     |
+| - [[/wiki/Scola_Tower][Scola]]                                                            |  |                                                                                                                                                                                     |
+| - Sicily                                                                                  |  |                                                                                                                                                                                     |
+| - [[/wiki/Sirenuse][Sirenuse]]                                                            |  |                                                                                                                                                                                     |
+| - [[/wiki/Tavolara_Island][Tavolara]]                                                     |  |                                                                                                                                                                                     |
+| - [[/wiki/Tinetto][Tinetto]]                                                              |  |                                                                                                                                                                                     |
+| - [[/wiki/Tino_(island)][Tino]]                                                           |  |                                                                                                                                                                                     |
+| - [[/wiki/Isole_Tremiti][Tremiti Islands]]                                                |  |                                                                                                                                                                                     |
+| - [[/wiki/Tuscan_Archipelago][Tuscan Archipelago]]                                        |  |                                                                                                                                                                                     |
+| - [[/wiki/Two_Brothers_Rocks][Two Brothers Rocks]]                                        |  |                                                                                                                                                                                     |
+| - [[/wiki/Ustica][Ustica]]                                                                |  |                                                                                                                                                                                     |
+| - [[/wiki/Venetian_Lagoon][Venetian Lagoon]]                                              |  |                                                                                                                                                                                     |
+
+| - [[/wiki/Template:Sicily][v]]                                                                                                                              |                                                                             |                                                                                                                                                                                                                                                             |
+| - [[/wiki/Template_talk:Sicily][t]]                                                                                                                         |                                                                             |                                                                                                                                                                                                                                                             |
+| - [[https://en.wikipedia.org/w/index.php?title=Template:Sicily&action=edit][e]]                                                                             |                                                                             |                                                                                                                                                                                                                                                             |
+|                                                                                                                                                             |                                                                             |                                                                                                                                                                                                                                                             |
+| <<23x15px&#124;border_&#124;alt=Sicily&#124;link=Sicily_Sicily>>                                                                                            |                                                                             |                                                                                                                                                                                                                                                             |
+| [[/wiki/Sicily][[[//upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_Sicily_%28revised%29.svg/23px-Flag_of_Sicily_%28revised%29.svg.png]]]] Sicily |                                                                             |                                                                                                                                                                                                                                                             |
+| [[/wiki/Provinces_of_Italy][Provinces,\\                                                                                                                    | - [[/wiki/Province_of_Agrigento][Agrigento]]                                | [[/wiki/File:Map_of_region_of_Sicily,_Italy,_with_provinces-en.svg][[[//upload.wikimedia.org/wikipedia/commons/thumb/5/5f/Map_of_region_of_Sicily%2C_Italy%2C_with_provinces-en.svg/230px-Map_of_region_of_Sicily%2C_Italy%2C_with_provinces-en.svg.png]]]] |
+| metropolitan cities\\                                                                                                                                       | - [[/wiki/Province_of_Caltanissetta][Caltanissetta]]                        |                                                                                                                                                                                                                                                             |
+| and places]]                                                                                                                                                | - [[/wiki/Metropolitan_City_of_Catania][Catania]]                           |                                                                                                                                                                                                                                                             |
+|                                                                                                                                                             | - [[/wiki/Province_of_Enna][Enna]]                                          |                                                                                                                                                                                                                                                             |
+|                                                                                                                                                             | - [[/wiki/Metropolitan_City_of_Messina][Messina]]                           |                                                                                                                                                                                                                                                             |
+|                                                                                                                                                             | - [[/wiki/Metropolitan_City_of_Palermo][Palermo]]                           |                                                                                                                                                                                                                                                             |
+|                                                                                                                                                             | - [[/wiki/Province_of_Ragusa][Ragusa]]                                      |                                                                                                                                                                                                                                                             |
+|                                                                                                                                                             | - [[/wiki/Province_of_Syracuse][Syracuse]]                                  |                                                                                                                                                                                                                                                             |
+|                                                                                                                                                             | - [[/wiki/Province_of_Trapani][Trapani]]                                    |                                                                                                                                                                                                                                                             |
+|                                                                                                                                                             | - [[/wiki/Category:Islands_of_Sicily][Islands]]                             |                                                                                                                                                                                                                                                             |
+|                                                                                                                                                             | - [[/wiki/Category:Cities_and_towns_in_Sicily][Cities, towns and villages]] |                                                                                                                                                                                                                                                             |
+|                                                                                                                                                             | - [[/wiki/List_of_communes_of_Sicily][List of communes]]                    |                                                                                                                                                                                                                                                             |
+| [[/wiki/History_of_Sicily][History]]                                                                                                                        |                                                                             | - [[/wiki/Magna_Graecia][Magna Graecia]]                                                                                                                                                                                                                    |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Sicilia_(Roman_province)][Sicilia province]]                                                                                                                                                                                                      |
+|                                                                                                                                                             |                                                                             | - [[/wiki/War_between_Sextus_Pompey_and_the_Second_Triumvirate][Sicilian revolt]]                                                                                                                                                                           |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Sicily_(theme)][Theme of Sicily]]                                                                                                                                                                                                                 |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Emirate_of_Sicily][Emirate of Sicily]]                                                                                                                                                                                                            |
+|                                                                                                                                                             |                                                                             | - [[/wiki/County_of_Sicily][County of Sicily]]                                                                                                                                                                                                              |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Kingdom_of_Sicily][Kingdom of Sicily]]                                                                                                                                                                                                            |
+|                                                                                                                                                             |                                                                             | - [[/wiki/War_of_the_Sicilian_Vespers][War of the Sicilian Vespers]]                                                                                                                                                                                        |
+|                                                                                                                                                             |                                                                             | - [[/wiki/List_of_monarchs_of_Sicily][Monarchs]]                                                                                                                                                                                                            |
+|                                                                                                                                                             |                                                                             | - [[/wiki/List_of_viceroys_of_Sicily][Viceroys]]                                                                                                                                                                                                            |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Sicilian_Parliament][Sicilian Parliament]]                                                                                                                                                                                                        |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Kingdom_of_the_Two_Sicilies][Two Sicilies]]                                                                                                                                                                                                       |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Italian_unification#Two_Sicilies_insurrection][Risorgimento]]                                                                                                                                                                                     |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Sicilian_revolution_of_1848][1848 Sicilian revolution]]                                                                                                                                                                                           |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Dictatorship_of_Garibaldi][Dictatorship of Garibaldi]]                                                                                                                                                                                            |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Allied_invasion_of_Sicily][Allied invasion of Sicily]]                                                                                                                                                                                            |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Sicilian_nationalism][Sicilian nationalism]]                                                                                                                                                                                                      |
+| [[/wiki/Politics_of_Sicily][Politics and\\                                                                                                                  |                                                                             | - [[/wiki/Politics_of_Sicily][Politics of Sicily]]                                                                                                                                                                                                          |
+| government]]                                                                                                                                                |                                                                             | - [[/wiki/Statute_of_Sicily][Statute of Sicily]]                                                                                                                                                                                                            |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Elections_in_Sicily][Elections in Sicily]]                                                                                                                                                                                                        |
+|                                                                                                                                                             |                                                                             | - [[/wiki/List_of_Presidents_of_Sicily][List of Presidents of Sicily]]                                                                                                                                                                                      |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Sicilian_Regional_Assembly][Sicilian Regional Assembly]]                                                                                                                                                                                          |
+| Culture and\\                                                                                                                                               |                                                                             | - [[/wiki/Sicilians][People]]                                                                                                                                                                                                                               |
+| heritage                                                                                                                                                    |                                                                             |                                                                                                                                                                                                                                                             |
+|                                                                                                                                                             |                                                                             |   - [[/wiki/List_of_people_from_Sicily][List of people from Sicily]]                                                                                                                                                                                        |
+|                                                                                                                                                             |                                                                             |                                                                                                                                                                                                                                                             |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Sicilian_cuisine][Cuisine]]                                                                                                                                                                                                                       |
+|                                                                                                                                                             |                                                                             |                                                                                                                                                                                                                                                             |
+|                                                                                                                                                             |                                                                             |   - [[/wiki/List_of_Sicilian_dishes][List of Sicilian dishes]]                                                                                                                                                                                              |
+|                                                                                                                                                             |                                                                             |                                                                                                                                                                                                                                                             |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Derby_di_Sicilia][Derby di Sicilia (football)]]                                                                                                                                                                                                   |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Sicilian_language][Language]]                                                                                                                                                                                                                     |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Music_of_Sicily][Music]]                                                                                                                                                                                                                          |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Norman-Arab-Byzantine_culture][Norman-Sicilian culture]]                                                                                                                                                                                          |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Sicilian_Baroque][Sicilian Baroque]]                                                                                                                                                                                                              |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Sicilian_School][Sicilian School]]                                                                                                                                                                                                                |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Sicilian_cart][Sicilian cart]]                                                                                                                                                                                                                    |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Coppola_cap][Coppola cap]]                                                                                                                                                                                                                        |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Flag_of_Sicily][Flags]]                                                                                                                                                                                                                           |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Triskelion#Sicily][Triskeles]]                                                                                                                                                                                                                    |
+|                                                                                                                                                             |                                                                             | - [[/wiki/Mount_Etna][Mount Etna]]                                                                                                                                                                                                                          |
+| [[//upload.wikimedia.org/wikipedia/en/thumb/9/96/Symbol_category_class.svg/16px-Symbol_category_class.svg.png]] [[/wiki/Category:Sicily][Category]]         |                                                                             |                                                                                                                                                                                                                                                             |
+
+| - [[/wiki/Template:Regions_of_Italy][v]]                                                                                                     |                                                                                                                                                                                                                    |
+| - [[/wiki/Template_talk:Regions_of_Italy][t]]                                                                                                |                                                                                                                                                                                                                    |
+| - [[https://en.wikipedia.org/w/index.php?title=Template:Regions_of_Italy&action=edit][e]]                                                    |                                                                                                                                                                                                                    |
+|                                                                                                                                              |                                                                                                                                                                                                                    |
+| <<23x15px&#124;border_&#124;alt=&#124;link=_Regions_of_Italy>>                                                                               |                                                                                                                                                                                                                    |
+| [[//upload.wikimedia.org/wikipedia/en/thumb/0/03/Flag_of_Italy.svg/23px-Flag_of_Italy.svg.png]] [[/wiki/Regions_of_Italy][Regions of Italy]] |                                                                                                                                                                                                                    |
+| [[/wiki/Central_Italy][Central]]                                                                                                             | - [[//upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Flag_of_Lazio.svg/23px-Flag_of_Lazio.svg.png]] [[/wiki/Lazio][Lazio]]                                                                                      |
+|                                                                                                                                              | - [[//upload.wikimedia.org/wikipedia/commons/thumb/0/07/Flag_of_Marche.svg/23px-Flag_of_Marche.svg.png]] [[/wiki/Marche][Marche]]                                                                                  |
+|                                                                                                                                              | - [[//upload.wikimedia.org/wikipedia/commons/thumb/f/f2/Flag_of_Tuscany.svg/23px-Flag_of_Tuscany.svg.png]] [[/wiki/Tuscany][Tuscany]]                                                                              |
+|                                                                                                                                              | - [[//upload.wikimedia.org/wikipedia/commons/thumb/c/cc/Flag_of_Umbria.svg/23px-Flag_of_Umbria.svg.png]] [[/wiki/Umbria][Umbria]]                                                                                  |
+| [[/wiki/Northeast_Italy][Northeast]]                                                                                                         | - [[//upload.wikimedia.org/wikipedia/commons/thumb/7/77/Flag_of_Emilia-Romagna_%28de_facto%29.svg/23px-Flag_of_Emilia-Romagna_%28de_facto%29.svg.png]] [[/wiki/Emilia-Romagna][Emilia-Romagna]]                    |
+|                                                                                                                                              | - [[//upload.wikimedia.org/wikipedia/commons/thumb/5/55/Flag_of_Friuli-Venezia_Giulia.svg/23px-Flag_of_Friuli-Venezia_Giulia.svg.png]] [[/wiki/Friuli_Venezia_Giulia][Friuli-Venezia Giulia]]^{1}                  |
+|                                                                                                                                              | - [[//upload.wikimedia.org/wikipedia/commons/thumb/7/7f/Flag_of_Trentino-South_Tyrol.svg/23px-Flag_of_Trentino-South_Tyrol.svg.png]] [[/wiki/Trentino-Alto_Adige/S%C3%BCdtirol][Trentino-Alto Adige/Südtirol]]^{1} |
+|                                                                                                                                              | - [[//upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Flag_of_Veneto.svg/23px-Flag_of_Veneto.svg.png]] [[/wiki/Veneto][Veneto]]                                                                                  |
+| [[/wiki/Northwest_Italy][Northwest]]                                                                                                         | - [[//upload.wikimedia.org/wikipedia/commons/thumb/9/90/Flag_of_Valle_d%27Aosta.svg/23px-Flag_of_Valle_d%27Aosta.svg.png]] [[/wiki/Aosta_Valley][Aosta Valley]]^{1}                                                |
+|                                                                                                                                              | - [[//upload.wikimedia.org/wikipedia/commons/thumb/8/88/Flag_of_Liguria.svg/23px-Flag_of_Liguria.svg.png]] [[/wiki/Liguria][Liguria]]                                                                              |
+|                                                                                                                                              | - [[//upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Flag_of_Lombardy.svg/23px-Flag_of_Lombardy.svg.png]] [[/wiki/Lombardy][Lombardy]]                                                                          |
+|                                                                                                                                              | - [[//upload.wikimedia.org/wikipedia/commons/thumb/b/b9/Flag_of_Piedmont.svg/23px-Flag_of_Piedmont.svg.png]] [[/wiki/Piedmont][Piedmont]]                                                                          |
+| [[/wiki/South_Italy][South]]                                                                                                                 | - [[//upload.wikimedia.org/wikipedia/commons/thumb/4/45/Flag_of_Abruzzo.svg/22px-Flag_of_Abruzzo.svg.png]] [[/wiki/Abruzzo][Abruzzo]]                                                                              |
+|                                                                                                                                              | - [[//upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Flag_of_Apulia.svg/23px-Flag_of_Apulia.svg.png]] [[/wiki/Apulia][Apulia]]                                                                                  |
+|                                                                                                                                              | - [[//upload.wikimedia.org/wikipedia/commons/thumb/8/8e/Flag_of_Basilicata.svg/23px-Flag_of_Basilicata.svg.png]] [[/wiki/Basilicata][Basilicata]]                                                                  |
+|                                                                                                                                              | - [[//upload.wikimedia.org/wikipedia/commons/thumb/8/8b/Flag_of_Calabria.svg/23px-Flag_of_Calabria.svg.png]] [[/wiki/Calabria][Calabria]]                                                                          |
+|                                                                                                                                              | - [[//upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Flag_of_Campania.svg/23px-Flag_of_Campania.svg.png]] [[/wiki/Campania][Campania]]                                                                          |
+|                                                                                                                                              | - [[//upload.wikimedia.org/wikipedia/commons/thumb/8/84/Flag_of_Molise.svg/23px-Flag_of_Molise.svg.png]] [[/wiki/Molise][Molise]]                                                                                  |
+| [[/wiki/Insular_Italy][Insular]]                                                                                                             | - [[//upload.wikimedia.org/wikipedia/commons/thumb/6/65/Flag_of_Sardinia.svg/23px-Flag_of_Sardinia.svg.png]] [[/wiki/Sardinia][Sardinia]]^{1}                                                                      |
+|                                                                                                                                              | - [[//upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_Sicily_%28revised%29.svg/23px-Flag_of_Sicily_%28revised%29.svg.png]] Sicily^{1}                                                                    |
+| ^{1} [[/wiki/Autonomous_administrative_division][Special statutes]]                                                                          |                                                                                                                                                                                                                    |
+
+| - [[/wiki/Template:Italy_topics][v]]                                                                                                                                     |                                                                                                                                                                      |                                                                                                                                                              |
+| - [[/wiki/Template_talk:Italy_topics][t]]                                                                                                                                |                                                                                                                                                                      |                                                                                                                                                              |
+| - [[https://en.wikipedia.org/w/index.php?title=Template:Italy_topics&action=edit][e]]                                                                                    |                                                                                                                                                                      |                                                                                                                                                              |
+|                                                                                                                                                                          |                                                                                                                                                                      |                                                                                                                                                              |
+| <<Italy_articles>>                                                                                                                                                       |                                                                                                                                                                      |                                                                                                                                                              |
+| [[/wiki/Italy][Italy]] articles                                                                                                                                          |                                                                                                                                                                      |                                                                                                                                                              |
+| [[/wiki/History_of_Italy][History]]                                                                                                                                      | | [[/wiki/Timeline_of_Italian_history][Chronology]] | - [[/wiki/Prehistoric_Italy][Prehistory]]                                                                    | | [[/wiki/Italy][[[//upload.wikimedia.org/wikipedia/commons/thumb/0/00/Emblem_of_Italy.svg/80px-Emblem_of_Italy.svg.png]]]]                                    |
+|                                                                                                                                                                          | |                                                   |                                                                                                              | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Italic_peoples][Italic peoples]]                                                                 | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/List_of_ancient_peoples_of_Italy][Ancient peoples of Italy]]                                     | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Pre-Nuragic_Sardinia][Pre-Nuragic Sardinia]]                                                     | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/List_of_ancient_Corsican_and_Sardinian_tribes][Nuragic peoples]]                                 | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |                                                                                                              | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   | - [[/wiki/Etruscan_civilization][Etruscan civilization]]                                                     | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   | - [[/wiki/Nuragic_civilization][Nuragic civilization]]                                                       | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   | - [[/wiki/Ancient_Carthage][Phoenician/Carthaginian colonies]]                                               | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   | - [[/wiki/Magna_Graecia][Magna Graecia]]                                                                     | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   | - [[/wiki/Ancient_Rome][Ancient Rome]]                                                                       | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |                                                                                                              | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Roman_Kingdom][Kingdom]]                                                                         | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Roman_Republic][Republic]]                                                                       | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Roman_Empire][Empire]]                                                                           | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |                                                                                                              | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |     - [[/wiki/Western_Roman_Empire][Western Empire]]                                                         | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |                                                                                                              | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   | - [[/wiki/Italy_in_the_Middle_Ages][Middle Ages]]                                                            | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |                                                                                                              | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - Italy under [[/wiki/Odoacer#King_of_Italy][Odoacer]]                                                     | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Ostrogothic_Kingdom][Ostrogoths]]                                                                | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Byzantine_Italy][Byzantium]]                                                                     | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Kingdom_of_the_Lombards][Lombards]]                                                              | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Papal_States][Papal States]]                                                                     | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Kingdom_of_Italy_(Holy_Roman_Empire)][the Holy Roman Empire]]                                    | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Sardinian_medieval_kingdoms][the Sardinian Judicates]]                                           | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/History_of_Islam_in_southern_Italy][Arabs]]                                                      | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Norman_conquest_of_southern_Italy][Normans]]                                                     | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Guelphs_and_Ghibellines][Guelphs and Ghibellines]]                                               | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - the [[/wiki/Italian_city-states][Italian city-states]]                                                   | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - the [[/wiki/Maritime_republics][maritime republics]]                                                     | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |                                                                                                              | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |     - [[/wiki/Republic_of_Venice][Venice]]                                                                   | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |     - [[/wiki/Republic_of_Genoa][Genoa]]                                                                     | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |     - [[/wiki/Republic_of_Pisa][Pisa]]                                                                       | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |     - [[/wiki/Duchy_of_Amalfi][Amalfi]]                                                                      | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |                                                                                                              | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   | - [[/wiki/Italian_Renaissance][Renaissance]]                                                                 | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |                                                                                                              | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Italian_Wars][Italian Wars]]                                                                     | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |                                                                                                              | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   | - [[/wiki/History_of_Italy_(1559%E2%80%931814)][Early Modern period]]                                        | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   | - [[/wiki/Italian_unification][Unification]]                                                                 | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |                                                                                                              | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Revolutions_of_1820][Revolutions of 1820]]                                                       | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Revolutions_of_1830#In_Italy][Revolutions of 1830]]                                              | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Revolutions_of_1848_in_the_Italian_states][Revolutions of 1848]]                                 | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Sicilian_revolution_of_1848][Sicilian revolution of 1848]]                                       | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/First_Italian_War_of_Independence][First War of Independence]]                                   | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Crimean_War#Piedmontese_Involvement][Crimean War]]                                               | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Second_Italian_War_of_Independence][Second War of Independence]]                                 | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Expedition_of_the_Thousand][Expedition of the Thousand]]                                         | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Third_Italian_War_of_Independence][Third War of Independence]]                                   | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Capture_of_Rome][Capture of Rome]]                                                               | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |                                                                                                              | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   | - [[/wiki/History_of_the_Kingdom_of_Italy_(1861%E2%80%931946)][Monarchy and the World Wars]]                 | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |                                                                                                              | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Kingdom_of_Italy][Kingdom of Italy]]                                                             | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Italian_Empire][Colonial Empire]]                                                                | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Military_history_of_Italy_during_World_War_I][World War I]]                                      | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Fascist_Italy_(1922%E2%80%931943)][Fascist Italy]]                                               | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Military_history_of_Italy_during_World_War_II][World War II]]                                    | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Italian_resistance_movement][Resistance]] and [[/wiki/Italian_Social_Republic][Social Republic]] | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Italian_Civil_War][Civil War]]                                                                   | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |                                                                                                              | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   | - [[/wiki/History_of_the_Italian_Republic][Republic]]                                                        | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |                                                                                                              | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Italian_economic_miracle][Economic Boom]]                                                        | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Years_of_Lead_(Italy)][Years of Lead]]                                                           | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Maxi_Trial][Maxi Trial]]                                                                         | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Mani_pulite][Mani pulite]]                                                                       | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/Great_Recession][Great Recession]]                                                               | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/European_migrant_crisis#Italy][European migrant crisis]]                                         | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   |   - [[/wiki/COVID-19_pandemic_in_Italy][Coronavirus pandemic]]                                               | |                                                                                                                                                              |
+|                                                                                                                                                                          | | By topic                                          | - [[/wiki/History_of_Italian_citizenship][Citizenship]]                                                      | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   | - [[/wiki/History_of_coins_in_Italy][Currency]]                                                              | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   | - [[/wiki/Economic_history_of_Italy][Economy]]                                                               | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   | - [[/wiki/History_of_Italian_fashion][Fashion]]                                                              | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   | - [[/wiki/List_of_Italian_flags][Flags]]                                                                     | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   | - [[/wiki/Genetic_history_of_Italy][Genetic]]                                                                | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   | - [[/wiki/List_of_historic_states_of_Italy][Historic states]]                                                | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   | - [[/wiki/Military_history_of_Italy][Military]]                                                              | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   | - [[/wiki/Music_history_of_Italy][Music]]                                                                    | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   | - [[/wiki/Name_of_Italy][Name]]                                                                              | |                                                                                                                                                              |
+|                                                                                                                                                                          | |                                                   | - [[/wiki/History_of_rail_transport_in_Italy][Railways]]                                                     | |                                                                                                                                                              |
+| [[/wiki/Geography_of_Italy][Geography]]                                                                                                                                  |                                                                                                                                                                      | | - [[/wiki/Italy_(geographical_region)][Geographical region]] |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Italian_Peninsula][Peninsula]]                     |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Northern_Italy][Northern]]                         |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                              |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | |   - [[/wiki/Northwest_Italy][Northwest]]                     |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | |   - [[/wiki/Northeast_Italy][Northeast]]                     |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                              |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Central_Italy][Central]]                           |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Southern_Italy][Southern]]                         |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                              |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | |   - [[/wiki/South_Italy][South]]                             |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | |   - [[/wiki/Insular_Italy][Insular]]                         |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                              |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Climate_of_Italy][Climate]]                        |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Geology_of_Italy][Geology]]                        |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Fauna_of_Italy][Fauna]]                            |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Flora_of_Italy][Flora]]                            |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/List_of_mountains_of_Italy][Mountains]]            |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                              |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | |   - [[/wiki/Alpine_foothills][Prealps]]                      |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | |   - [[/wiki/Alps][Alps]]                                     |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | |   - [[/wiki/Apennine_Mountains][Apennines]]                  |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                              |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Volcanology_of_Italy][Volcanology]]                |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                              |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | |   - [[/wiki/List_of_volcanoes_in_Italy][Volcanoes]]          |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                              |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/List_of_beaches_in_Italy][Beaches]]                |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/List_of_canals_in_Italy][Canals]]                  |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/List_of_caves_in_Italy][Caves]]                    |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/List_of_earthquakes_in_Italy][Earthquakes]]        |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/List_of_islands_of_Italy][Islands]]                |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/List_of_lakes_of_Italy][Lakes]]                    |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/List_of_national_parks_of_Italy][National parks]]  |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/List_of_rivers_of_Italy][Rivers]]                  |  |                                                                                          |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/List_of_valleys_of_Italy][Valleys]]                |  |                                                                                          |
+| [[/wiki/Politics_of_Italy][Politics]]                                                                                                                                    |                                                                                                                                                                      | | - [[/wiki/Constitution_of_Italy][Constitution]]                                                        |  |                                                |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Elections_in_Italy][Elections]]                                                              |  |                                                |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Foreign_relations_of_Italy][Foreign relations]]                                              |  |                                                |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Judiciary_of_Italy][Judiciary]]                                                              |  |                                                |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Law_enforcement_in_Italy][Law enforcement]]                                                  |  |                                                |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Italian_Armed_Forces][Military]]                                                             |  |                                                |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Italian_Parliament][Parliament]]                                                             |  |                                                |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/List_of_political_parties_in_Italy][Political parties]]                                      |  |                                                |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/President_of_Italy][President]] ([[/wiki/List_of_presidents_of_Italy][List]])                |  |                                                |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Prime_Minister_of_Italy][Prime Minister]] ([[/wiki/List_of_prime_ministers_of_Italy][List]]) |  |                                                |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Council_of_Ministers_(Italy)][Council of Ministers]]                                         |  |                                                |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Regions_of_Italy][Regions]]                                                                  |  |                                                |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Provinces_of_Italy][Provinces]]                                                              |  |                                                |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Metropolitan_cities_of_Italy][Metropolitan cities]]                                          |  |                                                |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/List_of_cities_in_Italy][Cities]]                                                            |  |                                                |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Comune][Comune]]                                                                             |  |                                                |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/List_of_municipalities_of_Italy][Municipalities]]                                            |  |                                                |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/List_of_renamed_municipalities_in_Italy][Renamed municipalities]]                            |  |                                                |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Fusion_of_Italian_municipalities][Fused municipalities]]                                     |  |                                                |
+| [[/wiki/Economy_of_Italy][Economy]]                                                                                                                                      |                                                                                                                                                                      | | - [[/wiki/Economic_history_of_Italy][Economic history]]             |  |                                                                                   |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/List_of_Italian_regions_by_GDP][Regions by GDP]]          |  |                                                                                   |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Automotive_industry_in_Italy][Automotive industry]]       |  |                                                                                   |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Banking_in_Italy][Banking]]                               |  |                                                                                   |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                     |  |                                                                                   |
+|                                                                                                                                                                          |                                                                                                                                                                      | |   - [[/wiki/Bank_of_Italy][Central Bank]]                           |  |                                                                                   |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                     |  |                                                                                   |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/List_of_companies_of_Italy][Companies]]                   |  |                                                                                   |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Energy_in_Italy][Energy]]                                 |  |                                                                                   |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Italian_government_debt][Government debt]]                |  |                                                                                   |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Science_and_technology_in_Italy][Science and technology]] |  |                                                                                   |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Borsa_Italiana][Stock exchange]]                          |  |                                                                                   |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Taxation_in_Italy][Taxation]]                             |  |                                                                                   |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Telecommunications_in_Italy][Telecommunications]]         |  |                                                                                   |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Tourism_in_Italy][Tourism]]                               |  |                                                                                   |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/List_of_trade_unions_in_Italy][Trade unions]]             |  |                                                                                   |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Transport_in_Italy][Transportation]]                      |  |                                                                                   |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Italian_welfare_state][Welfare]]                          |  |                                                                                   |
+| [[/wiki/Category:Italian_society][Society]]                                                                                                                              |                                                                                                                                                                      | | - [[/wiki/Corruption_in_Italy][Corruption]]                      |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Crime_in_Italy][Crime]]                                |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Organized_crime_in_Italy][Organized crime]]            |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Demographics_of_Italy][Demographics]]                  |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Education_in_Italy][Education]]                        |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Italian_diaspora][Emigration and diaspora]]            |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Gambling_in_Italy][Gambling]]                          |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Health_in_Italy][Health]]                              |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Immigration_to_Italy][Immigration]]                    |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/LGBT_rights_in_Italy][LGBT rights]]                    |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Italian_public_administration][Public administration]] |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Religion_in_Italy][Religion]]                          |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Social_class_in_Italy][Social class]]                  |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Terrorism_in_Italy][Terrorism]]                        |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | | - [[/wiki/Women_in_Italy][Women]]                                |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | | [[/wiki/Culture_of_Italy][Culture]]                              | - [[/wiki/Duecento][Duecento]]                                                        | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Trecento][Trecento]]                                                        | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Quattrocento][Quattrocento]]                                                | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Cinquecento][Cinquecento]]                                                  | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Seicento][Seicento]]                                                        | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/History_of_Italian_culture_(1700s)][Settecento]]                            | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Italian_Neoclassical_and_19th-century_art][Ottocento]]                      | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Architecture_of_Italy][Architecture]]                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Nobility_of_Italy][Aristocracy]]                                            | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Italian_art][Art]]                                                          | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/List_of_castles_in_Italy][Castles]]                                         | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Cinema_of_Italy][Cinema]]                                                   | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Italian_cuisine][Cuisine]]                                                  | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/List_of_cultural_icons_of_Italy][Cultural icons]]                           | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Orders,_decorations,_and_medals_of_Italy][Orders, decorations, and medals]] | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Italian_design][Design]]                                                    | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Italian_fashion][Fashion]]                                                  | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Folklore_of_Italy][Folklore]]                                               | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Italophilia][Italophilia]]                                                  | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/List_of_Italian_inventions_and_discoveries][Inventions and discoveries]]    | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Languages_of_Italy][Languages]]                                             | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  |   - [[/wiki/Italian_language][Italian]]                                               | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  |     - [[/wiki/Regional_Italian][Regional]]                                            | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Italian_literature][Literature]]                                            | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Media_of_Italy][Media]]                                                     | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/List_of_monuments_of_Italy][Monuments]]                                     | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Music_of_Italy][Music]]                                                     | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Mythology_of_Italy][Mythology]]                                             | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/National_symbols_of_Italy][National symbols]]                               | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  |   - [[/wiki/Il_Canto_degli_Italiani][Anthem]]                                         | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  |   - [[/wiki/Cockade_of_Italy][Cockade]]                                               | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  |   - [[/wiki/National_colours_of_Italy][Colours]]                                      | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  |   - [[/wiki/Emblem_of_Italy][Emblem]]                                                 | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  |   - [[/wiki/Flag_of_Italy][Flag]]                                                     | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  |     - [[/wiki/Flags_of_regions_of_Italy][Regions]]                                    | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  |   - [[/wiki/Altare_della_Patria][Monument]]                                           | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  |   - [[/wiki/Italia_turrita][Personification]]                                         | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  |   - [[/wiki/Strawberry_Tree_(national_symbol_of_Italy)][Tree]]                        | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Italians][Italians]]                                                        | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  |   - [[/wiki/List_of_people_from_Italy][People]]                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  |                                                                                       | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Italian_philosophy][Philosophy]]                                            | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Public_holidays_in_Italy][Public holidays]]                                 | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Sculpture_of_Italy][Sculpture]]                                             | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Sport_in_Italy][Sport]]                                                     | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/Traditions_of_Italy][Traditions]]                                           | |
+|                                                                                                                                                                          |                                                                                                                                                                      | |                                                                  | - [[/wiki/List_of_World_Heritage_Sites_in_Italy][World Heritage Sites]]               | |
+| - [[/wiki/File:Flag_of_Italy.svg][[[//upload.wikimedia.org/wikipedia/en/thumb/0/03/Flag_of_Italy.svg/16px-Flag_of_Italy.svg.png]]]] [[/wiki/Portal:Italy][Italy portal]] |                                                                                                                                                                      |                                                                                                                                                              |
+| - [[//upload.wikimedia.org/wikipedia/en/thumb/9/96/Symbol_category_class.svg/16px-Symbol_category_class.svg.png]] [[/wiki/Category:Italy][Category]]                     |                                                                                                                                                                      |                                                                                                                                                              |
+
+| - [[/wiki/Template:World%27s_largest_islands][v]]                                                  |                                                                |                                                                                                                                                                                     |
+| - [[/wiki/Template_talk:World%27s_largest_islands][t]]                                             |                                                                |                                                                                                                                                                                     |
+| - [[https://en.wikipedia.org/w/index.php?title=Template:World%27s_largest_islands&action=edit][e]] |                                                                |                                                                                                                                                                                     |
+|                                                                                                    |                                                                |                                                                                                                                                                                     |
+| <<World&#039;s_largest_islands>>                                                                   |                                                                |                                                                                                                                                                                     |
+| [[/wiki/List_of_islands_by_area][World's largest islands]]                                         |                                                                |                                                                                                                                                                                     |
+| 100,000 km^{2}\\                                                                                   | - [[/wiki/Greenland][Greenland]]                               | - [[/wiki/File:Ic%C3%B4ne_Ile.svg][[[//upload.wikimedia.org/wikipedia/commons/thumb/8/87/Ic%C3%B4ne_Ile.svg/28px-Ic%C3%B4ne_Ile.svg.png]]]][[/wiki/Portal:Islands][Islands portal]] |
+| (39,000 sq mi) and greater                                                                         | - [[/wiki/New_Guinea][New Guinea]]                             |                                                                                                                                                                                     |
+|                                                                                                    | - [[/wiki/Borneo][Borneo]]                                     |                                                                                                                                                                                     |
+|                                                                                                    | - [[/wiki/Madagascar][Madagascar]]                             |                                                                                                                                                                                     |
+|                                                                                                    | - [[/wiki/Baffin_Island][Baffin Island]]                       |                                                                                                                                                                                     |
+|                                                                                                    | - [[/wiki/Sumatra][Sumatra]]                                   |                                                                                                                                                                                     |
+|                                                                                                    | - [[/wiki/Honshu][Honshu]]                                     |                                                                                                                                                                                     |
+|                                                                                                    | - [[/wiki/Victoria_Island_(Canada)][Victoria Island (Canada)]] |                                                                                                                                                                                     |
+|                                                                                                    | - [[/wiki/Great_Britain][Great Britain]]                       |                                                                                                                                                                                     |
+|                                                                                                    | - [[/wiki/Ellesmere_Island][Ellesmere Island]]                 |                                                                                                                                                                                     |
+|                                                                                                    | - [[/wiki/Sulawesi][Sulawesi]]                                 |                                                                                                                                                                                     |
+|                                                                                                    | - [[/wiki/South_Island][South Island]]                         |                                                                                                                                                                                     |
+|                                                                                                    | - [[/wiki/Java][Java]]                                         |                                                                                                                                                                                     |
+|                                                                                                    | - [[/wiki/North_Island][North Island]]                         |                                                                                                                                                                                     |
+|                                                                                                    | - [[/wiki/Luzon][Luzon]]                                       |                                                                                                                                                                                     |
+|                                                                                                    | - [[/wiki/Newfoundland_(island)][Newfoundland]]                |                                                                                                                                                                                     |
+|                                                                                                    | - [[/wiki/Geography_of_Cuba][Cuba]]                            |                                                                                                                                                                                     |
+|                                                                                                    | - [[/wiki/Geography_of_Iceland][Iceland]]                      |                                                                                                                                                                                     |
+| 20,000--99,999 km^{2}\\                                                                            |                                                                | - [[/wiki/Mindanao][Mindanao]]                                                                                                                                                      |
+| (7,722--38,610 sq mi)                                                                              |                                                                | - [[/wiki/Ireland][Ireland]]                                                                                                                                                        |
+|                                                                                                    |                                                                | - [[/wiki/Hokkaido][Hokkaido]]                                                                                                                                                      |
+|                                                                                                    |                                                                | - [[/wiki/Hispaniola][Hispaniola]]                                                                                                                                                  |
+|                                                                                                    |                                                                | - [[/wiki/Sakhalin][Sakhalin]]                                                                                                                                                      |
+|                                                                                                    |                                                                | - [[/wiki/Banks_Island][Banks Island]]                                                                                                                                              |
+|                                                                                                    |                                                                | - [[/wiki/Geography_of_Sri_Lanka][Sri Lanka (main island)]]                                                                                                                         |
+|                                                                                                    |                                                                | - [[/wiki/Geography_of_Tasmania][Tasmania]]                                                                                                                                         |
+|                                                                                                    |                                                                | - [[/wiki/Devon_Island][Devon Island]]                                                                                                                                              |
+|                                                                                                    |                                                                | - [[/wiki/Alexander_Island][Alexander Island]]                                                                                                                                      |
+|                                                                                                    |                                                                | - [[/wiki/Severny_Island][Severny Island]]                                                                                                                                          |
+|                                                                                                    |                                                                | - [[/wiki/Isla_Grande_de_Tierra_del_Fuego][Isla Grande de Tierra del Fuego]]                                                                                                        |
+|                                                                                                    |                                                                | - [[/wiki/Axel_Heiberg_Island][Axel Heiberg Island]]                                                                                                                                |
+|                                                                                                    |                                                                | - [[/wiki/Melville_Island_(Northwest_Territories_and_Nunavut)][Melville Island]]                                                                                                    |
+|                                                                                                    |                                                                | - [[/wiki/Southampton_Island][Southampton Island]]                                                                                                                                  |
+|                                                                                                    |                                                                | - [[/wiki/Maraj%C3%B3][Marajó]]                                                                                                                                                     |
+|                                                                                                    |                                                                | - [[/wiki/Spitsbergen][Spitsbergen]]                                                                                                                                                |
+|                                                                                                    |                                                                | - [[/wiki/Kyushu][Kyushu]]                                                                                                                                                          |
+|                                                                                                    |                                                                | - [[/wiki/Geography_of_Taiwan][Taiwan]]                                                                                                                                             |
+|                                                                                                    |                                                                | - [[/wiki/New_Britain][New Britain]]                                                                                                                                                |
+|                                                                                                    |                                                                | - [[/wiki/Prince_of_Wales_Island_(Nunavut)][Prince of Wales Island]]                                                                                                                |
+|                                                                                                    |                                                                | - [[/wiki/Yuzhny_Island][Yuzhny Island]]                                                                                                                                            |
+|                                                                                                    |                                                                | - [[/wiki/Hainan][Hainan]]                                                                                                                                                          |
+|                                                                                                    |                                                                | - [[/wiki/Vancouver_Island][Vancouver Island]]                                                                                                                                      |
+|                                                                                                    |                                                                | - [[/wiki/Timor][Timor]]                                                                                                                                                            |
+|                                                                                                    |                                                                | - Sicily                                                                                                                                                                            |
+|                                                                                                    |                                                                | - [[/wiki/Somerset_Island_(Nunavut)][Somerset Island]]                                                                                                                              |
+|                                                                                                    |                                                                | - [[/wiki/Kotelny_Island][Kotelny Island]]                                                                                                                                          |
+|                                                                                                    |                                                                | - [[/wiki/Sardinia][Sardinia]]                                                                                                                                                      |
+|                                                                                                    |                                                                | - [[/wiki/Bananal_Island][Bananal]]                                                                                                                                                 |
+
+\\
+
+| <<Authority_control_frameless_&#124;text-top_&#124;10px_&#124;alt=Edit_this_at_Wikidata_&#124;link=https&#58;//www.wikidata.org/wiki/Q1460#identifiers&#124;Edit_this_at_Wikidata>>                                                              |                                                                                                                          |
+| [[/wiki/Help:Authority_control][Authority control]] [[https://www.wikidata.org/wiki/Q1460#identifiers][[[//upload.wikimedia.org/wikipedia/en/thumb/8/8a/OOjs_UI_icon_edit-ltr-progressive.svg/10px-OOjs_UI_icon_edit-ltr-progressive.svg.png]]]] |                                                                                                                          |
+| General                                                                                                                                                                                                                                          | - [[https://d-nb.info/gnd/4055193-3][Integrated Authority File (Germany)]]                                               |
+|                                                                                                                                                                                                                                                  | - [[/wiki/ISNI_(identifier)][ISNI]]                                                                                      |
+|                                                                                                                                                                                                                                                  |                                                                                                                          |
+|                                                                                                                                                                                                                                                  |   - [[https://isni.org/isni/0000000417561787][1]]                                                                        |
+|                                                                                                                                                                                                                                                  |                                                                                                                          |
+|                                                                                                                                                                                                                                                  | - [[/wiki/VIAF_(identifier)][VIAF]]                                                                                      |
+|                                                                                                                                                                                                                                                  |                                                                                                                          |
+|                                                                                                                                                                                                                                                  |   - [[https://viaf.org/viaf/253278303][1]]                                                                               |
+|                                                                                                                                                                                                                                                  |   - [[https://viaf.org/viaf/149921888][2]]                                                                               |
+|                                                                                                                                                                                                                                                  |                                                                                                                          |
+|                                                                                                                                                                                                                                                  | - [[https://www.worldcat.org/identities/viaf-253278303][WorldCat]]                                                       |
+| National libraries                                                                                                                                                                                                                               | - [[https://id.loc.gov/authorities/names/n79018703][United States]]                                                      |
+|                                                                                                                                                                                                                                                  | - [[https://id.ndl.go.jp/auth/ndlna/00628588][Japan]]                                                                    |
+| Other                                                                                                                                                                                                                                            | - [[http://id.worldcat.org/fast/1204499/][Faceted Application of Subject Terminology]]                                   |
+|                                                                                                                                                                                                                                                  | - [[/wiki/MBAREA_(identifier)][MusicBrainz]] [[https://musicbrainz.org/area/d4c33fca-8194-4c8f-824c-9df8717138cc][area]] |
+|                                                                                                                                                                                                                                                  | - [[https://catalog.archives.gov/id/10044830][National Archives (US)]]                                                   |
+
+[[//en.wikipedia.org/wiki/Special:CentralAutoLogin/start?type=1x1]]
+
+Retrieved from
+"[[https://en.wikipedia.org/w/index.php?title=Sicily&oldid=1054637362]]"
+
+<<catlinks>>
+
+<<mw-normal-catlinks>>
+[[/wiki/Help:Category][Categories]]:
+
+- [[/wiki/Category:Sicily][Sicily]]
+- [[/wiki/Category:Former_countries_in_Europe][Former countries in
+  Europe]]
+- [[/wiki/Category:Islands_of_Italy][Islands of Italy]]
+- [[/wiki/Category:Mediterranean][Mediterranean]]
+- [[/wiki/Category:Mediterranean_islands][Mediterranean islands]]
+- [[/wiki/Category:NUTS_2_statistical_regions_of_the_European_Union][NUTS
+  2 statistical regions of the European Union]]
+- [[/wiki/Category:Regions_of_Italy][Regions of Italy]]
+- [[/wiki/Category:Wine_regions_of_Italy][Wine regions of Italy]]
+- [[/wiki/Category:Autonomous_regions_of_Italy][Autonomous regions of
+  Italy]]
+
+<<mw-hidden-catlinks>>
+Hidden categories:
+
+- [[/wiki/Category:CS1_Italian-language_sources_(it)][CS1
+  Italian-language sources (it)]]
+- [[/wiki/Category:CS1_errors:_missing_periodical][CS1 errors: missing
+  periodical]]
+- [[/wiki/Category:Articles_incorporating_a_citation_from_the_1913_Catholic_Encyclopedia_with_Wikisource_reference][Articles
+  incorporating a citation from the 1913 Catholic Encyclopedia with
+  Wikisource reference]]
+- [[/wiki/Category:CS1_errors:_URL][CS1 errors: URL]]
+- [[/wiki/Category:Webarchive_template_wayback_links][Webarchive
+  template wayback links]]
+- [[/wiki/Category:Articles_with_Italian-language_sources_(it)][Articles
+  with Italian-language sources (it)]]
+- [[/wiki/Category:All_articles_with_dead_external_links][All articles
+  with dead external links]]
+- [[/wiki/Category:Articles_with_dead_external_links_from_July_2021][Articles
+  with dead external links from July 2021]]
+- [[/wiki/Category:Articles_with_short_description][Articles with short
+  description]]
+- [[/wiki/Category:Short_description_is_different_from_Wikidata][Short
+  description is different from Wikidata]]
+- [[/wiki/Category:Wikipedia_indefinitely_move-protected_pages][Wikipedia
+  indefinitely move-protected pages]]
+- [[/wiki/Category:Coordinates_on_Wikidata][Coordinates on Wikidata]]
+- [[/wiki/Category:EngvarB_from_July_2019][EngvarB from July 2019]]
+- [[/wiki/Category:Use_dmy_dates_from_July_2019][Use dmy dates from July
+  2019]]
+- [[/wiki/Category:Articles_containing_Italian-language_text][Articles
+  containing Italian-language text]]
+- [[/wiki/Category:Articles_containing_Sicilian-language_text][Articles
+  containing Sicilian-language text]]
+- [[/wiki/Category:Pages_using_infobox_settlement_with_possible_demonym_list][Pages
+  using infobox settlement with possible demonym list]]
+- [[/wiki/Category:Pages_using_infobox_settlement_with_no_coordinates][Pages
+  using infobox settlement with no coordinates]]
+- [[/wiki/Category:Articles_containing_Ancient_Greek_(to_1453)-language_text][Articles
+  containing Ancient Greek (to 1453)-language text]]
+- [[/wiki/Category:All_articles_with_unsourced_statements][All articles
+  with unsourced statements]]
+- [[/wiki/Category:Articles_with_unsourced_statements_from_August_2020][Articles
+  with unsourced statements from August 2020]]
+- [[/wiki/Category:Articles_with_specifically_marked_weasel-worded_phrases_from_August_2020][Articles
+  with specifically marked weasel-worded phrases from August 2020]]
+- [[/wiki/Category:All_articles_with_specifically_marked_weasel-worded_phrases][All
+  articles with specifically marked weasel-worded phrases]]
+- [[/wiki/Category:Articles_with_unsourced_statements_from_February_2019][Articles
+  with unsourced statements from February 2019]]
+- [[/wiki/Category:Articles_with_unsourced_statements_from_September_2019][Articles
+  with unsourced statements from September 2019]]
+- [[/wiki/Category:All_articles_with_failed_verification][All articles
+  with failed verification]]
+- [[/wiki/Category:Articles_with_failed_verification_from_May_2016][Articles
+  with failed verification from May 2016]]
+- [[/wiki/Category:Articles_with_unsourced_statements_from_November_2008][Articles
+  with unsourced statements from November 2008]]
+- [[/wiki/Category:All_articles_lacking_reliable_references][All
+  articles lacking reliable references]]
+- [[/wiki/Category:Articles_lacking_reliable_references_from_September_2019][Articles
+  lacking reliable references from September 2019]]
+- [[/wiki/Category:All_articles_needing_additional_references][All
+  articles needing additional references]]
+- [[/wiki/Category:Articles_needing_additional_references_from_March_2020][Articles
+  needing additional references from March 2020]]
+- [[/wiki/Category:Commons_category_link_is_on_Wikidata][Commons
+  category link is on Wikidata]]
+- [[/wiki/Category:Articles_with_GND_identifiers][Articles with GND
+  identifiers]]
+- [[/wiki/Category:Articles_with_ISNI_identifiers][Articles with ISNI
+  identifiers]]
+- [[/wiki/Category:Articles_with_VIAF_identifiers][Articles with VIAF
+  identifiers]]
+- [[/wiki/Category:Articles_with_LCCN_identifiers][Articles with LCCN
+  identifiers]]
+- [[/wiki/Category:Articles_with_NDL_identifiers][Articles with NDL
+  identifiers]]
+- [[/wiki/Category:Articles_with_FAST_identifiers][Articles with FAST
+  identifiers]]
+- [[/wiki/Category:Articles_with_MusicBrainz_area_identifiers][Articles
+  with MusicBrainz area identifiers]]
+- [[/wiki/Category:Articles_with_NARA_identifiers][Articles with NARA
+  identifiers]]
+- [[/wiki/Category:Articles_with_WORLDCATID_identifiers][Articles with
+  WORLDCATID identifiers]]
+- [[/wiki/Category:Articles_with_multiple_identifiers][Articles with
+  multiple identifiers]]
+
+<<mw-data-after-content>>
+
+<<mw-navigation>>
+** Navigation menu
+   :PROPERTIES:
+   :CUSTOM_ID: navigation-menu
+   :END:
+
+<<mw-head>>
+*** Personal tools
+    :PROPERTIES:
+    :CUSTOM_ID: p-personal-label
+    :CLASS: vector-menu-heading
+    :aria-label: 
+    :END:
+
+- Not logged in
+- [[/wiki/Special:MyTalk][Talk]]
+- [[/wiki/Special:MyContributions][Contributions]]
+- [[/w/index.php?title=Special:CreateAccount&returnto=Sicily][Create
+  account]]
+- [[/w/index.php?title=Special:UserLogin&returnto=Sicily][Log in]]
+
+<<left-navigation>>
+*** Namespaces
+    :PROPERTIES:
+    :CUSTOM_ID: p-namespaces-label
+    :CLASS: vector-menu-heading
+    :aria-label: 
+    :END:
+
+- [[/wiki/Sicily][Article]]
+- [[/wiki/Talk:Sicily][Talk]]
+
+*** Variants expanded collapsed
+    :PROPERTIES:
+    :CUSTOM_ID: p-variants-label
+    :CLASS: vector-menu-heading
+    :aria-label: Change language variant
+    :END:
+
+<<right-navigation>>
+*** Views
+    :PROPERTIES:
+    :CUSTOM_ID: p-views-label
+    :CLASS: vector-menu-heading
+    :aria-label: 
+    :END:
+
+- [[/wiki/Sicily][Read]]
+- [[/w/index.php?title=Sicily&action=edit][Edit]]
+- [[/w/index.php?title=Sicily&action=history][View history]]
+
+*** More expanded collapsed
+    :PROPERTIES:
+    :CUSTOM_ID: p-cactions-label
+    :CLASS: vector-menu-heading
+    :aria-label: 
+    :END:
+
+<<p-search>>
+
+*** Search
+    :PROPERTIES:
+    :CUSTOM_ID: search
+    :END:
+
+<<simpleSearch>>
+
+<<mw-panel>>
+
+<<p-logo>>
+[[/wiki/Main_Page][]]
+
+*** Navigation
+    :PROPERTIES:
+    :CUSTOM_ID: p-navigation-label
+    :CLASS: vector-menu-heading
+    :aria-label: 
+    :END:
+
+- [[/wiki/Main_Page][Main page]]
+- [[/wiki/Wikipedia:Contents][Contents]]
+- [[/wiki/Portal:Current_events][Current events]]
+- [[/wiki/Special:Random][Random article]]
+- [[/wiki/Wikipedia:About][About Wikipedia]]
+- [[//en.wikipedia.org/wiki/Wikipedia:Contact_us][Contact us]]
+- [[https://donate.wikimedia.org/wiki/Special:FundraiserRedirector?utm_source=donate&utm_medium=sidebar&utm_campaign=C13_en.wikipedia.org&uselang=en][Donate]]
+
+*** Contribute
+    :PROPERTIES:
+    :CUSTOM_ID: p-interaction-label
+    :CLASS: vector-menu-heading
+    :aria-label: 
+    :END:
+
+- [[/wiki/Help:Contents][Help]]
+- [[/wiki/Help:Introduction][Learn to edit]]
+- [[/wiki/Wikipedia:Community_portal][Community portal]]
+- [[/wiki/Special:RecentChanges][Recent changes]]
+- [[/wiki/Wikipedia:File_Upload_Wizard][Upload file]]
+
+*** Tools
+    :PROPERTIES:
+    :CUSTOM_ID: p-tb-label
+    :CLASS: vector-menu-heading
+    :aria-label: 
+    :END:
+
+- [[/wiki/Special:WhatLinksHere/Sicily][What links here]]
+- [[/wiki/Special:RecentChangesLinked/Sicily][Related changes]]
+- [[/wiki/Wikipedia:File_Upload_Wizard][Upload file]]
+- [[/wiki/Special:SpecialPages][Special pages]]
+- [[/w/index.php?title=Sicily&oldid=1054637362][Permanent link]]
+- [[/w/index.php?title=Sicily&action=info][Page information]]
+- [[/w/index.php?title=Special:CiteThisPage&page=Sicily&id=1054637362&wpFormIdentifier=titleform][Cite
+  this page]]
+- [[https://www.wikidata.org/wiki/Special:EntityPage/Q1460][Wikidata
+  item]]
+
+*** Print/export
+    :PROPERTIES:
+    :CUSTOM_ID: p-coll-print_export-label
+    :CLASS: vector-menu-heading
+    :aria-label: 
+    :END:
+
+- [[/w/index.php?title=Special:DownloadAsPdf&page=Sicily&action=show-download-screen][Download
+  as PDF]]
+- [[/w/index.php?title=Sicily&printable=yes][Printable version]]
+
+*** In other projects
+    :PROPERTIES:
+    :CUSTOM_ID: p-wikibase-otherprojects-label
+    :CLASS: vector-menu-heading
+    :aria-label: 
+    :END:
+
+- [[https://commons.wikimedia.org/wiki/Sicilia][Wikimedia Commons]]
+- [[https://en.wikinews.org/wiki/Category:Sicily][Wikinews]]
+- [[https://en.wikivoyage.org/wiki/Sicily][Wikivoyage]]
+
+*** Languages
+    :PROPERTIES:
+    :CUSTOM_ID: p-lang-label
+    :CLASS: vector-menu-heading
+    :aria-label: 
+    :END:
+
+- [[https://af.wikipedia.org/wiki/Sisili%C3%AB][Afrikaans]]
+- [[https://als.wikipedia.org/wiki/Autonome_Region_Sizilien][Alemannisch]]
+- [[https://am.wikipedia.org/wiki/%E1%88%B2%E1%8A%AA%E1%88%8D%E1%8B%AB][አማርኛ]]
+- [[https://ang.wikipedia.org/wiki/Sicilia][Ænglisc]]
+- [[https://ar.wikipedia.org/wiki/%D8%B5%D9%82%D9%84%D9%8A%D8%A9][العربية]]
+- [[https://an.wikipedia.org/wiki/Secilia][Aragonés]]
+- [[https://arc.wikipedia.org/wiki/%DC%A3%DC%A9%DC%A0%DC%9D%DC%90][ܐܪܡܝܐ]]
+- [[https://frp.wikipedia.org/wiki/Secila][Arpetan]]
+- [[https://ast.wikipedia.org/wiki/Sicilia][Asturianu]]
+- [[https://az.wikipedia.org/wiki/Siciliya][Azərbaycanca]]
+- [[https://azb.wikipedia.org/wiki/%D8%B3%DB%8C%D8%B3%DB%8C%D9%84][تۆرکجه]]
+- [[https://bn.wikipedia.org/wiki/%E0%A6%B8%E0%A6%BF%E0%A6%B8%E0%A6%BF%E0%A6%B2%E0%A6%BF][বাংলা]]
+- [[https://zh-min-nan.wikipedia.org/wiki/Sicilia][Bân-lâm-gú]]
+- [[https://be.wikipedia.org/wiki/%D0%A1%D1%96%D1%86%D1%8B%D0%BB%D1%96%D1%8F][Беларуская]]
+- [[https://be-tarask.wikipedia.org/wiki/%D0%A1%D1%8B%D1%86%D1%8B%D0%BB%D1%96%D1%8F][Беларуская
+  (тарашкевіца)]]
+- [[https://bcl.wikipedia.org/wiki/Sicily][Bikol Central]]
+- [[https://bg.wikipedia.org/wiki/%D0%A1%D0%B8%D1%86%D0%B8%D0%BB%D0%B8%D1%8F][Български]]
+- [[https://bar.wikipedia.org/wiki/Sizilien][Boarisch]]
+- [[https://bo.wikipedia.org/wiki/%E0%BD%A6%E0%BD%B2%E0%BC%8B%E0%BD%85%E0%BD%B2%E0%BC%8B%E0%BD%A3%E0%BD%B2%E0%BC%8B%E0%BD%A1%E0%BC%8D][བོད་ཡིག]]
+- [[https://bs.wikipedia.org/wiki/Sicilija][Bosanski]]
+- [[https://br.wikipedia.org/wiki/Sikilia][Brezhoneg]]
+- [[https://ca.wikipedia.org/wiki/Sic%C3%ADlia][Català]]
+- [[https://cv.wikipedia.org/wiki/%D0%A1%D0%B8%D1%86%D0%B8%D0%BB%D0%B8][Чӑвашла]]
+- [[https://ceb.wikipedia.org/wiki/Sicilia][Cebuano]]
+- [[https://cs.wikipedia.org/wiki/Sic%C3%ADlie][Čeština]]
+- [[https://co.wikipedia.org/wiki/Sicilia][Corsu]]
+- [[https://cy.wikipedia.org/wiki/Sisili][Cymraeg]]
+- [[https://da.wikipedia.org/wiki/Sicilien][Dansk]]
+- [[https://ary.wikipedia.org/wiki/%D8%B5%D9%82%D9%84%D9%8A%D8%A9][الدارجة]]
+- [[https://se.wikipedia.org/wiki/Sicilia][Davvisámegiella]]
+- [[https://de.wikipedia.org/wiki/Autonome_Region_Sizilien][Deutsch]]
+- [[https://dsb.wikipedia.org/wiki/Siciliska][Dolnoserbski]]
+- [[https://et.wikipedia.org/wiki/Sitsiilia_maakond][Eesti]]
+- [[https://el.wikipedia.org/wiki/%CE%A3%CE%B9%CE%BA%CE%B5%CE%BB%CE%AF%CE%B1][Ελληνικά]]
+- [[https://eml.wikipedia.org/wiki/Siz%C3%A9gglia][Emiliàn e rumagnòl]]
+- [[https://es.wikipedia.org/wiki/Sicilia][Español]]
+- [[https://eo.wikipedia.org/wiki/Sicilio][Esperanto]]
+- [[https://ext.wikipedia.org/wiki/Sic%C3%ADlia][Estremeñu]]
+- [[https://eu.wikipedia.org/wiki/Sizilia][Euskara]]
+- [[https://fa.wikipedia.org/wiki/%D8%B3%DB%8C%D8%B3%DB%8C%D9%84][فارسی]]
+- [[https://fo.wikipedia.org/wiki/Sisilia][Føroyskt]]
+- [[https://fr.wikipedia.org/wiki/Sicile][Français]]
+- [[https://fy.wikipedia.org/wiki/Sisylje][Frysk]]
+- [[https://fur.wikipedia.org/wiki/Sicilie][Furlan]]
+- [[https://ga.wikipedia.org/wiki/An_tSicil][Gaeilge]]
+- [[https://gd.wikipedia.org/wiki/Sicilia][Gàidhlig]]
+- [[https://gl.wikipedia.org/wiki/Sicilia][Galego]]
+- [[https://hak.wikipedia.org/wiki/Sicilia][客家語/Hak-kâ-ngî]]
+- [[https://ko.wikipedia.org/wiki/%EC%8B%9C%EC%B9%A0%EB%A6%AC%EC%95%84][한국어]]
+- [[https://ha.wikipedia.org/wiki/Sisiliya][Hausa]]
+- [[https://hy.wikipedia.org/wiki/%D5%8D%D5%AB%D6%81%D5%AB%D5%AC%D5%AB%D5%A1_(%D5%B4%D5%A1%D6%80%D5%A6)][Հայերեն]]
+- [[https://hi.wikipedia.org/wiki/%E0%A4%B8%E0%A4%BF%E0%A4%B8%E0%A4%BF%E0%A4%B2%E0%A5%80][हिन्दी]]
+- [[https://hsb.wikipedia.org/wiki/Sicilska][Hornjoserbsce]]
+- [[https://hr.wikipedia.org/wiki/Sicilija][Hrvatski]]
+- [[https://io.wikipedia.org/wiki/Sicilia][Ido]]
+- [[https://ilo.wikipedia.org/wiki/Sicilia][Ilokano]]
+- [[https://id.wikipedia.org/wiki/Sisilia][Bahasa Indonesia]]
+- [[https://ia.wikipedia.org/wiki/Sicilia][Interlingua]]
+- [[https://ie.wikipedia.org/wiki/Sicilia][Interlingue]]
+- [[https://os.wikipedia.org/wiki/%D0%A1%D0%B8%D1%86%D0%B8%D0%BB%D0%B8][Ирон]]
+- [[https://is.wikipedia.org/wiki/Sikiley][Íslenska]]
+- [[https://it.wikipedia.org/wiki/Sicilia][Italiano]]
+- [[https://he.wikipedia.org/wiki/%D7%A1%D7%99%D7%A6%D7%99%D7%9C%D7%99%D7%94][עברית]]
+- [[https://jv.wikipedia.org/wiki/Sisilia][Jawa]]
+- [[https://pam.wikipedia.org/wiki/Sicily][Kapampangan]]
+- [[https://ka.wikipedia.org/wiki/%E1%83%A1%E1%83%98%E1%83%AA%E1%83%98%E1%83%9A%E1%83%98%E1%83%90][ქართული]]
+- [[https://kk.wikipedia.org/wiki/%D0%A1%D0%B8%D1%86%D0%B8%D0%BB%D0%B8%D1%8F][Қазақша]]
+- [[https://kw.wikipedia.org/wiki/Sisili][Kernowek]]
+- [[https://sw.wikipedia.org/wiki/Sisilia][Kiswahili]]
+- [[https://ku.wikipedia.org/wiki/S%C3%AEs%C3%AElya][Kurdî]]
+- [[https://ky.wikipedia.org/wiki/%D0%A1%D0%B8%D1%86%D0%B8%D0%BB%D0%B8%D1%8F][Кыргызча]]
+- [[https://lad.wikipedia.org/wiki/Sisilia][Ladino]]
+- [[https://la.wikipedia.org/wiki/Sicilia_(regio_Italiae)][Latina]]
+- [[https://lv.wikipedia.org/wiki/Sic%C4%ABlija][Latviešu]]
+- [[https://lb.wikipedia.org/wiki/Sizilien][Lëtzebuergesch]]
+- [[https://lt.wikipedia.org/wiki/Sicilija][Lietuvių]]
+- [[https://lij.wikipedia.org/wiki/Si%C3%A7illia][Ligure]]
+- [[https://li.wikipedia.org/wiki/Sicili%C3%AB][Limburgs]]
+- [[https://lfn.wikipedia.org/wiki/Sisilia][Lingua Franca Nova]]
+- [[https://lmo.wikipedia.org/wiki/Sicilia][Lombard]]
+- [[https://hu.wikipedia.org/wiki/Szic%C3%ADlia][Magyar]]
+- [[https://mk.wikipedia.org/wiki/%D0%A1%D0%B8%D1%86%D0%B8%D0%BB%D0%B8%D1%98%D0%B0][Македонски]]
+- [[https://ml.wikipedia.org/wiki/%E0%B4%B8%E0%B4%BF%E0%B4%B8%E0%B4%BF%E0%B4%B2%E0%B4%BF][മലയാളം]]
+- [[https://mt.wikipedia.org/wiki/Sqallija][Malti]]
+- [[https://mr.wikipedia.org/wiki/%E0%A4%B8%E0%A4%BF%E0%A4%9A%E0%A4%BF%E0%A4%B2%E0%A5%8D%E0%A4%AF%E0%A4%BE][मराठी]]
+- [[https://xmf.wikipedia.org/wiki/%E1%83%A1%E1%83%98%E1%83%AA%E1%83%98%E1%83%9A%E1%83%98%E1%83%90][მარგალური]]
+- [[https://arz.wikipedia.org/wiki/%D8%B3%D9%8A%D8%B3%D9%8A%D9%84%D9%8A%D8%A7][مصرى]]
+- [[https://mzn.wikipedia.org/wiki/%D8%B3%DB%8C%D8%B3%DB%8C%D9%84][مازِرونی]]
+- [[https://ms.wikipedia.org/wiki/Sicilia][Bahasa Melayu]]
+- [[https://cdo.wikipedia.org/wiki/Sicily][Mìng-dĕ̤ng-ngṳ̄]]
+- [[https://my.wikipedia.org/wiki/%E1%80%85%E1%80%85%E1%80%B9%E1%80%85%E1%80%9C%E1%80%AE%E1%80%80%E1%80%BB%E1%80%BD%E1%80%94%E1%80%BA%E1%80%B8][မြန်မာဘာသာ]]
+- [[https://nl.wikipedia.org/wiki/Sicili%C3%AB][Nederlands]]
+- [[https://ja.wikipedia.org/wiki/%E3%82%B7%E3%83%81%E3%83%AA%E3%82%A2][日本語]]
+- [[https://nap.wikipedia.org/wiki/Sicilia][Napulitano]]
+- [[https://ce.wikipedia.org/wiki/%D0%A1%D0%B8%D1%86%D0%B8%D0%BB%D0%B8][Нохчийн]]
+- [[https://frr.wikipedia.org/wiki/Siziilien][Nordfriisk]]
+- [[https://pih.wikipedia.org/wiki/Sicilii][Norfuk / Pitkern]]
+- [[https://no.wikipedia.org/wiki/Sicilia][Norsk bokmål]]
+- [[https://nn.wikipedia.org/wiki/Sicilia][Norsk nynorsk]]
+- [[https://nrm.wikipedia.org/wiki/Sicile][Nouormand]]
+- [[https://oc.wikipedia.org/wiki/Sic%C3%ADlia][Occitan]]
+- [[https://pa.wikipedia.org/wiki/%E0%A8%B8%E0%A8%BF%E0%A8%9A%E0%A9%80%E0%A8%B2%E0%A9%80%E0%A8%86][ਪੰਜਾਬੀ]]
+- [[https://pnb.wikipedia.org/wiki/%D8%B3%D8%B3%D9%84%DB%8C][پنجابی]]
+- [[https://pcd.wikipedia.org/wiki/Sicile][Picard]]
+- [[https://pms.wikipedia.org/wiki/Sicilia][Piemontèis]]
+- [[https://nds.wikipedia.org/wiki/Sizilien][Plattdüütsch]]
+- [[https://pl.wikipedia.org/wiki/Sycylia][Polski]]
+- [[https://pt.wikipedia.org/wiki/Sic%C3%ADlia][Português]]
+- [[https://crh.wikipedia.org/wiki/Siciliya][Qırımtatarca]]
+- [[https://ro.wikipedia.org/wiki/Sicilia][Română]]
+- [[https://qu.wikipedia.org/wiki/Sicilia][Runa Simi]]
+- [[https://ru.wikipedia.org/wiki/%D0%A1%D0%B8%D1%86%D0%B8%D0%BB%D0%B8%D1%8F][Русский]]
+- [[https://sah.wikipedia.org/wiki/%D0%A1%D0%B8%D1%86%D0%B8%D0%B8%D0%BB%D0%B8%D0%B9%D1%8D][Саха
+  тыла]]
+- [[https://sc.wikipedia.org/wiki/Sitz%C3%AClia][Sardu]]
+- [[https://sco.wikipedia.org/wiki/Sicily][Scots]]
+- [[https://sq.wikipedia.org/wiki/Si%C3%A7ilia][Shqip]]
+- [[https://scn.wikipedia.org/wiki/Sicilia][Sicilianu]]
+- [[https://simple.wikipedia.org/wiki/Sicily][Simple English]]
+- [[https://sk.wikipedia.org/wiki/Sic%C3%ADlia_(auton%C3%B3mny_regi%C3%B3n)][Slovenčina]]
+- [[https://sl.wikipedia.org/wiki/Sicilija_(de%C5%BEela)][Slovenščina]]
+- [[https://szl.wikipedia.org/wiki/Sycylijo][Ślůnski]]
+- [[https://so.wikipedia.org/wiki/Sasiiliya][Soomaaliga]]
+- [[https://ckb.wikipedia.org/wiki/%D8%B3%DB%8C%D8%B3%DB%8C%D9%84%DB%8C%D8%A7][کوردی]]
+- [[https://sr.wikipedia.org/wiki/%D0%A1%D0%B8%D1%86%D0%B8%D0%BB%D0%B8%D1%98%D0%B0][Српски
+  / srpski]]
+- [[https://sh.wikipedia.org/wiki/Sicilija][Srpskohrvatski /
+  српскохрватски]]
+- [[https://fi.wikipedia.org/wiki/Sisilian_alue][Suomi]]
+- [[https://sv.wikipedia.org/wiki/Sicilien][Svenska]]
+- [[https://tl.wikipedia.org/wiki/Sicilia][Tagalog]]
+- [[https://ta.wikipedia.org/wiki/%E0%AE%9A%E0%AE%BF%E0%AE%9A%E0%AE%BF%E0%AE%B2%E0%AE%BF][தமிழ்]]
+- [[https://roa-tara.wikipedia.org/wiki/Sicilie][Tarandíne]]
+- [[https://tt.wikipedia.org/wiki/%D0%A1%D0%B8%D1%86%D0%B8%D0%BB%D0%B8%D1%8F_(%D1%82%D3%A9%D0%B1%D3%99%D0%BA)][Татарча/tatarça]]
+- [[https://te.wikipedia.org/wiki/%E0%B0%B8%E0%B0%BF%E0%B0%B8%E0%B0%BF%E0%B0%B2%E0%B1%80][తెలుగు]]
+- [[https://th.wikipedia.org/wiki/%E0%B9%81%E0%B8%84%E0%B8%A7%E0%B9%89%E0%B8%99%E0%B8%8B%E0%B8%B4%E0%B8%8B%E0%B8%B4%E0%B8%A5%E0%B8%B5][ไทย]]
+- [[https://tr.wikipedia.org/wiki/Sicilya][Türkçe]]
+- [[https://uk.wikipedia.org/wiki/%D0%A1%D0%B8%D1%86%D0%B8%D0%BB%D1%96%D1%8F][Українська]]
+- [[https://ur.wikipedia.org/wiki/%D8%B5%D9%82%D9%84%DB%8C%DB%81][اردو]]
+- [[https://ug.wikipedia.org/wiki/%D8%B3%D9%89%D8%AA%D8%B3%D9%89%D9%84%D9%89%D9%8A%DB%95][ئۇيغۇرچە
+  / Uyghurche]]
+- [[https://vec.wikipedia.org/wiki/Sic%C3%AClia][Vèneto]]
+- [[https://vi.wikipedia.org/wiki/Sicilia][Tiếng Việt]]
+- [[https://vls.wikipedia.org/wiki/Sicili%C3%AB][West-Vlams]]
+- [[https://war.wikipedia.org/wiki/Sicilia][Winaray]]
+- [[https://wuu.wikipedia.org/wiki/%E8%A5%BF%E8%A5%BF%E9%87%8C%E5%B2%9B][吴语]]
+- [[https://ts.wikipedia.org/wiki/Sicily][Xitsonga]]
+- [[https://yi.wikipedia.org/wiki/%D7%A1%D7%99%D7%A6%D7%99%D7%9C%D7%99%D7%A2][ייִדיש]]
+- [[https://yo.wikipedia.org/wiki/Sicily][Yorùbá]]
+- [[https://zh-yue.wikipedia.org/wiki/%E8%A5%BF%E8%A5%BF%E9%87%8C][粵語]]
+- [[https://diq.wikipedia.org/wiki/Sicilya][Zazaki]]
+- [[https://zh.wikipedia.org/wiki/%E8%A5%BF%E8%A5%BF%E9%87%8C%E5%B2%9B][中文]]
+
+[[https://www.wikidata.org/wiki/Special:EntityPage/Q1460#sitelinks-wikipedia][Edit
+links]]
+
+- This page was last edited on 11 November 2021, at 06:55 (UTC).
+- Text is available under the
+  [[//en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_3.0_Unported_License][Creative
+  Commons Attribution-ShareAlike
+  License]][[//creativecommons.org/licenses/by-sa/3.0/][]]; additional
+  terms may apply. By using this site, you agree to the
+  [[//foundation.wikimedia.org/wiki/Terms_of_Use][Terms of Use]] and
+  [[//foundation.wikimedia.org/wiki/Privacy_policy][Privacy Policy]].
+  Wikipedia® is a registered trademark of the
+  [[//www.wikimediafoundation.org/][Wikimedia Foundation, Inc.]], a
+  non-profit organization.
+
+- [[https://foundation.wikimedia.org/wiki/Privacy_policy][Privacy
+  policy]]
+- [[/wiki/Wikipedia:About][About Wikipedia]]
+- [[/wiki/Wikipedia:General_disclaimer][Disclaimers]]
+- [[//en.wikipedia.org/wiki/Wikipedia:Contact_us][Contact Wikipedia]]
+- [[//en.m.wikipedia.org/w/index.php?title=Sicily&mobileaction=toggle_view_mobile][Mobile
+  view]]
+- [[https://www.mediawiki.org/wiki/Special:MyLanguage/How_to_contribute][Developers]]
+- [[https://stats.wikimedia.org/#/en.wikipedia.org][Statistics]]
+- [[https://foundation.wikimedia.org/wiki/Cookie_statement][Cookie
+  statement]]
+
+- [[https://wikimediafoundation.org/][[[/static/images/footer/wikimedia-button.png]]]]
+- [[https://www.mediawiki.org/][[[/static/images/footer/poweredby_mediawiki_88x31.png]]]]

--- a/test/note-files/big-note.org
+++ b/test/note-files/big-note.org
@@ -23,6 +23,29 @@ condimentum erat eget erat aliquet accumsan. Etiam vestibulum sed nibh et
 venenatis. Duis porta auctor egestas. Fusce facilisis odio ut odio congue
 blandit vitae id ante. Donec at orci quis eros elementum interdum et id lectus.
 
+And some links:
+
+- https://reference0.org
+- https://reference1.org
+- https://reference2.org
+- https://reference3.org
+- https://reference4.org
+- https://reference5.org
+- https://reference6.org
+- https://reference7.org
+- https://reference8.org
+- https://reference9.org
+- https://reference10.org
+- https://reference11.org
+- https://reference12.org
+- https://reference13.org
+- https://reference14.org
+- https://reference15.org
+- https://reference16.org
+- https://reference17.org
+- https://reference18.org
+- https://reference19.org
+
 * Big note sub-heading
 :PROPERTIES:
 :ID:                     b77a4837-71d6-495e-98f1-b576464aacc1

--- a/test/note-files/with-meta.org
+++ b/test/note-files/with-meta.org
@@ -25,4 +25,5 @@ Don't mind me. I am a content of this note.
 :ID:                     f210cc49-0e71-4bb6-843f-89dd2d809e02
 :END:
 
-Probably you've heard about [[https://github.com][GitHub]].
+Probably you've heard about [[https://github.com][GitHub]]. And of course, you may have links with
+strange symbols like % and ', just like this [[https://en.wikipedia.org/wiki/I,_Olga_Hepnarov%C3%A1][link]] or this [[https://www.darenberg.com.au/assets/files/d'arenberg-the-stump-jump-lightly-wooded-chardonnay-2017.pdf][link]].

--- a/test/note-files/with-meta.org
+++ b/test/note-files/with-meta.org
@@ -19,3 +19,10 @@
 - answer :: 42
 
 Don't mind me. I am a content of this note.
+
+* Details
+:PROPERTIES:
+:ID:                     f210cc49-0e71-4bb6-843f-89dd2d809e02
+:END:
+
+Probably you've heard about [[https://github.com][GitHub]].

--- a/test/vulpea-db-test.el
+++ b/test/vulpea-db-test.el
@@ -873,26 +873,6 @@
                (emacsql-escape-identifier index-name))
               :to-equal (list (list (intern (emacsql-escape-identifier index-name))))))
 
-    ;; and we are able to query stuff, but extra info is not yet
-    ;; available as we did not run a full sync
-    (expect (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd")
-            :to-equal
-            (make-vulpea-note
-             :path (expand-file-name "with-meta.org" org-roam-directory)
-             :title "Note with META"
-             :tags nil
-             :level 0
-             :id "05907606-f836-45bf-bd36-a8444308eddd"
-             :links '(("https" . "https://en.wikipedia.org/wiki/Frappato")
-                      ("id" . "444f94d7-61e0-4b7c-bb7e-100814c6b4bb")
-                      ("id" . "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7"))
-             :properties (list
-                          (cons "CATEGORY" "with-meta")
-                          (cons "ID" "05907606-f836-45bf-bd36-a8444308eddd")
-                          (cons "BLOCKED" "")
-                          (cons "FILE" (expand-file-name "with-meta.org" org-roam-directory))
-                          (cons "PRIORITY" "B"))))
-
     ;; sync a file
     (message "update file")
     (org-roam-db-clear-file (expand-file-name "with-meta.org" org-roam-directory))

--- a/test/vulpea-db-test.el
+++ b/test/vulpea-db-test.el
@@ -823,6 +823,39 @@
             :to-equal
             "eeec8f05-927f-4c61-b39e-2fb8228cf484")))
 
+(describe "clear file"
+  (before-all
+    (vulpea-test--init))
+
+  (after-all
+    (vulpea-test--teardown))
+
+  (it "removing a file removes it from all tables"
+    (let* ((id "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7")
+           (note (vulpea-db-get-by-id id))
+           (file (vulpea-note-path note)))
+      (org-roam-db-clear-file file)
+      (expect (org-roam-db-query [:select *
+                                  :from files
+                                  :where (= file $s1)]
+                                 file)
+              :to-be nil)
+      (expect (org-roam-db-query [:select *
+                                  :from nodes
+                                  :where (= id $s1)]
+                                 id)
+              :to-be nil)
+      (expect (org-roam-db-query [:select *
+                                  :from notes
+                                  :where (= id $s1)]
+                                 id)
+              :to-be nil)
+      (expect (org-roam-db-query [:select *
+                                  :from meta
+                                  :where (= node-id $s1)]
+                                 id)
+              :to-be nil))))
+
 (describe "vulpea-db-setup"
   (before-all
     (vulpea-test--init 'no-setup))

--- a/test/vulpea-meta-test.el
+++ b/test/vulpea-meta-test.el
@@ -486,6 +486,13 @@ Just some text to make sure that meta is inserted before.
 #+title: Note with META
 
 Don't mind me. I am a content of this note.
+
+* Details
+:PROPERTIES:
+:ID:                     f210cc49-0e71-4bb6-843f-89dd2d809e02
+:END:
+
+Probably you've heard about [[https://github.com][GitHub]].
 "))))
 
 (provide 'vulpea-meta-test)

--- a/test/vulpea-meta-test.el
+++ b/test/vulpea-meta-test.el
@@ -492,7 +492,8 @@ Don't mind me. I am a content of this note.
 :ID:                     f210cc49-0e71-4bb6-843f-89dd2d809e02
 :END:
 
-Probably you've heard about [[https://github.com][GitHub]].
+Probably you've heard about [[https://github.com][GitHub]]. And of course, you may have links with
+strange symbols like % and ', just like this [[https://en.wikipedia.org/wiki/I,_Olga_Hepnarov%C3%A1][link]] or this [[https://www.darenberg.com.au/assets/files/d'arenberg-the-stump-jump-lightly-wooded-chardonnay-2017.pdf][link]].
 "))))
 
 (provide 'vulpea-meta-test)

--- a/test/vulpea-perf-test.el
+++ b/test/vulpea-perf-test.el
@@ -103,7 +103,7 @@ and the time taken by garbage collection. See also
   (format "%s notes"
           (seq-length notes)))
 
-(xdescribe "vulpea performance"
+(describe "vulpea performance"
   (before-all
     (vulpea-perf--init))
 

--- a/test/vulpea-perf-test.el
+++ b/test/vulpea-perf-test.el
@@ -78,11 +78,11 @@ When DISABLE-VULPEA-AUTOSYNC is non-nil,
                  (caar (emacsql db "select count(*) from nodes")))
         (emacsql db [:pragma (= foreign_keys 0)])
         (emacsql db (format "update nodes set file = '\"' || '%s' || replace(file, '\"', '') || '\"'"
-                            (string-remove-suffix "/" org-roam-directory)))
+                            (file-name-as-directory org-roam-directory)))
         (emacsql db (format "update files set file = '\"' || '%s' || replace(file, '\"', '') || '\"'"
-                            (string-remove-suffix "/" org-roam-directory)))
+                            (file-name-as-directory org-roam-directory)))
         (emacsql db (format "update notes set path = '\"' || '%s' || replace(path, '\"', '') || '\"'"
-                            (string-remove-suffix "/" org-roam-directory)))))
+                            (file-name-as-directory org-roam-directory)))))
     (unless disable-vulpea-autosync
       (vulpea-db-autosync-enable))
     (unless disable-org-roam-autosync

--- a/test/vulpea-perf-test.el
+++ b/test/vulpea-perf-test.el
@@ -279,7 +279,7 @@ and the time taken by garbage collection. See also
             (* 3 (nth 1 bres-bare)))))
 
 (describe "vulpea sync performance"
-  (it "should not create huge footprint on synchronisation"
+  (xit "should not create huge footprint on synchronisation"
     (let ((runs 1)
           (bres-bare)
           (bres-vulpea))

--- a/test/vulpea-perf-test.el
+++ b/test/vulpea-perf-test.el
@@ -38,7 +38,7 @@
 (require 'org-roam)
 (require 'vulpea)
 
-(defconst vulpea-perf-zip-branch "view-table")
+(defconst vulpea-perf-zip-branch "vulpea-view-table")
 
 (defconst vulpea-perf-zip-url
   (format
@@ -57,17 +57,19 @@
                                   vulpea-perf-zip-branch)
                           temp-loc)))
     (setq org-roam-directory (expand-file-name "notes/" test-notes-dir)
-          org-roam-db-location (expand-file-name "org-roam.db" test-notes-dir))
+          org-roam-db-location (expand-file-name "org-roam.db" org-roam-directory))
     (message "Initializing vulpea in %s" org-roam-directory)
     ;; fix file path values
     (let ((db (emacsql-sqlite org-roam-db-location)))
+      (message "Count of notes: %s"
+             (caar (emacsql db "select count(*) from nodes")))
       (emacsql db [:pragma (= foreign_keys 0)])
       (emacsql db (format "update nodes set file = '\"' || '%s' || replace(file, '\"', '') || '\"'"
-                          org-roam-directory))
+                          (string-remove-suffix "/" org-roam-directory)))
       (emacsql db (format "update files set file = '\"' || '%s' || replace(file, '\"', '') || '\"'"
-                          org-roam-directory))
+                          (string-remove-suffix "/" org-roam-directory)))
       (emacsql db (format "update notes set path = '\"' || '%s' || replace(path, '\"', '') || '\"'"
-                          org-roam-directory)))
+                          (string-remove-suffix "/" org-roam-directory))))
     (vulpea-db-autosync-enable)
     (org-roam-db-autosync-enable)))
 

--- a/test/vulpea-test.el
+++ b/test/vulpea-test.el
@@ -267,13 +267,13 @@
           (vulpea-create
            "Aglianico"
            "prefix-${slug}.org"
-           :head "#+roam_key: ${url}"
+           :head "#+author: ${name}"
            :tags '("tag1" "tag2")
            :body "Well, I am a grape!"
            :unnarrowed t
            :immediate-finish t
            :context
-           (list :url "https://d12frosted.io")
+           (list :name "frodo")
            :properties
            (list (cons "MY_TAG" "super-tag"))))
     (expect note
@@ -284,7 +284,6 @@
              :tags '("tag1" "tag2")
              :level 0
              :id (vulpea-note-id note)
-             :links '(("https" . "https://d12frosted.io"))
              :properties (list
                           (cons "CATEGORY" "prefix-aglianico")
                           (cons "MY_TAG" "super-tag")
@@ -304,7 +303,7 @@
 :END:
 #+title: Aglianico
 #+filetags: :tag1:tag2:
-#+roam_key: https://d12frosted.io
+#+author: frodo
 
 Well, I am a grape!
 "

--- a/vulpea-db.el
+++ b/vulpea-db.el
@@ -595,18 +595,16 @@ GET-DB is a function that returns connection to database."
       (seq-map
        (lambda (kvp)
          (org-roam-db-query
-          (format "update notes set links = '%s' where id = '\"%s\"'"
-                  (concat
-                   "("
-                   (string-join
-                    (seq-map
-                     (lambda (link)
-                       (format "(\"%s\" \"%s\")"
-                               (nth 1 link) (nth 2 link)))
-                     (cdr kvp))
-                    " ")
-                   ")")
-                  (car kvp))))
+          [:update notes
+           :set (= links $s2)
+           :where (= id $s1)]
+          (car kvp)
+          (seq-map
+           (lambda (link)
+             (list
+              (nth 1 link)
+              (nth 2 link)))
+           (cdr kvp))))
        kvps))))
 
 (defun vulpea-db--parse-link-element (link)

--- a/vulpea-db.el
+++ b/vulpea-db.el
@@ -341,7 +341,8 @@ If the FILE is relative, it is considered to be relative to
        aliases
        tags
        meta
-       links]))
+       links]
+      (:foreign-key [path] :references files [file] :on-delete :cascade)))
     (meta
      ([(node-id :not-null)
        (prop :not-null)

--- a/vulpea.el
+++ b/vulpea.el
@@ -5,7 +5,7 @@
 ;; Author: Boris Buliga <boris@d12frosted.io>
 ;; Maintainer: Boris Buliga <boris@d12frosted.io>
 ;; Version: 0.2.0
-;; Package-Requires: ((emacs "27.1") (org "9.4.4") (org-roam "2.0.0") (s "1.12"))
+;; Package-Requires: ((emacs "27.2") (org "9.4.4") (org-roam "2.0.0") (s "1.12"))
 ;;
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as


### PR DESCRIPTION
Release plan:

1. [x] Finish benchmarks.
2. [x] Document this change.
3. [x] Use it privately for some time.
4. [x] If everything is fine, merge to master.

After some time (e.g. maybe one week or more), I release new version of `vulpea`.

---

I am still not happy with performance query functions on a set of 9k+
notes. Partially, the culprit here is that horrific SQL. The more
tables I want to multiply, the worse performance becomes.

So idea here is simple. Instead of doing multiplication of matrices
during query operation, use a view table where every row is a full
`vulpea-note` (in reality multiple notes because of aliases, but
that's irrelevant here). This new view table is used in the following
functions:

- `vulpea-db-query`
- `vulpea-db-query-by-ids`
- `vulpea-db-get-by-id`

This transitively affects all specialized queries.

The way view table is being built is not optimal as it parses the
buffer for the second time in addition to `org-roam` routine. Ideally
this feature should be proposed to `org-roam` thus improving build
time.

Benchamarks
===========

Count of notes: 9554.

General benchmark with regular `org-roam` tables
------------------------------------------------

| test          | result size |            generic |  specialized |
| ------------- | ----------- | ------------------ | ------------ |
| `tags-some`   | 30 notes    | 4.6693460650999995 | 0.0605194177 |
| `tags-every`  | 3168 notes  | 4.7333844436999996 | 1.0618131127 |
| `links-some`  | 1657 notes  |       4.8095771283 |  1.362214091 |
| `links-every` | 92 notes    | 4.5517473337999995 | 0.1707312557 |

General benchmark with view table
---------------------------------

| test          | result size |            generic |        specialized |
| ------------- | ----------- | ------------------ | ------------------ |
| `tags-some`   | 30 notes    |       1.0112478712 |       0.0066033426 |
| `tags-every=` | 3168 notes  |       1.0059819176 | 0.5709392964999999 |
| `links-some`  | 1657 notes  | 1.0462236128999999 |       0.4248580532 |
| `links-every` | 92 notes    |       1.0204833089 |       0.0545313596 |

Comparison of `vulpea-db-query`
-------------------------------

| test          | result size |            regular |         view table |     ratio |
| ------------- | ----------- | ------------------ | ------------------ | --------- |
| `tags-some`   | 30 notes    | 4.6693460650999995 |       1.0112478712 | 4.6174100 |
| `tags-every`  | 3168 notes  | 4.7333844436999996 |       1.0059819176 | 4.7052381 |
| `links-some`  | 1657 notes  |       4.8095771283 | 1.0462236128999999 | 4.5970833 |
| `links-every` | 92 notes    | 4.5517473337999995 |       1.0204833089 | 4.4603839 |

Since `vulpea-db-query` loads everything into memory, no surprise that
improvement is pretty much the same across test scenarios. The good
part here is that on average new implementation performs 4.595 times
faster. And since it stays around 1 second for 9554 notes it makes it
quite practical.

Comparison of specialized queries
---------------------------------

| test          | result size |      regular |         view table |     ratio |
| ------------- | ----------- | ------------ | ------------------ | --------- |
| `tags-some`   | 30 notes    | 0.0605194177 |       0.0066033426 | 9.1649671 |
| `tags-every`  | 3168 notes  | 1.0618131127 | 0.5709392964999999 | 1.8597653 |
| `links-some`  | 1657 notes  |  1.362214091 |       0.4248580532 | 3.2062805 |
| `links-every` | 92 notes    | 0.1707312557 |       0.0545313596 | 3.1308821 |

Since specialized query performance depends on result size (e.g. how
many notes it needs to load into memory) the improvement is not
stable. But even for big slices it outperforms previous
implementation. On average, new implementation performs 4.34 times
faster. Not really useful metric in this case, but still.

Comparison of db sync
---------------------

Now the real question is how synchronisation is affected. We have the
following test scenarios.

1. Sync one small sized note.
2. Sync one medium sized note.
3. Sync one big sized note.
4. Sync vulpea-test-notes (e.g. 9554 relatively small sized notes).

| test                |            regular |     view table |         diff |     ratio |
| ------------------- | ------------------ | -------------- | ------------ | --------- |
| `vulpea-test-notes` | 172.79389154999998 |   337.61603822 |    164.82215 | 1.9538656 |
| `small`             |     0.000354079889 | 0.000416262194 | 6.2182305e-5 | 1.1756166 |
| `medium`            |     0.000492199416 | 0.000539389997 | 4.7190581e-5 | 1.0958770 |
| `huge`              |       0.1732851848 |   0.2240508243 |  0.050765640 | 1.2929601 |

As you can see, it affects dramatically full rebuild, but when it
comes to singular updates, the difference is pretty small.

Conclusion
----------

View table improves query performance dramatically. Since most of the
time I am using query functions and reading notes, this small
difference on syncing small to medium files is not critical for
release of view tables. Though full rebuild penalty is quite big and
should improved in the future iterations.

P. S. I am leaving the full sync test case disabled because I don't
want to add 8.5 minutes to the tests. If needed, just replace xit with
it.
