### PR TITLE
feat: orphan and isolated note detection (#207)

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -12,6 +12,7 @@
 *Features*
 
 - [[https://github.com/d12frosted/vulpea/issues/206][vulpea#206]] Add =vulpea-db-query-dead-links= for finding broken ID links that point to non-existent notes. Returns a list of cons cells =(SOURCE-NOTE . BROKEN-TARGET-ID)=. Only checks links of type "id"; other link types are ignored.
+- [[https://github.com/d12frosted/vulpea/issues/207][vulpea#207]] Add =vulpea-db-query-orphan-notes= for finding notes with no incoming ID links, and =vulpea-db-query-isolated-notes= for finding notes with no incoming or outgoing ID links.
 
 ** v2.0.1
 

--- a/docs/api-reference.org
+++ b/docs/api-reference.org
@@ -167,6 +167,26 @@ Find broken ID links that point to non-existent notes:
 
 Returns list of cons cells =(SOURCE-NOTE . BROKEN-TARGET-ID)=. Only checks links of type "id".
 
+** Orphan Notes
+
+Find notes with no incoming ID links (nothing links to them):
+
+#+begin_src emacs-lisp
+(vulpea-db-query-orphan-notes)
+;; => (#s(vulpea-note ...) ...)
+#+end_src
+
+** Isolated Notes
+
+Find notes with no incoming or outgoing ID links (completely disconnected):
+
+#+begin_src emacs-lisp
+(vulpea-db-query-isolated-notes)
+;; => (#s(vulpea-note ...) ...)
+#+end_src
+
+This is stricter than =vulpea-db-query-orphan-notes= — a note that links out but has no incoming links is an orphan but not isolated.
+
 * Statistics
 
 #+begin_src emacs-lisp
@@ -628,6 +648,8 @@ For advanced use cases, direct database access:
 | =vulpea-db-query-by-level=            | Notes at specific level              |
 | =vulpea-db-query-tags=                | Get all unique tags                  |
 | =vulpea-db-query-dead-links=          | Find broken ID links                 |
+| =vulpea-db-query-orphan-notes=        | Notes with no incoming ID links       |
+| =vulpea-db-query-isolated-notes=      | Notes with no connections at all      |
 
 ** Buffer Functions
 


### PR DESCRIPTION
## Summary

Add two diagnostic query functions for finding disconnected notes in the knowledge graph.

Closes #207

## API

```elisp
;; Notes with no incoming ID links (nothing links to them)
(vulpea-db-query-orphan-notes) → list of vulpea-note

;; Notes with no incoming OR outgoing ID links (completely disconnected)
(vulpea-db-query-isolated-notes) → list of vulpea-note
```

Both only consider links of type "id". Orphan is the broader check (no incoming); isolated is stricter (no connections at all).