### PR TITLE
fix: strip org link markup from titles during extraction

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -15,6 +15,10 @@
 - [[https://github.com/d12frosted/vulpea/issues/207][vulpea#207]] Add =vulpea-db-query-orphan-notes= for finding notes with no incoming ID links, and =vulpea-db-query-isolated-notes= for finding notes with no incoming or outgoing ID links.
 - [[https://github.com/d12frosted/vulpea/issues/208][vulpea#208]] Add =vulpea-db-query-title-collisions= for finding notes that share the same title. Returns list of =(TITLE . NOTES)= groups.
 
+*Fixes*
+
+- [[https://github.com/d12frosted/vulpea/issues/221][vulpea#221]] Strip org link markup from note titles during extraction. Previously, titles containing org links (e.g. =The Memory Illusion [[id:...][book]]=) were stored verbatim with raw link syntax. Now =org-link-display-format= is applied at extraction time so titles, file-titles, and outline paths are stored as clean display text. Links from titles are still extracted and persisted in the links table.
+
 ** v2.0.1
 
 *Features*


### PR DESCRIPTION
Closes #221.

## Summary

- Strip org link markup from note titles at extraction time using `org-link-display-format`, so titles like `The Memory Illusion [[id:...][book]]` are stored as `The Memory Illusion book`
- Apply same treatment to heading titles, file-titles, and outline paths
- Add `vulpea-db--extract-links-from-string` helper to parse bracket links from raw `#+TITLE` keyword values (org-element doesn't parse these as link elements), ensuring links in titles are still persisted in the links table
- Also extract links from heading `:raw-value` titles, fixing a pre-existing gap where links inside heading titles were not captured by the content-walking link extractor