### PR TITLE
feat: title collision detection (#208)

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -13,6 +13,7 @@
 
 - [[https://github.com/d12frosted/vulpea/issues/206][vulpea#206]] Add =vulpea-db-query-dead-links= for finding broken ID links that point to non-existent notes. Returns a list of cons cells =(SOURCE-NOTE . BROKEN-TARGET-ID)=. Only checks links of type "id"; other link types are ignored.
 - [[https://github.com/d12frosted/vulpea/issues/207][vulpea#207]] Add =vulpea-db-query-orphan-notes= for finding notes with no incoming ID links, and =vulpea-db-query-isolated-notes= for finding notes with no incoming or outgoing ID links.
+- [[https://github.com/d12frosted/vulpea/issues/208][vulpea#208]] Add =vulpea-db-query-title-collisions= for finding notes that share the same title. Returns list of =(TITLE . NOTES)= groups.
 
 ** v2.0.1
 

--- a/docs/api-reference.org
+++ b/docs/api-reference.org
@@ -187,6 +187,22 @@ Find notes with no incoming or outgoing ID links (completely disconnected):
 
 This is stricter than =vulpea-db-query-orphan-notes= — a note that links out but has no incoming links is an orphan but not isolated.
 
+** Title Collisions
+
+Find notes that share the same title:
+
+#+begin_src emacs-lisp
+;; All notes
+(vulpea-db-query-title-collisions)
+;; => (("Wine" . (#s(vulpea-note ...) #s(vulpea-note ...)))
+;;     ("Beer" . (#s(vulpea-note ...) #s(vulpea-note ...))))
+
+;; File-level notes only
+(vulpea-db-query-title-collisions 0)
+#+end_src
+
+Returns list of =(TITLE . NOTES)= groups where each group has two or more notes with the same title. Optional LEVEL argument restricts to notes at a specific heading level (0 for file-level).
+
 * Statistics
 
 #+begin_src emacs-lisp
@@ -650,6 +666,7 @@ For advanced use cases, direct database access:
 | =vulpea-db-query-dead-links=          | Find broken ID links                 |
 | =vulpea-db-query-orphan-notes=        | Notes with no incoming ID links       |
 | =vulpea-db-query-isolated-notes=      | Notes with no connections at all      |
+| =vulpea-db-query-title-collisions=    | Notes sharing the same title          |
 
 ** Buffer Functions
 


### PR DESCRIPTION
## Summary

Add `vulpea-db-query-title-collisions` for finding notes that share the same title.

Closes #208

## API

```elisp
(vulpea-db-query-title-collisions) → list of (title . list-of-notes)
```

Two SQL queries: first finds colliding titles via `GROUP BY ... HAVING COUNT(*) > 1`, then batch-fetches all notes for those titles. Groups via hash table in Elisp.