### PR TITLE
feat: respect aliases in meta blocks when extracting value as note

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -16,6 +16,7 @@
 - [[https://github.com/d12frosted/vulpea/issues/130][vulpea#130]] Introduce mechanism to automatically rebuild database when needed. This happens either on the first usage of Vulpea or when =vulpea-db-version= increases.
 - [[https://github.com/d12frosted/vulpea/pull/158][vulpea#158]] Introduce mechanism to define more tables in Org Roam database (see =vulpea-db-define-table=). And provide a hook to fill defined tables with data (see =vulpea-db-insert-note-functions=).
 - Handle forced database sync. Whenever it happens, make sure that all the extra tables are initialized and versions are set accordingly.
+- Respect aliases used in the meta blocks when extracting value as a note.
 
 ** v0.3.0
 :PROPERTIES:

--- a/test/note-files/with-meta.org
+++ b/test/note-files/with-meta.org
@@ -14,6 +14,8 @@
 - symbol :: red
 - url :: [[https://en.wikipedia.org/wiki/Frappato][wikipedia.org]]
 - link :: [[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Note without META]]
+- link with alias :: [[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Alias of the note without meta]]
+- link with arbitrary desc :: [[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][haha]]
 - references :: [[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Note without META]]
 - references :: [[id:5093fc4e-8c63-4e60-a1da-83fc7ecd5db7][Reference]]
 - answer :: 42

--- a/test/note-files/without-meta.org
+++ b/test/note-files/without-meta.org
@@ -1,5 +1,6 @@
 :PROPERTIES:
 :ID:                     444f94d7-61e0-4b7c-bb7e-100814c6b4bb
+:ROAM_ALIASES:           "Alias of the note without meta"
 :END:
 #+title: Note without META
 

--- a/test/vulpea-db-test.el
+++ b/test/vulpea-db-test.el
@@ -216,6 +216,8 @@
                 ("symbol" . ("red"))
                 ("url" . ("[[https://en.wikipedia.org/wiki/Frappato][wikipedia.org]]"))
                 ("link" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Note without META]]"))
+                ("link with alias" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Alias of the note without meta]]"))
+                ("link with arbitrary desc" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][haha]]"))
                 ("references" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Note without META]]"
                                  "[[id:5093fc4e-8c63-4e60-a1da-83fc7ecd5db7][Reference]]"))
                 ("answer" . ("42")))
@@ -447,6 +449,8 @@
                 ("symbol" . ("red"))
                 ("url" . ("[[https://en.wikipedia.org/wiki/Frappato][wikipedia.org]]"))
                 ("link" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Note without META]]"))
+                ("link with alias" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Alias of the note without meta]]"))
+                ("link with arbitrary desc" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][haha]]"))
                 ("references" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Note without META]]"
                                  "[[id:5093fc4e-8c63-4e60-a1da-83fc7ecd5db7][Reference]]"))
                 ("answer" . ("42")))
@@ -514,6 +518,8 @@
                 ("symbol" . ("red"))
                 ("url" . ("[[https://en.wikipedia.org/wiki/Frappato][wikipedia.org]]"))
                 ("link" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Note without META]]"))
+                ("link with alias" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Alias of the note without meta]]"))
+                ("link with arbitrary desc" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][haha]]"))
                 ("references" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Note without META]]"
                                  "[[id:5093fc4e-8c63-4e60-a1da-83fc7ecd5db7][Reference]]"))
                 ("answer" . ("42")))
@@ -619,6 +625,8 @@
                 ("symbol" . ("red"))
                 ("url" . ("[[https://en.wikipedia.org/wiki/Frappato][wikipedia.org]]"))
                 ("link" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Note without META]]"))
+                ("link with alias" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Alias of the note without meta]]"))
+                ("link with arbitrary desc" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][haha]]"))
                 ("references" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Note without META]]"
                                  "[[id:5093fc4e-8c63-4e60-a1da-83fc7ecd5db7][Reference]]"))
                 ("answer" . ("42")))
@@ -686,6 +694,8 @@
                 ("symbol" . ("red"))
                 ("url" . ("[[https://en.wikipedia.org/wiki/Frappato][wikipedia.org]]"))
                 ("link" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Note without META]]"))
+                ("link with alias" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Alias of the note without meta]]"))
+                ("link with arbitrary desc" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][haha]]"))
                 ("references" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Note without META]]"
                                  "[[id:5093fc4e-8c63-4e60-a1da-83fc7ecd5db7][Reference]]"))
                 ("answer" . ("42")))
@@ -801,6 +811,8 @@
                      ("symbol" . ("red"))
                      ("url" . ("[[https://en.wikipedia.org/wiki/Frappato][wikipedia.org]]"))
                      ("link" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Note without META]]"))
+                     ("link with alias" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Alias of the note without meta]]"))
+                     ("link with arbitrary desc" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][haha]]"))
                      ("references" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Note without META]]"
                                       "[[id:5093fc4e-8c63-4e60-a1da-83fc7ecd5db7][Reference]]"))
                      ("answer" . ("42")))
@@ -980,6 +992,8 @@
                      ("symbol" . ("red"))
                      ("url" . ("[[https://en.wikipedia.org/wiki/Frappato][wikipedia.org]]"))
                      ("link" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Note without META]]"))
+                     ("link with alias" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Alias of the note without meta]]"))
+                     ("link with arbitrary desc" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][haha]]"))
                      ("references" . ("[[id:444f94d7-61e0-4b7c-bb7e-100814c6b4bb][Note without META]]"
                                       "[[id:5093fc4e-8c63-4e60-a1da-83fc7ecd5db7][Reference]]"))
                      ("answer" . ("42")))

--- a/test/vulpea-meta-test.el
+++ b/test/vulpea-meta-test.el
@@ -61,6 +61,20 @@
     (expect (vulpea-meta-get "05907606-f836-45bf-bd36-a8444308eddd" "link" 'note)
             :to-equal (vulpea-db-get-by-id "444f94d7-61e0-4b7c-bb7e-100814c6b4bb")))
 
+  (it "extracts note value respecting alias"
+    (expect (vulpea-note-title
+             (vulpea-meta-get
+              (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd")
+              "link with alias" 'note))
+            :to-equal "Alias of the note without meta"))
+
+  (it "extracts note value ignoring unknown title"
+    (expect (vulpea-note-title
+             (vulpea-meta-get
+              (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd")
+              "link with arbitrary desc" 'note))
+            :to-equal "Note without META"))
+
   (it "extracts symbol value"
     (expect (vulpea-meta-get "05907606-f836-45bf-bd36-a8444308eddd" "symbol" 'symbol)
             :to-equal 'red))
@@ -237,7 +251,7 @@
                         (plist-get (vulpea-meta with-meta-id)
                                    :pl)
                         'item #'identity))
-            :to-equal 14)
+            :to-equal 16)
     (vulpea-meta-clean with-meta-id)
     (expect (length (org-element-map
                         (plist-get (vulpea-meta with-meta-id)
@@ -278,6 +292,7 @@
               :to-contain-exactly
               ":PROPERTIES:
 :ID:                     444f94d7-61e0-4b7c-bb7e-100814c6b4bb
+:ROAM_ALIASES:           \"Alias of the note without meta\"
 :END:
 #+title: Note without META
 
@@ -292,6 +307,7 @@ Just some text to make sure that meta is inserted before.
               :to-contain-exactly
               ":PROPERTIES:
 :ID:                     444f94d7-61e0-4b7c-bb7e-100814c6b4bb
+:ROAM_ALIASES:           \"Alias of the note without meta\"
 :END:
 #+title: Note without META
 
@@ -306,6 +322,7 @@ Just some text to make sure that meta is inserted before.
               :to-contain-exactly
               ":PROPERTIES:
 :ID:                     444f94d7-61e0-4b7c-bb7e-100814c6b4bb
+:ROAM_ALIASES:           \"Alias of the note without meta\"
 :END:
 #+title: Note without META
 
@@ -320,6 +337,7 @@ Just some text to make sure that meta is inserted before.
               :to-contain-exactly
               ":PROPERTIES:
 :ID:                     444f94d7-61e0-4b7c-bb7e-100814c6b4bb
+:ROAM_ALIASES:           \"Alias of the note without meta\"
 :END:
 #+title: Note without META
 
@@ -355,6 +373,7 @@ Some fancy description
               :to-contain-exactly
               ":PROPERTIES:
 :ID:                     444f94d7-61e0-4b7c-bb7e-100814c6b4bb
+:ROAM_ALIASES:           \"Alias of the note without meta\"
 :END:
 #+title: Note without META
 
@@ -376,6 +395,7 @@ Just some text to make sure that meta is inserted before.
               :to-contain-exactly
               ":PROPERTIES:
 :ID:                     444f94d7-61e0-4b7c-bb7e-100814c6b4bb
+:ROAM_ALIASES:           \"Alias of the note without meta\"
 :END:
 #+title: Note without META
 
@@ -397,6 +417,7 @@ Just some text to make sure that meta is inserted before.
               :to-contain-exactly
               ":PROPERTIES:
 :ID:                     444f94d7-61e0-4b7c-bb7e-100814c6b4bb
+:ROAM_ALIASES:           \"Alias of the note without meta\"
 :END:
 #+title: Note without META
 
@@ -460,10 +481,10 @@ Just some text to make sure that meta is inserted before.
     (it "inserts values with respect to trailing new lines in file with body"
       (vulpea-test--map-file (lambda (_)
                                ;; first line after the body
-                               (goto-char 168)
+                               (goto-char 226)
                                (insert "\n\n\n")
                                ;; first line after the header
-                               (goto-char 109)
+                               (goto-char 167)
                                (insert "\n\n\n\n\n"))
                              without-meta-file)
       (vulpea-meta-set without-meta-id
@@ -476,6 +497,7 @@ Just some text to make sure that meta is inserted before.
               :to-contain-exactly
               ":PROPERTIES:
 :ID:                     444f94d7-61e0-4b7c-bb7e-100814c6b4bb
+:ROAM_ALIASES:           \"Alias of the note without meta\"
 :END:
 #+title: Note without META
 

--- a/test/vulpea-note-test.el
+++ b/test/vulpea-note-test.el
@@ -67,6 +67,20 @@
     (expect (vulpea-note-meta-get (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "link" 'note)
             :to-equal (vulpea-db-get-by-id "444f94d7-61e0-4b7c-bb7e-100814c6b4bb")))
 
+  (it "extracts note value respecting alias"
+    (expect (vulpea-note-title
+             (vulpea-note-meta-get
+              (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd")
+              "link with alias" 'note))
+            :to-equal "Alias of the note without meta"))
+
+  (it "extracts note value ignoring unknown title"
+    (expect (vulpea-note-title
+             (vulpea-note-meta-get
+              (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd")
+              "link with arbitrary desc" 'note))
+            :to-equal "Note without META"))
+
   (it "extracts symbol value"
     (expect (vulpea-note-meta-get (vulpea-db-get-by-id "05907606-f836-45bf-bd36-a8444308eddd") "symbol" 'symbol)
             :to-equal 'red))

--- a/vulpea-buffer.el
+++ b/vulpea-buffer.el
@@ -248,8 +248,15 @@ Each element value depends on TYPE:
               (when (equal 'link
                            (org-element-type el))
                 (pcase (org-element-property :type el)
-                  ("id" (vulpea-db-get-by-id
-                         (org-element-property :path el)))))))
+                  ("id"
+                   (let* ((id (org-element-property :path el))
+                          (desc (substring-no-properties
+                                 (car (org-element-contents el))))
+                          (note (vulpea-db-get-by-id id)))
+                     (when (seq-contains-p (vulpea-note-aliases note) desc)
+                       (setf (vulpea-note-primary-title note) (vulpea-note-title note))
+                       (setf (vulpea-note-title note) desc))
+                     note))))))
            (`link
             (let ((el (car (org-element-contents val))))
               (when (equal 'link

--- a/vulpea-note.el
+++ b/vulpea-note.el
@@ -73,10 +73,15 @@ Each element value depends on TYPE:
          (`symbol (intern item))
          (`number (string-to-number item))
          (`note (if (string-match org-link-bracket-re item)
-                    (let ((link (match-string 1 item)))
+                    (let ((link (match-string 1 item))
+                          (desc (match-string 2 item)))
                       (if (string-prefix-p "id:" link)
-                          (vulpea-db-get-by-id
-                           (string-remove-prefix "id:" link))
+                          (let* ((id (string-remove-prefix "id:" link))
+                                 (note (vulpea-db-get-by-id id)))
+                            (when (seq-contains-p (vulpea-note-aliases note) desc)
+                              (setf (vulpea-note-primary-title note) (vulpea-note-title note))
+                              (setf (vulpea-note-title note) desc))
+                            note)
                         (user-error "Expected id link, but got '%s'"
                                     item)))
                   (user-error "Expected link, but got '%s'" item)))


### PR DESCRIPTION
Historically, `vulpea[-note]-meta-get*` ignores description provided in link. This commit makes these functions to respect the description if its alias. See tests for examples.