### PR TITLE
perf: make async autosync startup non-blocking

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -17,6 +17,10 @@
 
 - Add =vulpea-db-query-attachments-by-path= for efficiently querying all attachment link destinations for notes at a given file path. Uses a single SQL query with JOIN, avoiding N+1 queries when processing multiple notes in a file.
 
+*Performance*
+
+- Async autosync startup is now non-blocking. When =vulpea-db-sync-scan-on-enable= is ='async=, the startup function returns in ~240ms instead of ~1400ms (measured with 13,800 files in GUI Emacs). File listing uses an =fd= (or =find=) subprocess instead of synchronous =directory-files-recursively=, and cleanup of deleted files uses set comparison against the subprocess output instead of per-file =file-exists-p= calls. Added =vulpea-db-sync-debug= variable for timing instrumentation.
+
 *Fixes*
 
 - [[https://github.com/d12frosted/vulpea/issues/200][vulpea#200]] Fix heading-level metadata not being persisted to the database. Previously, =vulpea-db-query-by-meta-key= and =vulpea-db-query-by-meta= returned no results for heading-level metadata because =org-element-map= with NO-RECURSION ='headline= wouldn't descend into the headline element itself during extraction.

--- a/bench/sync-timing-test.el
+++ b/bench/sync-timing-test.el
@@ -1,0 +1,93 @@
+;;; sync-timing-test.el --- Benchmark autosync startup -*- lexical-binding: t; -*-
+
+;; Measures the time spent in each phase of vulpea-db-sync--start
+;; and subsequent queue processing.
+;;
+;; Usage with eldev:
+;;   eldev -dtT exec -f sync-timing-test-run
+;;
+;; Or from Emacs:
+;;   (require 'sync-timing-test)
+;;   (sync-timing-test-run)
+;;
+;; Set VULPEA_NOTES_DIR env var to override notes directory
+;; (default: ~/vulpea).
+
+(require 'vulpea-db)
+(require 'vulpea-db-sync)
+(require 'vulpea-db-extract)
+
+(defun sync-timing-test-run ()
+  "Benchmark autosync startup against real notes."
+  (let* ((notes-dir (or (getenv "VULPEA_NOTES_DIR")
+                        (expand-file-name "~/vulpea")))
+         (db-file (make-temp-file "vulpea-bench-" nil ".db"))
+         (vulpea-directory notes-dir)
+         (vulpea-db-location db-file)
+         (vulpea-db-sync-directories (list notes-dir))
+         (vulpea-db-sync-scan-on-enable 'async)
+         (vulpea-db-sync-external-method nil)
+         (vulpea-db-parse-method 'single-temp-buffer)
+         (vulpea-db-index-heading-level t)
+         (vulpea-db-sync-debug t))
+
+    (message "========================================")
+    (message "Sync Timing Test")
+    (message "========================================")
+    (message "Notes dir: %s" notes-dir)
+    (message "DB file:   %s" db-file)
+    (message "")
+
+    ;; Phase 1: Cold start - full scan to build DB
+    (message "--- Phase 1: Cold start (full scan) ---")
+    (vulpea-db)  ; ensure DB is initialized
+    (let ((start (current-time)))
+      (vulpea-db-sync-full-scan t)
+      (message "[sync-timing] full-scan: %.0fms"
+               (* 1000 (float-time (time-subtract (current-time) start)))))
+
+    (message "")
+
+    ;; Phase 2: Warm start - autosync enable (the real startup path)
+    ;; With async scan, this should return almost instantly.
+    ;; The subprocess sentinel will populate the queue later.
+    (message "--- Phase 2: Warm start (autosync enable) ---")
+    (let ((start (current-time)))
+      (vulpea-db-autosync-mode 1)
+      (message "[sync-timing] autosync-mode returned in: %.0fms"
+               (* 1000 (float-time (time-subtract (current-time) start)))))
+
+    ;; Phase 3: Wait for async subprocess to finish and queue to populate
+    (message "")
+    (message "--- Phase 3: Waiting for async scan subprocess ---")
+    (let ((start (current-time))
+          (timeout 60))
+      ;; Accept process output until the vulpea-scan process finishes
+      (while (and (get-process "vulpea-scan")
+                  (< (float-time (time-subtract (current-time) start)) timeout))
+        (accept-process-output nil 0.1))
+      (message "[sync-timing] subprocess finished in: %.0fms"
+               (* 1000 (float-time (time-subtract (current-time) start)))))
+
+    ;; Phase 4: Drain the queue
+    (message "")
+    (message "--- Phase 4: Queue processing ---")
+    (message "Queue length: %d" (length vulpea-db-sync--queue))
+    (let ((start (current-time))
+          (batches 0))
+      (while vulpea-db-sync--queue
+        (vulpea-db-sync--process-queue)
+        (setq batches (1+ batches)))
+      (message "[sync-timing] queue drain: %.0fms (%d batches)"
+               (* 1000 (float-time (time-subtract (current-time) start)))
+               batches))
+
+    ;; Cleanup
+    (vulpea-db-autosync-mode -1)
+    (delete-file db-file)
+
+    (message "")
+    (message "========================================")))
+
+(provide 'sync-timing-test)
+;;; sync-timing-test.el ends here

--- a/docs/configuration.org
+++ b/docs/configuration.org
@@ -213,14 +213,15 @@ Control what happens when =vulpea-db-autosync-mode= is enabled.
 ;; Skip initial scan (fast startup, recommended)
 (setq vulpea-db-sync-scan-on-enable nil)
 
-;; Scan asynchronously (non-blocking but may cause lag)
+;; Scan asynchronously (non-blocking, uses fd/find subprocess)
 (setq vulpea-db-sync-scan-on-enable 'async)
 
 ;; Scan synchronously (blocks until complete)
 (setq vulpea-db-sync-scan-on-enable 'blocking)
 #+end_src
 
-*Recommendation:* Use =nil= and run =vulpea-db-sync-full-scan= manually when needed.
+*Recommendation:* Use ='async= for hands-off operation.  Startup returns
+in ~240ms even with large collections.
 
 * Aliases
 

--- a/docs/sync-architecture.org
+++ b/docs/sync-architecture.org
@@ -124,7 +124,38 @@ Timer fires every N seconds
 *Note*: All file watchers ALWAYS use async queue, regardless of autosync mode
 
 
-** 5. Async Queue Processing
+** 5. Autosync Startup (async mode)
+
+#+begin_example
+vulpea-db-autosync-mode +1
+  │
+  └─ vulpea-db-sync--start
+      │
+      ├─ Start idle timer (queue ready to process)
+      ├─ Start external monitoring (fswatch/poll)
+      ├─ Setup directory watchers (filenotify)
+      │
+      ├─ scan-on-enable = 'async?
+      │   └─ Launch fd/find SUBPROCESS        ← returns immediately
+      │       └─ [sentinel callback when done]
+      │           ├─ Guard: check autosync still active
+      │           ├─ Cleanup deleted files (set comparison)
+      │           └─ Enqueue all files for change detection
+      │
+      ├─ scan-on-enable = 'blocking?
+      │   ├─ Cleanup deleted files (sync)
+      │   └─ Update all directories (sync)     ← blocks
+      │
+      └─ scan-on-enable = nil?
+          └─ Cleanup deleted files (sync)
+#+end_example
+
+*Key feature*: With ='async=, startup returns in ~240ms instead of
+~1400ms for large collections.  File listing runs as an =fd= (or
+=find=) subprocess.  Cleanup uses set comparison against the subprocess
+output instead of per-file =file-exists-p= calls.
+
+** 6. Async Queue Processing
 
 #+begin_example
 vulpea-db-sync--enqueue(path)
@@ -217,6 +248,7 @@ vulpea-db-sync--update-file-if-changed(path)
 (setq vulpea-db-sync-external-method 'auto)  ; fswatch or poll
 (vulpea-db-autosync-mode 1)
 ;; Everything automatic, hands-off
+;; Startup returns in ~240ms (file listing runs as subprocess)
 #+end_src
 
 ** Minimal (manual only)

--- a/docs/troubleshooting.org
+++ b/docs/troubleshooting.org
@@ -77,17 +77,27 @@ Emacs hangs when enabling =vulpea-db-autosync-mode=.
 
 *** Cause
 
-Initial scan is processing all files.
+Initial scan is processing all files synchronously.
 
 *** Solutions
 
-1. *Skip startup scan:*
+1. *Use async scan* (recommended, non-blocking):
+
+   #+begin_src emacs-lisp
+   (setq vulpea-db-sync-scan-on-enable 'async)
+   #+end_src
+
+   With async scan, startup returns in ~240ms.  File listing runs as
+   a subprocess (=fd= or =find=), and changed files are processed
+   incrementally via idle timer.
+
+2. *Skip startup scan entirely:*
 
    #+begin_src emacs-lisp
    (setq vulpea-db-sync-scan-on-enable nil)
    #+end_src
 
-2. *Run sync manually* when convenient:
+3. *Run sync manually* when convenient:
 
    #+begin_src emacs-lisp
    (vulpea-db-sync-full-scan)


### PR DESCRIPTION
## Summary

- Reduce blocking time of `vulpea-db-autosync-mode` startup from ~1400ms to ~240ms (GUI Emacs, 13,800 files)
- File listing now uses `fd` (or `find`) subprocess instead of synchronous `directory-files-recursively`
- Deleted file cleanup uses set comparison against subprocess output instead of per-file `file-exists-p`
- Add `vulpea-db-sync-debug` variable for timing instrumentation of all sync phases

## Benchmark results (GUI Emacs, 13,813 files)

| Metric | Before | After |
|--------|--------|-------|
| `autosync-mode` return time | 1371ms | **239ms** |
| cleanup-deleted-files | 135ms (sync) | 48ms (async, set diff) |
| list+enqueue | 1008ms (sync) | 80ms (async, fd subprocess) |
| watch-directory | 224ms | 237ms (unchanged) |