### PR TITLE
fix: return string keys from properties after JSON round-trip

### DIFF
--- a/test/vulpea-db-query-test.el
+++ b/test/vulpea-db-query-test.el
@@ -605,7 +605,7 @@ from being inserted into the normalized tags table."
       (should (= (vulpea-note-pos note) 0))
       (should (equal (vulpea-note-tags note) '("tag1" "tag2")))
       (should (equal (vulpea-note-aliases note) '("alias1")))
-      (should (equal (vulpea-note-properties note) '((key . "value"))))
+      (should (equal (vulpea-note-properties note) '(("key" . "value"))))
       (should (equal (vulpea-note-meta note)
                      '(("country" . ("France")))))
       (should (equal (vulpea-note-links note) '((:dest "target" :type "id" :pos 100))))
@@ -801,6 +801,24 @@ from being inserted into the normalized tags table."
 
     (should-not (vulpea-db-query-by-property "CATEGORY" "project"))
     (should-not (vulpea-db-query-by-property-key "NONEXISTENT"))))
+
+(ert-deftest vulpea-db-query-properties-have-string-keys ()
+  "Test that note properties from DB have string keys, not symbols.
+
+Properties are stored with string keys during extraction and should
+be returned with string keys after JSON round-trip through the DB."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--insert-test-note "note1" "Note 1"
+                                   :properties '(("CREATED" . "[2025-12-08 Mon 10:00]")
+                                                 ("CATEGORY" . "journal")))
+    (let* ((note (vulpea-db-get-by-id "note1"))
+           (props (vulpea-note-properties note)))
+      ;; Keys must be strings
+      (should (stringp (caar props)))
+      ;; String key lookup must work
+      (should (assoc "CREATED" props))
+      (should (equal (cdr (assoc "CATEGORY" props)) "journal")))))
 
 ;;; Created-At Query Tests
 

--- a/vulpea-db-query.el
+++ b/vulpea-db-query.el
@@ -116,7 +116,9 @@ ROW is a vector from the notes table with all fields in schema order."
      :pos pos
      :title title
      :properties (when (and properties (not (string= properties "null")))
-                   (json-parse-string properties :object-type 'alist))
+                   (mapcar (lambda (pair)
+                             (cons (symbol-name (car pair)) (cdr pair)))
+                           (json-parse-string properties :object-type 'alist)))
      :tags (when (and tags (not (string= tags "null")))
              (append (json-parse-string tags :array-type 'list) nil))
      :aliases (when (and aliases (not (string= aliases "null")))


### PR DESCRIPTION
## Summary

- `json-parse-string` with `:object-type 'alist` returns symbol keys, but properties are stored with string keys during extraction. This causes `(assoc "KEY" properties)` to return nil for notes read from the DB.
- Convert symbol keys back to strings in `vulpea-db--row-to-note` so consumers can rely on string key lookups.

Ref: d12frosted/vulpea-journal#9