### PR TITLE
fix: expand ~ in sync paths to prevent DB query mismatches

### DIFF
--- a/vulpea-db-sync.el
+++ b/vulpea-db-sync.el
@@ -406,8 +406,14 @@ Excludes:
   "List all tracked org files in DIR recursively.
 
 Uses `vulpea-db-sync--org-file-p' to filter files, ensuring
-consistency with file watcher filtering."
-  (let ((regex (mapconcat (lambda (ext)
+consistency with file watcher filtering.
+
+DIR is expanded via `expand-file-name' to ensure returned paths
+are absolute (e.g., ~/notes becomes /home/user/notes).  This
+keeps paths consistent with `vulpea-db-sync--scan-files-async'
+and prevents tilde-vs-absolute mismatches in database queries."
+  (let ((dir (expand-file-name dir))
+        (regex (mapconcat (lambda (ext)
                             (concat (regexp-quote ext) "\\'"))
                           (vulpea-db--all-extensions)
                           "\\|")))

--- a/vulpea.el
+++ b/vulpea.el
@@ -76,16 +76,17 @@
   "Vulpea note-taking system."
   :group 'org)
 
-(defcustom vulpea-default-notes-directory
-  (car vulpea-db-sync-directories)
+(defcustom vulpea-default-notes-directory nil
   "Default directory for creating new notes.
 
-Defaults to the first entry in `vulpea-db-sync-directories', which
-itself defaults to `org-directory'.
+When nil (the default), dynamically resolves to the first entry in
+`vulpea-db-sync-directories', which itself defaults to
+`org-directory'.
 
-This allows you to control where `vulpea-create' places new notes
-without specifying an explicit file path."
-  :type 'directory
+Set this explicitly only if you want notes created in a different
+directory than the first sync directory."
+  :type '(choice (const :tag "Use first sync directory" nil)
+                 (directory :tag "Explicit directory"))
   :group 'vulpea)
 
 (defcustom vulpea-create-default-function nil


### PR DESCRIPTION
## Summary

- Expand `dir` via `expand-file-name` in `vulpea-db-sync--list-org-files` before calling `directory-files-recursively`, consistent with `vulpea-db-sync--scan-files-async` which already expanded
- Change `vulpea-default-notes-directory` defcustom default from `(car vulpea-db-sync-directories)` to `nil` to prevent stale load-time evaluation with `use-package :custom`

**Root cause**: `directory-files-recursively` constructs return paths by concatenating its `dir` argument with filenames. When `vulpea-db-sync-directories` contains `~/notes`, the DB stored `~/notes/file.org` (tilde preserved). But consumers calling `expand-file-name` got `/home/user/notes/file.org`. The exact SQL `=` match in `vulpea-db-query-by-file-path` then failed.

Fixes d12frosted/vulpea-journal#5