### PR TITLE
feat: dead link detection (#206)

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,6 +9,10 @@
 
 ** Unreleased
 
+*Features*
+
+- [[https://github.com/d12frosted/vulpea/issues/206][vulpea#206]] Add =vulpea-db-query-dead-links= for finding broken ID links that point to non-existent notes. Returns a list of cons cells =(SOURCE-NOTE . BROKEN-TARGET-ID)=. Only checks links of type "id"; other link types are ignored.
+
 ** v2.0.1
 
 *Features*

--- a/docs/api-reference.org
+++ b/docs/api-reference.org
@@ -154,6 +154,19 @@ For complex queries:
 ;; => ("project" "task" "meeting" ...)
 #+end_src
 
+* Diagnostics
+
+** Dead Links
+
+Find broken ID links that point to non-existent notes:
+
+#+begin_src emacs-lisp
+(vulpea-db-query-dead-links)
+;; => ((#s(vulpea-note ...) . "nonexistent-id") ...)
+#+end_src
+
+Returns list of cons cells =(SOURCE-NOTE . BROKEN-TARGET-ID)=. Only checks links of type "id".
+
 * Statistics
 
 #+begin_src emacs-lisp
@@ -614,6 +627,7 @@ For advanced use cases, direct database access:
 | =vulpea-db-query-by-file-paths=       | Notes from specific files            |
 | =vulpea-db-query-by-level=            | Notes at specific level              |
 | =vulpea-db-query-tags=                | Get all unique tags                  |
+| =vulpea-db-query-dead-links=          | Find broken ID links                 |
 
 ** Buffer Functions
 


### PR DESCRIPTION
## Summary

Add `vulpea-db-query-dead-links` for finding broken ID links that point to non-existent notes.

Closes #206

## API

```elisp
(vulpea-db-query-dead-links) → list of (source-note . broken-target-id)
```

SQL: finds rows in `links` table where `type = "id"` and `dest` has no matching note in `notes` table.