### PR TITLE
(fix) Only insert new line when there is more than one meta item

### DIFF
--- a/vulpea-buffer.el
+++ b/vulpea-buffer.el
@@ -311,8 +311,9 @@ which case VALUE is added at the end of the meta."
               (org-element-copy img)
               (vulpea-buffer-meta-format val)))))
          values)
-        (when (equal (length items)
-                     (length (org-element-contents pl)))
+        (when (and (equal (length items)
+                          (length (org-element-contents pl)))
+                   (> (length items) 1))
           (insert "\n")))
 
        ;; property is not yet set, simply set it


### PR DESCRIPTION
Addresses #134

I haven't added a test for this because:
- I have never worked with `eldev` before 😅 
- I couldn't find a test suit for `vulpea-buffer-meta-set`

That being said, I'm very happy to learn `eldev` & introduce some tests for this function in general, including coverage for my fix. 