### PR TITLE
fix: normalize property keys to uppercase during extraction

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -19,6 +19,7 @@
 *Fixes*
 
 - [[https://github.com/d12frosted/vulpea/issues/221][vulpea#221]] Strip org link markup from note titles during extraction. Previously, titles containing org links (e.g. =The Memory Illusion [[id:...][book]]=) were stored verbatim with raw link syntax. Now =org-link-display-format= is applied at extraction time so titles, file-titles, and outline paths are stored as clean display text. Links from titles are still extracted and persisted in the links table.
+- [[https://github.com/d12frosted/vulpea/issues/222][vulpea#222]] Normalize property keys to uppercase during extraction. Previously, files with lowercase property names (e.g. =:id:= instead of =:ID:=) were silently skipped because =assoc= lookups are case-sensitive. Now property keys are upcased at the extraction boundary, matching org-mode's case-insensitive treatment of properties.
 
 ** v2.0.1
 

--- a/vulpea-db-extract.el
+++ b/vulpea-db-extract.el
@@ -583,8 +583,8 @@ Returns alist of (key . value) pairs."
       (lambda (drawer)
         (org-element-map drawer 'node-property
           (lambda (prop)
-            (cons (vulpea-db--string-no-properties
-                   (org-element-property :key prop))
+            (cons (upcase (vulpea-db--string-no-properties
+                          (org-element-property :key prop)))
                   (vulpea-db--string-no-properties
                    (org-element-property :value prop))))))
       nil t)))  ; First match only


### PR DESCRIPTION
Closes #222.

## Summary

- Upcase property keys in `vulpea-db--extract-properties` so that files with lowercase `:id:` (or mixed-case properties) are correctly indexed
- This is the single entry point for all property keys, so one-line fix covers all downstream consumers (`ID`, `VULPEA_IGNORE`, `ARCHIVE_TIME`, `CREATED`, aliases, etc.)
- Matches org-mode's case-insensitive treatment of property names