### PR TITLE
fix: auto-rebuild database on schema version change

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -11,6 +11,7 @@
 
 *Features*
 
+- [[https://github.com/d12frosted/vulpea/issues/243][vulpea#243]] Automatic database rebuild on schema version change. When =vulpea-db-version= changes, the database file is deleted and recreated from scratch on next access. When =vulpea-db-autosync-mode= is active, a forced re-index of all files is triggered automatically.
 - [[https://github.com/d12frosted/vulpea-journal/issues/3][vulpea-journal#3]] Add =vulpea-db-extra-extensions= for tracking non-.org files (e.g., =.org.age=, =.org.gpg=). Files with extra extensions are always parsed via =find-file= to support decryption hooks. Default is =nil= (opt-in only).
 - Store link descriptions in the database. Links now include a =:description= field extracted during parsing, eliminating the need for file I/O when querying link descriptions. The =vulpea-db-query-links-*= functions now return plists with =:source=, =:dest=, =:type=, =:pos=, and =:description= keys. Database schema version bumped to 3 (existing databases will rebuild automatically).
 - [[https://github.com/d12frosted/vulpea/issues/212][vulpea#212]] Add title propagation system for renaming notes:

--- a/vulpea-db-sync.el
+++ b/vulpea-db-sync.el
@@ -326,6 +326,13 @@ a subprocess.  The `blocking' mode still scans synchronously."
         (message "[vulpea-sync] cleanup-deleted-files: %.0fms"
                  (* 1000 (float-time (time-subtract (current-time) t-phase))))))
 
+    ;; If schema was rebuilt, trigger forced re-index
+    (when vulpea-db--schema-rebuilt
+      (setq vulpea-db--schema-rebuilt nil)
+      (message "Vulpea: Schema upgraded, re-indexing all files...")
+      (dolist (dir vulpea-db-sync-directories)
+        (vulpea-db-sync-update-directory dir 'force)))
+
     (when vulpea-db-sync-debug
       (message "[vulpea-sync] start complete: %.0fms total (sync portion)"
                (* 1000 (float-time (time-subtract (current-time) t-total)))))))


### PR DESCRIPTION
## Summary

- `vulpea-db--init` now checks the stored schema version in `schema-registry` against `vulpea-db-version` on every connection
- On version mismatch, the DB file is deleted and recreated from scratch (simpler and more reliable than dropping individual tables, which would miss plugin tables)
- Sets `vulpea-db--schema-rebuilt` flag so `vulpea-db-sync--start` can trigger a forced re-index of all files automatically
- For non-autosync users, a message instructs them to run `vulpea-db-sync-full-scan`

Closes #243