### PR TITLE
feat: vulpea-db-query-by-level

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -20,6 +20,7 @@
 - Introduce =vulpea-insert-default-candidates-source=.
 - Introduce =vulpea-db-query-by-tags-none=.
 - Include =outline-path= in =vulpea-note= and bump =notes= table version (i.e. a full rebuild is required).
+- Introduce =vulpea-db-query-by-level=, which returns all notes of a given =LEVEL=.
 
 ** v0.3.0
 :PROPERTIES:

--- a/README.org
+++ b/README.org
@@ -1049,6 +1049,7 @@ As you can see, =vulpea-db-query= doesn't allow to pass any custom SQL for filte
 - =vulpea-db-query-by-tags-none= - return all notes not tagged by any tag from the list of provided =TAGS=.
 - =vulpea-db-query-by-links-some= - return all notes linking at least one of the provided =DESTINATIONS=.
 - =vulpea-db-query-by-links-every= - return all notes linking each and every provided =DESTINATIONS=.
+- =vulpea-db-query-by-level= - return all notes of a given =LEVEL=.
 
 **** Other functions
 :PROPERTIES:

--- a/test/vulpea-db-test.el
+++ b/test/vulpea-db-test.el
@@ -739,6 +739,21 @@
                (seq-contains-p note-links tag))
              links))))))))
 
+(describe "vulpea-db-query-by-level"
+  (before-all
+    (vulpea-test--init))
+
+  (after-all
+    (vulpea-test--teardown))
+
+  (it "returns the same elements as vulpea-db-query"
+    (expect
+     (vulpea-db-query-by-level 0)
+     :to-have-same-items-as
+     (vulpea-db-query
+      (lambda (note)
+        (= 0 (vulpea-note-level note)))))))
+
 (describe "vulpea-db-get-by-id"
   (before-all
     (vulpea-test--init))

--- a/vulpea-db.el
+++ b/vulpea-db.el
@@ -246,6 +246,32 @@ DESTINATIONS are returned."
          destinations)
         "\nintersect\n"))))))
 
+(defun vulpea-db-query-by-level (level)
+  "Query a list of `vulpea-note' from database.
+
+Only notes that have their level equal to LEVEL are returned."
+  (let* ((rows
+          (org-roam-db-query
+           (format
+            "select
+  id,
+  path,
+  \"level\",
+  title,
+  properties,
+  aliases,
+  tags,
+  meta,
+  links,
+  attach,
+  outline_path
+from notes
+where notes.level = %s"
+            level))))
+    (seq-mapcat
+     #'vulpea-db--notes-from-row
+     rows)))
+
 ;;
 ;; Exchanging ID to X
 


### PR DESCRIPTION
It's not a tremendous improvement, but still saves a dozen of milis on a collection of 10k+ notes