### PR TITLE
feat: extend vulpea-create to support heading-level note creation

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -21,6 +21,7 @@
 - [[https://github.com/d12frosted/vulpea/issues/211][vulpea#211]] Add per-note tag operations in new =vulpea-tags.el= module: =vulpea-tags= (get), =vulpea-tags-add=, =vulpea-tags-remove=, =vulpea-tags-set=. These work with both file-level notes (filetags) and heading-level notes (org heading tags).
 - [[https://github.com/d12frosted/vulpea/issues/211][vulpea#211]] Add batch tag operations: =vulpea-tags-batch-add=, =vulpea-tags-batch-remove=, and =vulpea-tags-batch-rename=. The rename function implements [[https://github.com/d12frosted/vulpea/issues/120][vulpea#120]], allowing global tag renaming across all notes. =vulpea-tags-batch-rename= is interactive with completion for existing tags.
 - [[https://github.com/d12frosted/vulpea/issues/211][vulpea#211]] Add batch metadata operations: =vulpea-meta-batch-set= and =vulpea-meta-batch-remove= for efficiently setting or removing metadata properties across multiple notes. Both use =vulpea-utils-process-notes= for optimized batch processing.
+- [[https://github.com/d12frosted/vulpea-journal/issues/2][vulpea-journal#2]] Extend =vulpea-create= with =:parent= and =:after= parameters for creating heading-level notes under existing notes. When =:parent= is a =vulpea-note=, a heading is inserted in the parent's file at =parent-level + 1=. =:after= controls insertion order: ='last= (default, append as last child), =nil= (insert as first child), or a note ID string (insert after that sibling).
 
 *Fixes*
 

--- a/docs/api-reference.org
+++ b/docs/api-reference.org
@@ -313,6 +313,8 @@ There are multiple ways to read metadata, each with different trade-offs:
 
 * Creating Notes
 
+** File-level notes
+
 #+begin_src emacs-lisp
 ;; Simple
 (vulpea-create "My Note")
@@ -329,6 +331,53 @@ There are multiple ways to read metadata, each with different trade-offs:
 #+end_src
 
 Returns the created =vulpea-note=. Signals an error if a file already exists at the target path (to prevent accidental overwrites).
+
+** Heading-level notes
+
+Use =:parent= to create a heading inside an existing note's file:
+
+#+begin_src emacs-lisp
+;; Create a heading under an existing note
+(let ((parent (vulpea-db-get-by-id "parent-id")))
+  (vulpea-create "Sub-heading"
+                 nil
+                 :parent parent
+                 :tags '("journal")
+                 :properties '(("CREATED" . "[2025-01-15]"))))
+
+;; Insert as first child
+(vulpea-create "First Item" nil
+               :parent parent-note
+               :after nil)
+
+;; Insert after a specific sibling
+(vulpea-create "After Sibling" nil
+               :parent parent-note
+               :after "sibling-note-id")
+#+end_src
+
+The heading level is computed automatically as =parent-level + 1=. The parent's file must exist. Returns the created =vulpea-note=.
+
+** Parameters
+
+| Parameter     | Description                             | Default            |
+|---------------+-----------------------------------------+--------------------|
+| =title=       | Note title (required)                   |                    |
+| =file-name=   | File path relative to default directory | from template      |
+| =:id=         | UUID for the note                       | auto-generated     |
+| =:tags=       | List of tags                            |                    |
+| =:head=       | Content after =#+title:=                |                    |
+| =:body=       | Note body content                       |                    |
+| =:properties= | Alist for property drawer               |                    |
+| =:meta=       | Alist for metadata                      |                    |
+| =:context=    | Custom variables for template expansion |                    |
+| =:parent=     | =vulpea-note= to create heading under   | =nil= (file-level) |
+| =:after=      | Insertion position among siblings       | ='last=            |
+
+=:after= accepts:
+- ='last= — append as last child (default)
+- =nil= — insert as first child
+- string — insert after the sibling with that note ID
 
 * Visiting Notes
 
@@ -792,7 +841,7 @@ For advanced use cases, direct database access:
 | =vulpea-find=          | Interactive note selection and navigation |
 | =vulpea-find-backlink= | Find notes linking to current note        |
 | =vulpea-insert=        | Insert link to a note                     |
-| =vulpea-create=        | Create new note programmatically          |
+| =vulpea-create=        | Create file-level or heading-level note   |
 | =vulpea-visit=         | Visit note by ID or struct                |
 
 ** Query Functions

--- a/docs/configuration.org
+++ b/docs/configuration.org
@@ -110,6 +110,8 @@ For context-aware defaults:
 | =:properties= | Alist for property drawer               | ='(("STATUS" . "active"))=   |
 | =:meta=       | Alist for metadata                      | ='(("author" . "me"))=       |
 | =:context=    | Custom variables for template expansion | ='(:project "MyProject")=    |
+| =:parent=     | =vulpea-note= to create heading under   | =parent-note=                |
+| =:after=      | Insertion position (='last=, =nil=, id) | ='last=                      |
 
 ** Template Expansion Syntax
 
@@ -237,10 +239,10 @@ When =fswatch= is not available, Vulpea falls back to polling — periodically s
 
 If you use polling, install =fd= — it is critical for polling performance. Benchmark on a 14k-file collection:
 
-| Method  | File listing time | Blocking time (editor) |
-|---------+-------------------+------------------------|
-| =fd=    | ~50ms             | 0ms (async)            |
-| =find=  | ~900ms            | 0ms (async)            |
+| Method | File listing time | Blocking time (editor) |
+|--------+-------------------+------------------------|
+| =fd=   | ~50ms             | 0ms (async)            |
+| =find= | ~900ms            | 0ms (async)            |
 
 Both run asynchronously and don't block the editor, but =fd= completes the scan 15× faster, meaning changes are detected sooner.
 

--- a/docs/sync-architecture.org
+++ b/docs/sync-architecture.org
@@ -32,7 +32,9 @@ vulpea-db-update-file(path)
 #+begin_example
 vulpea-create(title, ...)
   │
-  ├─ Write file to disk
+  ├─ :parent nil?
+  │   ├─ YES: Write new file to disk (file-level note)
+  │   └─ NO:  Insert heading in parent's file (heading-level note)
   ├─ org-id-add-location(id, path)
   └─ vulpea-db-update-file(path)  ← ALWAYS IMMEDIATE
       └─ Returns note object

--- a/docs/user-guide.org
+++ b/docs/user-guide.org
@@ -74,6 +74,21 @@ For scripts or custom commands:
                        ("rating" . "4")))
 #+end_src
 
+** Under Existing Notes
+
+Create heading-level notes inside an existing file using =:parent=:
+
+#+begin_src emacs-lisp
+;; Add a heading under an existing note
+(let ((parent (vulpea-db-get-by-id "parent-id")))
+  (vulpea-create "New Section" nil :parent parent))
+
+;; Control insertion order with :after
+(vulpea-create "First" nil :parent parent :after nil)      ; first child
+(vulpea-create "Last" nil :parent parent :after 'last)     ; last child (default)
+(vulpea-create "After X" nil :parent parent :after "x-id") ; after specific sibling
+#+end_src
+
 ** Default Templates
 
 Configure defaults that apply to all new notes:


### PR DESCRIPTION
## Summary

- Add `:parent` and `:after` keyword parameters to `vulpea-create` for creating heading-level notes inside existing files
- When `:parent` is a `vulpea-note`, a heading is inserted at `parent-level + 1` in the parent's file
- `:after` controls insertion order: `'last` (default), `nil` (first child), or a note ID string (after that sibling)
- Update changelog, API reference, user guide, configuration docs, and sync architecture diagram

Required by d12frosted/vulpea-journal#2