### PR TITLE
fix: extract #+CATEGORY keyword as file-level property

### DIFF
--- a/vulpea-db-extract.el
+++ b/vulpea-db-extract.el
@@ -437,6 +437,12 @@ Returns nil if:
                              (vulpea-db--string-no-properties
                               (org-element-property :value kw))))))
          (properties (vulpea-db--extract-properties ast nil))
+         (category-kw (cdr (assoc "CATEGORY" keywords)))
+         (properties (if (and category-kw
+                              (not (assoc "CATEGORY" properties)))
+                         (append properties
+                                 (list (cons "CATEGORY" category-kw)))
+                       properties))
          (id (cdr (assoc "ID" properties)))
          (ignored (cdr (assoc "VULPEA_IGNORE" properties)))
          (filetags (cl-mapcan (lambda (kw)


### PR DESCRIPTION
## Summary

- Extract `#+CATEGORY:` keyword at file level into the properties table, fixing the gap where only `:CATEGORY:` in `:PROPERTIES:` drawers was captured.
- Property drawer values take precedence when both `#+CATEGORY:` and `:CATEGORY:` are present.

Closes #257