### PR TITLE
fix: don't steal first heading's ID as file-level ID

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -37,6 +37,7 @@
 - [[https://github.com/d12frosted/vulpea/issues/255][vulpea#255]] Fix fswatch sync ignoring file changes when =vulpea-db-sync-directories= contains relative paths (e.g. =~/notes=). The fswatch path validator now expands directory paths before comparison, consistent with all other sync functions.
 - [[https://github.com/d12frosted/vulpea/issues/257][vulpea#257]] Extract =#+CATEGORY= keyword at file level as a property. Previously only =:CATEGORY:= in the =:PROPERTIES:= drawer was captured.
 - [[https://github.com/d12frosted/vulpea-journal/issues/9][vulpea-journal#9]] Fix =vulpea-note-properties= returning symbol keys after database round-trip. =json-parse-string= with =:object-type 'alist= produces symbol keys, but the rest of the API uses string keys consistently. Property keys are now converted back to strings in =vulpea-db--row-to-note=.
+- [[https://github.com/d12frosted/vulpea/issues/260][vulpea#260]] Fix first heading with =:ID:= not being indexed when the file has no file-level ID. The file-level property extraction was searching the entire AST for a property drawer, accidentally finding the first heading's drawer and stealing its ID for a bogus file-level note.
 
 ** v2.1.0
 

--- a/vulpea-db-extract.el
+++ b/vulpea-db-extract.el
@@ -694,7 +694,11 @@ Returns alist of (key . value) pairs."
                           (org-element-property :key prop)))
                   (vulpea-db--string-no-properties
                    (org-element-property :value prop))))))
-      nil t)))  ; First match only
+      nil t
+      ;; When extracting file-level properties, don't recurse into
+      ;; headlines — otherwise the first heading's property drawer
+      ;; is mistakenly returned as the file-level one.
+      (unless headline 'headline))))
 
 (defun vulpea-db--extract-links (ast-or-node &optional no-recursion)
   "Extract all links from AST-OR-NODE.


### PR DESCRIPTION
## Summary

- Fix [#260](https://github.com/d12frosted/vulpea/issues/260): when a file has no file-level property drawer, `vulpea-db--extract-properties` searched the entire AST and found the first heading's property drawer instead, stealing its ID for a bogus file-level note
- Add `no-recursion` argument (`'headline`) to `org-element-map` in `vulpea-db--extract-properties` so file-level extraction doesn't descend into headlines
- Add regression tests at both the parse level and database level

Closes #260