### PR TITLE
feat: add batch tag and metadata operations

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,6 +9,12 @@
 
 ** Unreleased
 
+*Features*
+
+- [[https://github.com/d12frosted/vulpea/issues/211][vulpea#211]] Add per-note tag operations in new =vulpea-tags.el= module: =vulpea-tags= (get), =vulpea-tags-add=, =vulpea-tags-remove=, =vulpea-tags-set=. These work with both file-level notes (filetags) and heading-level notes (org heading tags).
+- [[https://github.com/d12frosted/vulpea/issues/211][vulpea#211]] Add batch tag operations: =vulpea-tags-batch-add=, =vulpea-tags-batch-remove=, and =vulpea-tags-batch-rename=. The rename function implements [[https://github.com/d12frosted/vulpea/issues/120][vulpea#120]], allowing global tag renaming across all notes. =vulpea-tags-batch-rename= is interactive with completion for existing tags.
+- [[https://github.com/d12frosted/vulpea/issues/211][vulpea#211]] Add batch metadata operations: =vulpea-meta-batch-set= and =vulpea-meta-batch-remove= for efficiently setting or removing metadata properties across multiple notes. Both use =vulpea-utils-process-notes= for optimized batch processing.
+
 *Fixes*
 
 - [[https://github.com/d12frosted/vulpea/issues/227][vulpea#227]] Enable alias expansion by default in =vulpea-find= and =vulpea-insert=. Previously, notes could only be found by their primary title even though the =:expand-aliases= feature existed in =vulpea-select-from=. Now both functions pass =:expand-aliases t= by default, so notes with aliases appear multiple times in the completion list — once for the original title and once for each alias.

--- a/docs/api-reference.org
+++ b/docs/api-reference.org
@@ -444,6 +444,73 @@ For heading-level notes (=level > 0=), metadata is the first description list wi
 
 This scoping applies to all =vulpea-meta-*= and =vulpea-buffer-meta-*= functions.
 
+* Tags
+
+** Per-Note Tag Operations
+
+Get or modify tags for a specific note (works with both file-level and heading-level notes):
+
+#+begin_src emacs-lisp
+;; Get tags for a note
+(vulpea-tags note-or-id)
+;; => ("project" "active")
+
+;; Add tags
+(vulpea-tags-add note-or-id "new-tag")
+(vulpea-tags-add note-or-id "tag1" "tag2" "tag3")
+
+;; Remove tags
+(vulpea-tags-remove note-or-id "old-tag")
+(vulpea-tags-remove note-or-id "tag1" "tag2")
+
+;; Set tags (replaces all existing tags)
+(vulpea-tags-set note-or-id "only" "these" "tags")
+#+end_src
+
+For file-level notes (=level = 0=), these modify =#+filetags=. For heading-level notes (=level > 0=), they modify org heading tags.
+
+** Batch Tag Operations
+
+Operate on multiple notes efficiently using =vulpea-utils-process-notes=:
+
+#+begin_src emacs-lisp
+;; Add a tag to multiple notes
+(vulpea-tags-batch-add notes "archived")
+;; => count of notes processed
+
+;; Remove a tag from multiple notes
+(vulpea-tags-batch-remove notes "active")
+;; => count of notes processed
+
+;; Rename a tag across all notes (implements #120)
+(vulpea-tags-batch-rename "old-tag" "new-tag")
+;; => count of notes modified
+
+;; Interactive: M-x vulpea-tags-batch-rename
+;; - Prompts for old tag (with completion from existing tags)
+;; - Prompts for new tag name
+;; - Shows count of modified notes
+#+end_src
+
+The rename function queries for all notes with the old tag, removes it, and adds the new tag. When called interactively via =M-x vulpea-tags-batch-rename=, it provides completion for existing tags.
+
+** Batch Metadata Operations
+
+Operate on metadata across multiple notes:
+
+#+begin_src emacs-lisp
+;; Set a metadata property on multiple notes
+(vulpea-meta-batch-set notes "status" "archived")
+;; => count of notes processed
+
+;; Set a list value
+(vulpea-meta-batch-set notes "tags" '("a" "b" "c"))
+
+;; Remove a metadata property from multiple notes
+(vulpea-meta-batch-remove notes "deprecated-key")
+;; => count of notes processed
+#+end_src
+
 * Modifying Notes Programmatically
 
 ** With Async Sync
@@ -684,13 +751,27 @@ For advanced use cases, direct database access:
 | =vulpea-db-query-by-level=            | Notes at specific level              |
 | =vulpea-db-query-tags=                | Get all unique tags                  |
 | =vulpea-db-query-dead-links=          | Find broken ID links                 |
-| =vulpea-db-query-orphan-notes=        | Notes with no incoming ID links       |
-| =vulpea-db-query-isolated-notes=      | Notes with no connections at all      |
-| =vulpea-db-query-title-collisions=    | Notes sharing the same title          |
-| =vulpea-db-query-links=              | All links as plists                   |
-| =vulpea-db-query-links-by-type=      | Links filtered by type                |
-| =vulpea-db-query-links-from=         | Outgoing links from a note            |
-| =vulpea-db-query-links-to=           | Incoming links (backlinks) to a note  |
+| =vulpea-db-query-orphan-notes=        | Notes with no incoming ID links      |
+| =vulpea-db-query-isolated-notes=      | Notes with no connections at all     |
+| =vulpea-db-query-title-collisions=    | Notes sharing the same title         |
+| =vulpea-db-query-links=               | All links as plists                  |
+| =vulpea-db-query-links-by-type=       | Links filtered by type               |
+| =vulpea-db-query-links-from=          | Outgoing links from a note           |
+| =vulpea-db-query-links-to=            | Incoming links (backlinks) to a note |
+
+** Tag Functions
+
+| Function                   | Description                                 |
+|----------------------------+---------------------------------------------|
+| =vulpea-tags=              | Get tags for a note                         |
+| =vulpea-tags-add=          | Add tags to a note                          |
+| =vulpea-tags-remove=       | Remove tags from a note                     |
+| =vulpea-tags-set=          | Set tags for a note (replace all)           |
+| =vulpea-tags-batch-add=    | Add a tag to multiple notes                 |
+| =vulpea-tags-batch-remove= | Remove a tag from multiple notes            |
+| =vulpea-tags-batch-rename= | Rename a tag across all notes (interactive) |
+| =vulpea-meta-batch-set=    | Set metadata property on notes              |
+| =vulpea-meta-batch-remove= | Remove metadata property from notes         |
 
 ** Buffer Functions
 

--- a/docs/user-guide.org
+++ b/docs/user-guide.org
@@ -187,6 +187,51 @@ M-x vulpea-buffer-tags-remove
 (vulpea-buffer-tags-set '("project" "active"))
 #+end_src
 
+** Working with Tags by Note
+
+When you have a note (or note ID) and want to modify its tags without visiting the buffer:
+
+#+begin_src emacs-lisp
+;; Get tags for any note
+(vulpea-tags note-or-id)
+
+;; Add/remove tags
+(vulpea-tags-add note-or-id "new-tag")
+(vulpea-tags-remove note-or-id "old-tag")
+
+;; Replace all tags
+(vulpea-tags-set note-or-id "only" "these")
+#+end_src
+
+** Renaming Tags Globally
+
+To rename a tag across all notes:
+
+#+begin_example
+M-x vulpea-tags-batch-rename
+#+end_example
+
+This prompts for the old tag (with completion) and new tag name, then updates all affected notes.
+
+Programmatically:
+
+#+begin_src emacs-lisp
+(vulpea-tags-batch-rename "old-name" "new-name")
+;; => count of modified notes
+#+end_src
+
+** Batch Tag Operations
+
+For operating on multiple notes at once:
+
+#+begin_src emacs-lisp
+;; Add a tag to multiple notes
+(vulpea-tags-batch-add notes "archived")
+
+;; Remove a tag from multiple notes
+(vulpea-tags-batch-remove notes "active")
+#+end_src
+
 * Managing Aliases
 
 Aliases are alternative titles for a note, useful when the same concept has multiple names.

--- a/test/vulpea-tags-test.el
+++ b/test/vulpea-tags-test.el
@@ -1,0 +1,338 @@
+;;; vulpea-tags-test.el --- Tests for vulpea-tags -*- lexical-binding: t; -*-
+;;
+;; Copyright (c) 2020-2026 Boris Buliga
+;;
+;; Author: Boris Buliga <boris@d12frosted.io>
+;; Maintainer: Boris Buliga <boris@d12frosted.io>
+;;
+;; Created: 03 Feb 2026
+;;
+;; URL: https://github.com/d12frosted/vulpea
+;;
+;; License: GPLv3
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; Commentary:
+;;
+;; Test `vulpea-tags' module.
+;;
+;;; Code:
+
+(require 'ert)
+(require 'vulpea-tags)
+(require 'vulpea-db)
+(require 'vulpea-db-extract)
+(require 'vulpea-db-query)
+(require 'vulpea-utils)
+
+;;; Test Helpers
+
+(defvar vulpea-tags-test--fixture-dir
+  (expand-file-name "test/note-files"
+                    (file-name-directory
+                     (directory-file-name
+                      (file-name-directory (or load-file-name buffer-file-name)))))
+  "Directory containing test fixture files.")
+
+(defvar vulpea-tags-test--notes-dir nil
+  "Temporary notes directory for current test.")
+
+(defmacro vulpea-tags-test--with-temp-db (&rest body)
+  "Execute BODY with a temporary database initialized with test fixtures."
+  (declare (indent 0))
+  (let ((db-file-var (make-symbol "temp-db-file"))
+        (notes-dir-var (make-symbol "temp-notes-dir")))
+    `(progn
+       ;; Clean up orphan org buffers from previous tests
+       ;; This prevents `save-some-buffers' in batch operations from
+       ;; trying to save buffers pointing to deleted temp directories
+       (dolist (buf (buffer-list))
+         (when (and (buffer-file-name buf)
+                    (string-match-p "\\.org$" (buffer-file-name buf))
+                    (not (file-exists-p (buffer-file-name buf))))
+           (with-current-buffer buf
+             (set-buffer-modified-p nil))
+           (kill-buffer buf)))
+       (let* ((,db-file-var (make-temp-file "vulpea-tags-test-" nil ".db"))
+              (,notes-dir-var (expand-file-name (make-temp-name "vulpea-tags-notes-")
+                               temporary-file-directory))
+              (vulpea-db-location ,db-file-var)
+              (vulpea-db--connection nil)
+              (vulpea-tags-test--notes-dir ,notes-dir-var))
+         ;; Create temp notes directory
+         (make-directory ,notes-dir-var t)
+         (unwind-protect
+             (progn
+            ;; Copy all fixture files to temp directory
+            (dolist (file (directory-files vulpea-tags-test--fixture-dir t "\\.org$"))
+             (copy-file file (expand-file-name (file-name-nondirectory file) ,notes-dir-var)))
+            ;; Initialize database
+            (vulpea-db)
+            ;; Update database with all files
+            (dolist (file (directory-files ,notes-dir-var t "\\.org$"))
+             (vulpea-db-update-file file))
+            ,@body)
+        ;; Cleanup: kill all org buffers from this test
+        (dolist (buf (buffer-list))
+          (when (and (buffer-file-name buf)
+                     (string-prefix-p ,notes-dir-var (buffer-file-name buf)))
+            (kill-buffer buf)))
+        (when vulpea-db--connection
+         (vulpea-db-close))
+        (when (file-exists-p ,db-file-var)
+         (delete-file ,db-file-var))
+        (when (file-exists-p ,notes-dir-var)
+         (delete-directory ,notes-dir-var t)))))))
+
+(defun vulpea-tags-test--save-all-buffers ()
+  "Save all buffers visiting files in the test notes directory."
+  (dolist (buf (buffer-list))
+    (with-current-buffer buf
+      (when (and buffer-file-name
+                 (string-prefix-p vulpea-tags-test--notes-dir buffer-file-name))
+        (save-buffer)))))
+
+(defun vulpea-tags-test--file-content (file-name)
+  "Get the content of FILE-NAME in test notes directory."
+  (let ((file-path (expand-file-name file-name vulpea-tags-test--notes-dir)))
+    (with-temp-buffer
+      (insert-file-contents file-path)
+      (buffer-string))))
+
+;;; vulpea-tags Tests (per-note get)
+
+(ert-deftest vulpea-tags-get-file-level-with-tags ()
+  "Test getting tags from a file-level note that has tags."
+  (vulpea-tags-test--with-temp-db
+   ;; reference.org has :tag1:tag2:tag3:
+   (should (equal (vulpea-tags "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7")
+                  '("tag1" "tag2" "tag3")))))
+
+(ert-deftest vulpea-tags-get-file-level-without-tags ()
+  "Test getting tags from a file-level note without tags."
+  (vulpea-tags-test--with-temp-db
+   ;; without-meta.org has no tags
+   (should (equal (vulpea-tags "444f94d7-61e0-4b7c-bb7e-100814c6b4bb")
+                  nil))))
+
+(ert-deftest vulpea-tags-get-with-note-struct ()
+  "Test getting tags by passing a note struct."
+  (vulpea-tags-test--with-temp-db
+   (let ((note (vulpea-db-get-by-id "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7")))
+     (should (equal (vulpea-tags note)
+                    '("tag1" "tag2" "tag3"))))))
+
+;;; vulpea-tags-add Tests
+
+(ert-deftest vulpea-tags-add-single-tag ()
+  "Test adding a single tag to a note."
+  (vulpea-tags-test--with-temp-db
+   (vulpea-tags-add "444f94d7-61e0-4b7c-bb7e-100814c6b4bb" "newtag")
+   (should (equal (vulpea-tags "444f94d7-61e0-4b7c-bb7e-100814c6b4bb")
+                  '("newtag")))))
+
+(ert-deftest vulpea-tags-add-multiple-tags ()
+  "Test adding multiple tags to a note."
+  (vulpea-tags-test--with-temp-db
+   (vulpea-tags-add "444f94d7-61e0-4b7c-bb7e-100814c6b4bb" "tag1" "tag2")
+   (let ((tags (vulpea-tags "444f94d7-61e0-4b7c-bb7e-100814c6b4bb")))
+     (should (member "tag1" tags))
+     (should (member "tag2" tags)))))
+
+(ert-deftest vulpea-tags-add-to-note-with-existing-tags ()
+  "Test adding tags to a note that already has tags."
+  (vulpea-tags-test--with-temp-db
+   ;; reference.org has :tag1:tag2:tag3:
+   (vulpea-tags-add "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7" "tag4")
+   (let ((tags (vulpea-tags "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7")))
+     (should (= (length tags) 4))
+     (should (member "tag1" tags))
+     (should (member "tag4" tags)))))
+
+(ert-deftest vulpea-tags-add-duplicate-tag ()
+  "Test that adding a duplicate tag does not create duplicates."
+  (vulpea-tags-test--with-temp-db
+   ;; reference.org has :tag1:tag2:tag3:
+   (vulpea-tags-add "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7" "tag1")
+   (let ((tags (vulpea-tags "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7")))
+     (should (= (length tags) 3)))))
+
+;;; vulpea-tags-remove Tests
+
+(ert-deftest vulpea-tags-remove-single-tag ()
+  "Test removing a single tag from a note."
+  (vulpea-tags-test--with-temp-db
+   ;; reference.org has :tag1:tag2:tag3:
+   (vulpea-tags-remove "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7" "tag2")
+   (let ((tags (vulpea-tags "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7")))
+     (should (= (length tags) 2))
+     (should (member "tag1" tags))
+     (should (member "tag3" tags))
+     (should-not (member "tag2" tags)))))
+
+(ert-deftest vulpea-tags-remove-multiple-tags ()
+  "Test removing multiple tags from a note."
+  (vulpea-tags-test--with-temp-db
+   ;; reference.org has :tag1:tag2:tag3:
+   (vulpea-tags-remove "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7" "tag1" "tag3")
+   (should (equal (vulpea-tags "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7")
+                  '("tag2")))))
+
+(ert-deftest vulpea-tags-remove-nonexistent-tag ()
+  "Test removing a tag that doesn't exist has no effect."
+  (vulpea-tags-test--with-temp-db
+   ;; reference.org has :tag1:tag2:tag3:
+   (vulpea-tags-remove "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7" "nonexistent")
+   (should (equal (vulpea-tags "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7")
+                  '("tag1" "tag2" "tag3")))))
+
+(ert-deftest vulpea-tags-remove-from-note-without-tags ()
+  "Test removing tags from a note without any tags has no effect."
+  (vulpea-tags-test--with-temp-db
+   (vulpea-tags-remove "444f94d7-61e0-4b7c-bb7e-100814c6b4bb" "sometag")
+   (should (equal (vulpea-tags "444f94d7-61e0-4b7c-bb7e-100814c6b4bb")
+                  nil))))
+
+;;; vulpea-tags-set Tests
+
+(ert-deftest vulpea-tags-set-replace-all ()
+  "Test that vulpea-tags-set replaces all existing tags."
+  (vulpea-tags-test--with-temp-db
+   ;; reference.org has :tag1:tag2:tag3:
+   (vulpea-tags-set "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7" "new1" "new2")
+   (should (equal (vulpea-tags "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7")
+                  '("new1" "new2")))))
+
+(ert-deftest vulpea-tags-set-in-note-without-tags ()
+  "Test setting tags in a note that has no tags."
+  (vulpea-tags-test--with-temp-db
+   (vulpea-tags-set "444f94d7-61e0-4b7c-bb7e-100814c6b4bb" "a" "b" "c")
+   (should (equal (vulpea-tags "444f94d7-61e0-4b7c-bb7e-100814c6b4bb")
+                  '("a" "b" "c")))))
+
+(ert-deftest vulpea-tags-set-empty-removes-all ()
+  "Test that setting no tags removes all tags."
+  (vulpea-tags-test--with-temp-db
+   ;; reference.org has :tag1:tag2:tag3:
+   (vulpea-tags-set "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7")
+   (should (equal (vulpea-tags "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7")
+                  nil))))
+
+;;; File formatting Tests
+
+(ert-deftest vulpea-tags-add-format-in-file ()
+  "Test that tags are formatted correctly in file."
+  (vulpea-tags-test--with-temp-db
+   (vulpea-tags-add "444f94d7-61e0-4b7c-bb7e-100814c6b4bb" "newtag")
+   (vulpea-tags-test--save-all-buffers)
+   (should (string-match-p "#\\+filetags:.*:newtag:"
+                           (vulpea-tags-test--file-content "without-meta.org")))))
+
+(ert-deftest vulpea-tags-set-format-in-file ()
+  "Test that setting tags creates correct filetags line."
+  (vulpea-tags-test--with-temp-db
+   (vulpea-tags-set "444f94d7-61e0-4b7c-bb7e-100814c6b4bb" "x" "y" "z")
+   (vulpea-tags-test--save-all-buffers)
+   (should (string-match-p "#\\+filetags: :x:y:z:"
+                           (vulpea-tags-test--file-content "without-meta.org")))))
+
+;;; Heading-level tag Tests
+
+(ert-deftest vulpea-tags-heading-add ()
+  "Test adding tags to a heading-level note."
+  (vulpea-tags-test--with-temp-db
+   ;; Section One has no tags initially
+   (vulpea-tags-add "11111111-1111-1111-1111-111111111111" "htag1" "htag2")
+   (let ((tags (vulpea-tags "11111111-1111-1111-1111-111111111111")))
+     (should (member "htag1" tags))
+     (should (member "htag2" tags)))))
+
+(ert-deftest vulpea-tags-heading-remove ()
+  "Test removing tags from a heading-level note."
+  (vulpea-tags-test--with-temp-db
+   ;; First add tags
+   (vulpea-tags-add "11111111-1111-1111-1111-111111111111" "htag1" "htag2")
+   ;; Then remove one
+   (vulpea-tags-remove "11111111-1111-1111-1111-111111111111" "htag1")
+   (let ((tags (vulpea-tags "11111111-1111-1111-1111-111111111111")))
+     (should-not (member "htag1" tags))
+     (should (member "htag2" tags)))))
+
+(ert-deftest vulpea-tags-heading-does-not-affect-file ()
+  "Test that heading tag changes don't affect file-level tags."
+  (vulpea-tags-test--with-temp-db
+   ;; Add tags to heading
+   (vulpea-tags-add "11111111-1111-1111-1111-111111111111" "headingtag")
+   ;; File-level note should not have the tag
+   (should-not (member "headingtag"
+                       (vulpea-tags "a1b2c3d4-e5f6-7890-abcd-ef1234567890")))))
+
+;;; Batch operation Tests
+
+(ert-deftest vulpea-tags-batch-add-single-note ()
+  "Test batch adding a tag to a single note."
+  (vulpea-tags-test--with-temp-db
+   (let ((notes (list (vulpea-db-get-by-id "444f94d7-61e0-4b7c-bb7e-100814c6b4bb"))))
+     (vulpea-tags-batch-add notes "batchtag")
+     (should (member "batchtag" (vulpea-tags "444f94d7-61e0-4b7c-bb7e-100814c6b4bb"))))))
+
+(ert-deftest vulpea-tags-batch-add-multiple-notes ()
+  "Test batch adding a tag to multiple notes."
+  (vulpea-tags-test--with-temp-db
+   (let ((notes (list (vulpea-db-get-by-id "444f94d7-61e0-4b7c-bb7e-100814c6b4bb")
+                      (vulpea-db-get-by-id "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7"))))
+     (vulpea-tags-batch-add notes "common")
+     (should (member "common" (vulpea-tags "444f94d7-61e0-4b7c-bb7e-100814c6b4bb")))
+     (should (member "common" (vulpea-tags "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7"))))))
+
+(ert-deftest vulpea-tags-batch-remove-from-multiple-notes ()
+  "Test batch removing a tag from multiple notes."
+  (vulpea-tags-test--with-temp-db
+   ;; First add a common tag to two notes
+   (vulpea-tags-add "444f94d7-61e0-4b7c-bb7e-100814c6b4bb" "common")
+   (vulpea-tags-add "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7" "common")
+   ;; Now batch remove it
+   (let ((notes (list (vulpea-db-get-by-id "444f94d7-61e0-4b7c-bb7e-100814c6b4bb")
+                      (vulpea-db-get-by-id "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7"))))
+     (vulpea-tags-batch-remove notes "common")
+     (should-not (member "common" (vulpea-tags "444f94d7-61e0-4b7c-bb7e-100814c6b4bb")))
+     (should-not (member "common" (vulpea-tags "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7"))))))
+
+(ert-deftest vulpea-tags-batch-rename ()
+  "Test renaming a tag across all notes that have it."
+  (vulpea-tags-test--with-temp-db
+   ;; reference.org has :tag1:tag2:tag3:
+   ;; Rename tag1 -> newtag1
+   (vulpea-tags-batch-rename "tag1" "newtag1")
+   (let ((tags (vulpea-tags "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7")))
+     (should (member "newtag1" tags))
+     (should-not (member "tag1" tags))
+     ;; Other tags should be preserved
+     (should (member "tag2" tags))
+     (should (member "tag3" tags)))))
+
+(ert-deftest vulpea-tags-batch-rename-affects-all-notes ()
+  "Test that batch rename affects all notes with the tag."
+  (vulpea-tags-test--with-temp-db
+   ;; Add tag1 to another note and sync to DB
+   (vulpea-tags-add "444f94d7-61e0-4b7c-bb7e-100814c6b4bb" "tag1")
+   (vulpea-tags-test--save-all-buffers)
+   (vulpea-db-update-file (expand-file-name "without-meta.org" vulpea-tags-test--notes-dir))
+   ;; Rename tag1 -> renamed
+   (vulpea-tags-batch-rename "tag1" "renamed")
+   ;; Both notes should have the renamed tag
+   (should (member "renamed" (vulpea-tags "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7")))
+   (should (member "renamed" (vulpea-tags "444f94d7-61e0-4b7c-bb7e-100814c6b4bb")))
+   ;; Neither should have the old tag
+   (should-not (member "tag1" (vulpea-tags "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7")))
+   (should-not (member "tag1" (vulpea-tags "444f94d7-61e0-4b7c-bb7e-100814c6b4bb")))))
+
+(ert-deftest vulpea-tags-batch-rename-nonexistent ()
+  "Test that renaming a nonexistent tag has no effect."
+  (vulpea-tags-test--with-temp-db
+   (let ((count (vulpea-tags-batch-rename "nonexistent" "something")))
+     (should (= count 0)))))
+
+(provide 'vulpea-tags-test)
+;;; vulpea-tags-test.el ends here

--- a/vulpea-meta.el
+++ b/vulpea-meta.el
@@ -313,5 +313,29 @@ When called interactively, operates on the note at point:
           ;; File-level note - use buffer scope
           (vulpea-buffer-meta-clean))))))
 
+;;; Batch meta operations
+
+(defun vulpea-meta-batch-set (notes prop value)
+  "Set VALUE of PROP for all NOTES.
+
+Uses `vulpea-utils-process-notes' for efficient batch processing.
+Returns the count of notes processed."
+  (let ((count 0))
+    (vulpea-utils-process-notes notes
+      (vulpea-buffer-meta-set prop value)
+      (setq count (1+ count)))
+    count))
+
+(defun vulpea-meta-batch-remove (notes prop)
+  "Remove PROP from all NOTES.
+
+Uses `vulpea-utils-process-notes' for efficient batch processing.
+Returns the count of notes processed."
+  (let ((count 0))
+    (vulpea-utils-process-notes notes
+      (vulpea-buffer-meta-remove prop)
+      (setq count (1+ count)))
+    count))
+
 (provide 'vulpea-meta)
 ;;; vulpea-meta.el ends here

--- a/vulpea-tags.el
+++ b/vulpea-tags.el
@@ -1,0 +1,156 @@
+;;; vulpea-tags.el --- Tag manipulation -*- lexical-binding: t; -*-
+;;
+;; Copyright (c) 2015-2026 Boris Buliga <boris@d12frosted.io>
+;;
+;; Author: Boris Buliga <boris@d12frosted.io>
+;; Maintainer: Boris Buliga <boris@d12frosted.io>
+;;
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program. If not, see
+;; <http://www.gnu.org/licenses/>.
+;;
+;; Created: 03 Feb 2026
+;;
+;; URL: https://github.com/d12frosted/vulpea
+;;
+;; License: GPLv3
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; Commentary:
+;;
+;; Functionality for tag manipulation. Provides both per-note
+;; primitives and batch operations for managing tags across notes.
+;;
+;; Per-note functions:
+;; - `vulpea-tags' - get tags for a note
+;; - `vulpea-tags-add' - add tags to a note
+;; - `vulpea-tags-remove' - remove tags from a note
+;; - `vulpea-tags-set' - set all tags for a note
+;;
+;; Batch functions:
+;; - `vulpea-tags-batch-add' - add a tag to multiple notes
+;; - `vulpea-tags-batch-remove' - remove a tag from multiple notes
+;; - `vulpea-tags-batch-rename' - rename a tag across all notes
+;;
+;;; Code:
+
+(require 'seq)
+(require 'vulpea-utils)
+(require 'vulpea-db)
+(require 'vulpea-db-query)
+(require 'vulpea-buffer)
+
+;;; Per-note tag operations
+
+(defun vulpea-tags (note-or-id)
+  "Get tags for NOTE-OR-ID.
+
+For file-level notes (level = 0), returns filetags.
+For heading-level notes (level > 0), returns heading tags."
+  (let* ((note (if (stringp note-or-id)
+                   (vulpea-db-get-by-id note-or-id)
+                 note-or-id)))
+    (when note
+      (vulpea-utils-with-note note
+        (vulpea-buffer-tags-get)))))
+
+(defun vulpea-tags-add (note-or-id &rest tags)
+  "Add TAGS to NOTE-OR-ID.
+
+For file-level notes (level = 0), modifies filetags.
+For heading-level notes (level > 0), modifies heading tags."
+  (let* ((note (if (stringp note-or-id)
+                   (vulpea-db-get-by-id note-or-id)
+                 note-or-id)))
+    (when note
+      (vulpea-utils-with-note note
+        (vulpea-buffer-tags-add tags)))))
+
+(defun vulpea-tags-remove (note-or-id &rest tags)
+  "Remove TAGS from NOTE-OR-ID.
+
+For file-level notes (level = 0), modifies filetags.
+For heading-level notes (level > 0), modifies heading tags.
+
+Does nothing if the note has no tags."
+  (let* ((note (if (stringp note-or-id)
+                   (vulpea-db-get-by-id note-or-id)
+                 note-or-id)))
+    (when note
+      (vulpea-utils-with-note note
+        (when (vulpea-buffer-tags-get)
+          (vulpea-buffer-tags-remove tags))))))
+
+(defun vulpea-tags-set (note-or-id &rest tags)
+  "Set TAGS for NOTE-OR-ID, replacing any existing tags.
+
+For file-level notes (level = 0), modifies filetags.
+For heading-level notes (level > 0), modifies heading tags."
+  (let* ((note (if (stringp note-or-id)
+                   (vulpea-db-get-by-id note-or-id)
+                 note-or-id)))
+    (when note
+      (vulpea-utils-with-note note
+        (apply #'vulpea-buffer-tags-set tags)))))
+
+;;; Batch tag operations
+
+(defun vulpea-tags-batch-add (notes tag)
+  "Add TAG to all NOTES.
+
+Uses `vulpea-utils-process-notes' for efficient batch processing.
+Returns the count of notes processed."
+  (let ((count 0))
+    (vulpea-utils-process-notes notes
+      (vulpea-buffer-tags-add (list tag))
+      (setq count (1+ count)))
+    count))
+
+(defun vulpea-tags-batch-remove (notes tag)
+  "Remove TAG from all NOTES.
+
+Uses `vulpea-utils-process-notes' for efficient batch processing.
+Returns the count of notes processed."
+  (let ((count 0))
+    (vulpea-utils-process-notes notes
+      (vulpea-buffer-tags-remove (list tag))
+      (setq count (1+ count)))
+    count))
+
+(defun vulpea-tags-batch-rename (old-tag new-tag)
+  "Rename OLD-TAG to NEW-TAG across all notes.
+
+Finds all notes with OLD-TAG, removes it, and adds NEW-TAG.
+Returns the count of notes modified.
+
+When called interactively, prompts for OLD-TAG from existing tags
+and NEW-TAG as a string."
+  (interactive
+   (let* ((tags (vulpea-db-query-tags))
+          (old (completing-read "Rename tag: " tags nil t))
+          (new (read-string (format "Rename '%s' to: " old))))
+     (list old new)))
+  (let* ((notes (vulpea-db-query-by-tags-some (list old-tag)))
+         (count 0))
+    (vulpea-utils-process-notes notes
+      (vulpea-buffer-tags-remove (list old-tag))
+      (vulpea-buffer-tags-add (list new-tag))
+      (setq count (1+ count)))
+    (when (called-interactively-p 'any)
+      (message "Renamed '%s' to '%s' in %d note%s"
+               old-tag new-tag count (if (= count 1) "" "s")))
+    count))
+
+(provide 'vulpea-tags)
+;;; vulpea-tags.el ends here

--- a/vulpea-utils.el
+++ b/vulpea-utils.el
@@ -134,8 +134,9 @@ If note level is equal to 0, then the point is placed at the
 beginning of the buffer. Otherwise at the heading with note id."
   (declare (indent 1) (debug t))
   `(with-current-buffer (find-file-noselect (vulpea-note-path ,note))
-    (when (> (vulpea-note-level ,note) 0)
-     (goto-char (org-find-entry-with-id (vulpea-note-id ,note))))
+    (if (> (vulpea-note-level ,note) 0)
+        (goto-char (org-find-entry-with-id (vulpea-note-id ,note)))
+      (goto-char (point-min)))
     ,@body))
 
 (defmacro vulpea-utils-with-note-sync (note &rest body)
@@ -164,8 +165,9 @@ Returns the result of the last form in BODY."
     `(let ((,path (vulpea-note-path ,note))
            ,result)
       (with-current-buffer (find-file-noselect ,path)
-       (when (> (vulpea-note-level ,note) 0)
-        (goto-char (org-find-entry-with-id (vulpea-note-id ,note))))
+       (if (> (vulpea-note-level ,note) 0)
+           (goto-char (org-find-entry-with-id (vulpea-note-id ,note)))
+         (goto-char (point-min)))
        (setq ,result (progn ,@body))
        (save-buffer))
       (vulpea-db-update-file ,path)

--- a/vulpea.el
+++ b/vulpea.el
@@ -66,6 +66,7 @@
 (require 'vulpea-meta)
 (require 'vulpea-note)
 (require 'vulpea-select)
+(require 'vulpea-tags)
 (require 'vulpea-utils)
 (require 's)
 


### PR DESCRIPTION
## Summary

- Add new `vulpea-tags.el` module with per-note tag primitives: `vulpea-tags`, `vulpea-tags-add`, `vulpea-tags-remove`, `vulpea-tags-set`
- Add batch tag operations: `vulpea-tags-batch-add`, `vulpea-tags-batch-remove`, `vulpea-tags-batch-rename`
- Add batch metadata operations: `vulpea-meta-batch-set`, `vulpea-meta-batch-remove`
- `vulpea-tags-batch-rename` is interactive with completion for existing tags
- Fix `vulpea-utils-with-note` and `vulpea-utils-with-note-sync` to correctly position point at beginning of buffer for file-level notes (matching documented behavior)

Closes #211, closes #120