### PR TITLE
feat: support aliases on heading-level notes

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -12,6 +12,7 @@
 *Fixes*
 
 - [[https://github.com/d12frosted/vulpea/issues/227][vulpea#227]] Enable alias expansion by default in =vulpea-find= and =vulpea-insert=. Previously, notes could only be found by their primary title even though the =:expand-aliases= feature existed in =vulpea-select-from=. Now both functions pass =:expand-aliases t= by default, so notes with aliases appear multiple times in the completion list — once for the original title and once for each alias.
+- [[https://github.com/d12frosted/vulpea/issues/232][vulpea#232]] Support aliases on heading-level notes. Previously, aliases were only extracted for file-level notes. Now heading-level notes with =:ALIASES:= (or =:ROAM_ALIASES:= etc.) properties are extracted and appear in =vulpea-find= via alias expansion.
 - [[https://github.com/d12frosted/vulpea/issues/221][vulpea#221]] Fix links in note titles not being persisted to the normalized =links= table. Previously, =vulpea-db--extract-links-from-string= set =:pos= to =nil=, which violated the =NOT NULL= constraint on the =links= table, causing silent insertion failure. Title links were stored in the =notes= JSON column but not in the =links= table, so =vulpea-find-backlink= could not find notes linked via their titles. Now buffer positions are computed correctly for title links. Additionally, links in non-note heading titles (headings without =:ID:=) are now extracted and attributed to the nearest ancestor note.
 
 ** v2.1.0

--- a/vulpea-db-extract.el
+++ b/vulpea-db-extract.el
@@ -527,7 +527,7 @@ Respects `vulpea-db-index-heading-level' setting."
                         :level level
                         :pos pos
                         :title title
-                        :aliases nil  ; Only file-level has aliases
+                        :aliases (vulpea-db--extract-aliases properties)
                         :tags tags
                         :links links
                         :properties properties


### PR DESCRIPTION
## Summary

- Extract aliases for heading-level notes (previously hardcoded to `nil`)
- Headings with `:ID:` and `:ALIASES:` (or `:ROAM_ALIASES:` etc.) now have their aliases persisted and visible in `vulpea-find` via alias expansion

One-line change in extraction + tests.

Closes #232