### PR TITLE
fix: expand paths in fswatch validator for relative directories

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -34,6 +34,7 @@
 - [[https://github.com/d12frosted/vulpea-journal/issues/5][vulpea-journal#5]] Fix =~= paths in database causing query mismatches. =vulpea-db-sync--list-org-files= now expands directory paths before calling =directory-files-recursively=, consistent with =vulpea-db-sync--scan-files-async=. Previously, when =vulpea-db-sync-directories= contained =~/notes=, the database stored paths with =~= unexpanded, causing exact-match lookups to fail.
 - [[https://github.com/d12frosted/vulpea/issues/252][vulpea#252]] Fix =vulpea-find-backlink= failing when cursor is inside a heading without its own ID. The function now inherits the ID from the nearest ancestor (parent heading or file-level note). Additionally, the resolved ID is validated against the database — if it does not correspond to a known note, a clear error is shown.
 - [[https://github.com/d12frosted/vulpea-journal/issues/5][vulpea-journal#5]] Change =vulpea-default-notes-directory= default from =(car vulpea-db-sync-directories)= to =nil=. The old default was evaluated once at load time, before =use-package :custom= could take effect, causing stale values. When =nil=, it dynamically resolves via =vulpea--default-directory=.
+- [[https://github.com/d12frosted/vulpea/issues/255][vulpea#255]] Fix fswatch sync ignoring file changes when =vulpea-db-sync-directories= contains relative paths (e.g. =~/notes=). The fswatch path validator now expands directory paths before comparison, consistent with all other sync functions.
 
 ** v2.1.0
 

--- a/test/vulpea-db-sync-test.el
+++ b/test/vulpea-db-sync-test.el
@@ -1099,6 +1099,26 @@
 
 ;;; Extra Extensions Tests
 
+;;; FSWatch Path Validation Tests
+
+(ert-deftest vulpea-db-sync-fswatch-path-valid-p-absolute ()
+  "Test fswatch path validation with absolute directories."
+  (let ((vulpea-db-sync-directories (list "/tmp/notes")))
+    (should (vulpea-db-sync--fswatch-path-valid-p "/tmp/notes/file.org"))
+    (should (vulpea-db-sync--fswatch-path-valid-p "/tmp/notes/sub/file.org"))
+    (should-not (vulpea-db-sync--fswatch-path-valid-p "/tmp/other/file.org"))
+    (should-not (vulpea-db-sync--fswatch-path-valid-p nil))))
+
+(ert-deftest vulpea-db-sync-fswatch-path-valid-p-tilde ()
+  "Test fswatch path validation with tilde (relative) directories."
+  (let ((vulpea-db-sync-directories (list "~/notes")))
+    ;; fswatch reports absolute paths - must match expanded tilde
+    (should (vulpea-db-sync--fswatch-path-valid-p
+             (expand-file-name "notes/file.org" "~")))
+    (should-not (vulpea-db-sync--fswatch-path-valid-p "/other/file.org"))))
+
+;;; Extra Extensions Tests
+
 (ert-deftest vulpea-db-sync-org-file-p-extra-extensions ()
   "Test org-file-p recognizes extra extensions."
   (let ((vulpea-db-extra-extensions '(".org.age" ".org.gpg")))

--- a/vulpea-db-sync.el
+++ b/vulpea-db-sync.el
@@ -1005,7 +1005,7 @@ is enabled."
   (and path
        (file-name-absolute-p path)
        (seq-some (lambda (dir)
-                   (string-prefix-p (file-name-as-directory dir) path))
+                   (string-prefix-p (file-name-as-directory (expand-file-name dir)) path))
                  vulpea-db-sync-directories)))
 
 (defun vulpea-db-sync--fswatch-filter (_proc output)


### PR DESCRIPTION
## Summary

- Fix `vulpea-db-sync--fswatch-path-valid-p` silently dropping all fswatch events when `vulpea-db-sync-directories` contains tilde paths (e.g. `~/notes`)
- Add `expand-file-name` to match what every other sync function already does

Closes #255