### PR TITLE
fix: persist title links to normalized links table for backlink queries

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -12,6 +12,7 @@
 *Fixes*
 
 - [[https://github.com/d12frosted/vulpea/issues/227][vulpea#227]] Enable alias expansion by default in =vulpea-find= and =vulpea-insert=. Previously, notes could only be found by their primary title even though the =:expand-aliases= feature existed in =vulpea-select-from=. Now both functions pass =:expand-aliases t= by default, so notes with aliases appear multiple times in the completion list — once for the original title and once for each alias.
+- [[https://github.com/d12frosted/vulpea/issues/221][vulpea#221]] Fix links in note titles not being persisted to the normalized =links= table. Previously, =vulpea-db--extract-links-from-string= set =:pos= to =nil=, which violated the =NOT NULL= constraint on the =links= table, causing silent insertion failure. Title links were stored in the =notes= JSON column but not in the =links= table, so =vulpea-find-backlink= could not find notes linked via their titles. Now buffer positions are computed correctly for title links. Additionally, links in non-note heading titles (headings without =:ID:=) are now extracted and attributed to the nearest ancestor note.
 
 ** v2.1.0
 


### PR DESCRIPTION
## Summary

- Fix links in note titles not being persisted to the normalized `links` table, causing `vulpea-find-backlink` to miss them
- `vulpea-db--extract-links-from-string` previously set `:pos` to `nil`, violating the `NOT NULL` constraint — now computes accurate buffer positions
- Fix non-note heading title links (headings without `:ID:`) being silently dropped — now extracted and attributed to the nearest ancestor note

Closes #221