### PR TITLE
perf: skip filenotify watchers when fswatch is active

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -19,7 +19,7 @@
 
 *Performance*
 
-- Async autosync startup is now non-blocking. When =vulpea-db-sync-scan-on-enable= is ='async=, the startup function returns in ~240ms instead of ~1400ms (measured with 13,800 files in GUI Emacs). File listing uses an =fd= (or =find=) subprocess instead of synchronous =directory-files-recursively=, and cleanup of deleted files uses set comparison against the subprocess output instead of per-file =file-exists-p= calls. Added =vulpea-db-sync-debug= variable for timing instrumentation.
+- Async autosync startup is now non-blocking. When =vulpea-db-sync-scan-on-enable= is ='async=, the startup function returns in ~8ms instead of ~1400ms (measured with 13,800 files in GUI Emacs). File listing uses an =fd= (or =find=) subprocess instead of synchronous =directory-files-recursively=, and cleanup of deleted files uses set comparison against the subprocess output instead of per-file =file-exists-p= calls. When =fswatch= is active, filenotify watchers are skipped entirely as they are redundant. Added =vulpea-db-sync-debug= variable for timing instrumentation.
 
 *Fixes*
 

--- a/bench/sync-timing-test.el
+++ b/bench/sync-timing-test.el
@@ -26,7 +26,8 @@
          (vulpea-db-location db-file)
          (vulpea-db-sync-directories (list notes-dir))
          (vulpea-db-sync-scan-on-enable 'async)
-         (vulpea-db-sync-external-method nil)
+         (vulpea-db-sync-external-method
+          (if (executable-find "fswatch") 'fswatch nil))
          (vulpea-db-parse-method 'single-temp-buffer)
          (vulpea-db-index-heading-level t)
          (vulpea-db-sync-debug t))

--- a/docs/sync-architecture.org
+++ b/docs/sync-architecture.org
@@ -150,10 +150,14 @@ vulpea-db-autosync-mode +1
           └─ Cleanup deleted files (sync)
 #+end_example
 
-*Key feature*: With ='async=, startup returns in ~240ms instead of
-~1400ms for large collections.  File listing runs as an =fd= (or
-=find=) subprocess.  Cleanup uses set comparison against the subprocess
-output instead of per-file =file-exists-p= calls.
+*Key feature*: With ='async= and =fswatch=, startup returns in ~8ms
+instead of ~1400ms for large collections.  File listing runs as an
+=fd= (or =find=) subprocess.  Cleanup uses set comparison against the
+subprocess output instead of per-file =file-exists-p= calls.  When
+=fswatch= is active, filenotify watchers are skipped entirely since
+=fswatch= already monitors all filesystem changes.  Programmatic
+changes (=vulpea-create=, =vulpea-utils-with-note-sync=) call
+=vulpea-db-update-file= directly and never rely on filenotify.
 
 ** 6. Async Queue Processing
 


### PR DESCRIPTION
## Summary

- Skip filenotify watcher setup when fswatch is already running (redundant)
- Eliminates ~237ms of blocking startup (97 recursive `file-notify-add-watch` calls)
- Combined with PR #204, total blocking drops from **1371ms → 8ms** (171x)

## Benchmark (GUI Emacs, 13,813 files)

| Metric | Original | PR #204 | This PR |
|--------|----------|---------|---------|
| **autosync-mode return** | **1371ms** | **239ms** | **8ms** |
| cleanup-deleted-files | 135ms | 0ms | 0ms |
| list+enqueue | 1008ms | 0ms | 0ms |
| watch-directory | 224ms | 237ms | **0ms** |
| setup-external-monitoring | 0ms | 0ms | 7ms |

Filenotify is only needed when no external monitoring is active. Programmatic changes (`vulpea-create`, `vulpea-utils-with-note-sync`) call `vulpea-db-update-file` directly and never rely on filenotify.