### PR TITLE
dev: disable 28.1 build for now

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          - 28.1
+          # - 28.1
           - snapshot
     env:
       ORG_ROAM_V2_PATH: .org-roam


### PR DESCRIPTION
There are some differences I am not ready to tackle. They affect only tests, so it's not critical.