### PR TITLE
feat: add vulpea-db-extra-extensions for tracking non-.org files

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -11,6 +11,7 @@
 
 *Features*
 
+- [[https://github.com/d12frosted/vulpea-journal/issues/3][vulpea-journal#3]] Add =vulpea-db-extra-extensions= for tracking non-.org files (e.g., =.org.age=, =.org.gpg=). Files with extra extensions are always parsed via =find-file= to support decryption hooks. Default is =nil= (opt-in only).
 - Store link descriptions in the database. Links now include a =:description= field extracted during parsing, eliminating the need for file I/O when querying link descriptions. The =vulpea-db-query-links-*= functions now return plists with =:source=, =:dest=, =:type=, =:pos=, and =:description= keys. Database schema version bumped to 3 (existing databases will rebuild automatically).
 - [[https://github.com/d12frosted/vulpea/issues/212][vulpea#212]] Add title propagation system for renaming notes:
   - =vulpea-propagate-title-change= - interactive command to rename a note's title and update incoming link descriptions. Supports dry-run with =C-u= prefix, categorizes links into exact matches (auto-update) and partial matches (manual review), and optionally renames the file.

--- a/docs/configuration.org
+++ b/docs/configuration.org
@@ -19,6 +19,36 @@ Vulpea watches these directories recursively for =.org= files.
 
 Default: =(list org-directory)=
 
+** Extra File Extensions
+
+By default, Vulpea only tracks =.org= files. To index files with other
+extensions (e.g., age-encrypted or GPG-encrypted org files), configure:
+
+#+begin_src emacs-lisp
+(setq vulpea-db-extra-extensions '(".org.age" ".org.gpg"))
+#+end_src
+
+Default: =nil= (only =.org= files)
+
+*Requirements:*
+- Install the appropriate Emacs package for your encryption tool:
+  - =age.el= for =.org.age= files
+  - =epa-file= (built-in) for =.org.gpg= files
+- After changing this setting, run =M-x vulpea-db-sync-full-scan= to
+  index existing files
+
+*How it works:*
+- Files with extra extensions are always parsed using the =find-file=
+  method (regardless of =vulpea-db-parse-method=) so that decryption
+  hooks can run
+- Change detection uses raw (encrypted) file bytes — decrypted content
+  is never persisted outside of the temporary parse buffer
+- The parse buffer is killed immediately after extraction
+
+*Security note:* Metadata extracted from encrypted files (titles, tags,
+links, properties) is stored in the *plaintext* database. Only opt in
+if you accept this trade-off.
+
 ** Default Notes Directory
 
 Where new notes are created:
@@ -320,6 +350,9 @@ With optimized settings on modern hardware (M1 Mac):
 ;; Directories (only needed if different from org-directory)
 (setq vulpea-db-sync-directories '("~/org/" "~/work-notes/"))
 (setq vulpea-default-notes-directory "~/org/notes/")
+
+;; Extra file extensions (opt-in for encrypted files)
+;; (setq vulpea-db-extra-extensions '(".org.age" ".org.gpg"))
 
 ;; Performance (for large collections)
 (setq vulpea-db-parse-method 'single-temp-buffer)

--- a/docs/user-guide.org
+++ b/docs/user-guide.org
@@ -382,6 +382,20 @@ If you need to force a sync:
 vulpea-db-autosync-mode
 #+end_src
 
+** Encrypted Files
+
+Vulpea can track age-encrypted (=.org.age=) and GPG-encrypted (=.org.gpg=)
+org files. See [[file:configuration.org][Configuration → Extra File Extensions]] for setup.
+
+Once configured, encrypted files work like regular org files:
+- =vulpea-find= includes them in search results
+- Links, tags, and metadata are queryable
+- Changes are detected automatically by the sync system
+
+*Note:* Encrypted files are parsed more slowly (via =find-file=) than
+regular =.org= files. For large collections, keep the number of
+encrypted files manageable.
+
 * Tips and Workflows
 
 ** Zettelkasten-Style Notes

--- a/test/vulpea-db-extract-test.el
+++ b/test/vulpea-db-extract-test.el
@@ -1782,5 +1782,23 @@ File abc / * Parent (no ID) / ** Mention [[id:foo][person]] (no ID) -> abc -> fo
           (should (member "italic" (plist-get node :aliases))))
       (delete-file path))))
 
+;;; Parse Method Override Tests
+
+(ert-deftest vulpea-db-extract-non-org-uses-find-file ()
+  "Non-.org files are parsed via find-file even when parse-method is temp-buffer."
+  (let* ((vulpea-db-parse-method 'temp-buffer)
+         (base (make-temp-file "vulpea-test-" nil ".org"))
+         (path (concat base ".age")))
+    (rename-file base path)
+    (with-temp-file path
+      (insert ":PROPERTIES:\n:ID: enc-id\n:END:\n#+TITLE: Encrypted\n"))
+    (unwind-protect
+        (let ((ctx (vulpea-db--parse-file path)))
+          (should (vulpea-parse-ctx-p ctx))
+          (should (equal (vulpea-parse-ctx-path ctx) path))
+          (should (vulpea-parse-ctx-file-node ctx))
+          (should (equal (plist-get (vulpea-parse-ctx-file-node ctx) :id) "enc-id")))
+      (delete-file path))))
+
 (provide 'vulpea-db-extract-test)
 ;;; vulpea-db-extract-test.el ends here

--- a/vulpea-db-extract.el
+++ b/vulpea-db-extract.el
@@ -358,9 +358,16 @@ Returns `vulpea-parse-ctx' structure with:
 - Heading-level node data (if enabled)
 - File metadata (hash, mtime, size)
 
-Respects `vulpea-db-parse-method' setting for parsing approach."
-  (let ((vulpea-db--active-parse-method vulpea-db-parse-method))
-    (pcase vulpea-db-parse-method
+Respects `vulpea-db-parse-method' setting for parsing approach.
+
+For non-.org files (e.g., .org.age, .org.gpg), always uses the
+`find-file' method regardless of `vulpea-db-parse-method' to
+ensure decryption hooks run properly."
+  (let* ((vulpea-db--active-parse-method vulpea-db-parse-method)
+         (method (if (string-suffix-p ".org" path)
+                     vulpea-db-parse-method
+                   'find-file)))
+    (pcase method
       ('single-temp-buffer
        (vulpea-db--parse-with-temp-buffer path nil))
 

--- a/vulpea-db.el
+++ b/vulpea-db.el
@@ -87,6 +87,24 @@ to be queried. Excluding them keeps the database cleaner and faster."
   :type 'boolean
   :group 'vulpea-db)
 
+(defcustom vulpea-db-extra-extensions nil
+  "List of extra file extensions to track besides .org files.
+
+Each entry is a suffix string with leading dot, e.g. \".org.age\".
+
+Files with these extensions are always parsed using the `find-file'
+method (regardless of `vulpea-db-parse-method') so that decryption
+hooks (age.el, epa-file) can run.
+
+WARNING: metadata (titles, tags, links) from encrypted files will
+be stored in the plaintext database.  Only opt in if you accept
+this trade-off.
+
+Example:
+  (setq vulpea-db-extra-extensions \\='(\".org.age\" \".org.gpg\"))"
+  :type '(repeat string)
+  :group 'vulpea-db)
+
 ;;; Constants
 
 (defconst vulpea-db-version 3
@@ -272,6 +290,10 @@ Use with caution!"
     (not (null (emacsql (vulpea-db)
                         (format "SELECT name FROM sqlite_master WHERE type = 'index' AND name = '%s'"
                                 index-name))))))
+
+(defun vulpea-db--all-extensions ()
+  "Return all tracked file extensions (`.org' + extras)."
+  (cons ".org" vulpea-db-extra-extensions))
 
 ;;; CRUD Operations
 


### PR DESCRIPTION
## Summary

- Add `vulpea-db-extra-extensions` defcustom (default `nil`) for opt-in tracking of non-`.org` files (e.g., `.org.age`, `.org.gpg`)
- Force `find-file` parse method for non-`.org` files so decryption hooks (age.el, epa-file) run properly
- Update file discovery (`fd`/`find`/`directory-files-recursively`), file filtering, and async scanning to support extra extensions

Closes d12frosted/vulpea-journal#3

## Changed files

- **`vulpea-db.el`** — new `vulpea-db-extra-extensions` defcustom and `vulpea-db--all-extensions` helper
- **`vulpea-db-sync.el`** — updated `vulpea-db-sync--org-file-p`, `vulpea-db-sync--list-org-files`, `vulpea-db-sync--scan-files-async`
- **`vulpea-db-extract.el`** — `vulpea-db--parse-file` forces `find-file` for non-`.org` files
- **`docs/configuration.org`** — new "Extra File Extensions" section with security notes
- **`docs/user-guide.org`** — "Encrypted Files" subsection under Synchronization
- **`CHANGELOG.org`** — feature entry