### PR TITLE
fix: org-attach directory resolution when parsing

### DIFF
--- a/vulpea-db-extract.el
+++ b/vulpea-db-extract.el
@@ -298,13 +298,16 @@ after loading PATH so file-local keywords and hooks are respected."
   (let ((vulpea-db--parse-buffer-run-hooks rerun-org-mode))
     (vulpea-db--with-parse-buffer
       (let* ((t0 (current-time))
-             (_ (let ((inhibit-read-only t))
+
+             ;; Required in case of relative `org-attach-dir'
+             (_ (setq buffer-file-name path
+                      default-directory (file-name-directory path)))
+
+             (_ (let ((inhibit-read-only t)
+                      (inhibit-modification-hooks t))
                   (erase-buffer)
                   (insert-file-contents path)))
              (t1 (current-time))
-             (_ (progn
-                  (setq buffer-file-name path)  ; Required for org-attach-dir
-                  (setq default-directory (file-name-directory path))))  ; Fix attach-dir paths
              (_ (when rerun-org-mode
                   (let ((delay-mode-hooks nil))
                     (org-mode))))


### PR DESCRIPTION
Problem: org-attach emitting ``(error "Need absolute `org-attach-id-dir' to attach in buffers without filename")`` during parsing. Here&rsquo;s the relevant stack-trace.

```
Debugger entered--entering a function:
 * org-attach-check-absolute-path(nil)
   org-attach-dir()
   org-attach-expand("some-attachment.html")
   org-attach-expand-links(latex)
   org-export--annotate-info(...)
   org-latex-preview--get-preamble()
   org-latex-preview-place(...)
   org-latex-preview--place-from-elements(...)
   org-latex-preview-mode--detect-fragments-in-change(...)
   insert-file-contents("my-org-directory/some-file.org")
   (let ((inhibit-read-only t)) (erase-buffer) (insert-file-contents path))
   ...
   vulpea-db--parse-with-temp-buffer("my-org-directory/some-file.org" t)
   vulpea-db--parse-file("my-org-directory/some-file.org")
   vulpea-db-update-file("my-org-directory/some-file.org")
   vulpea-db-sync-update-file("my-org-directory/some-file.org")
```

Using `debugger-eval-expression` to evaluate `buffer-file-name` in the stack frame indeed yields `nil`.

The problem is that since we&rsquo;re reusing the parse buffer (`vulpea-db-parse-method` set to `temp-buffer`), `org-latex-preview-mode` is already enabled buffer-locally from a previous run. Consequently, calling `insert-file-contents` triggers `org-latex-preview` modification hooks (through `after-change-functions`) attempting to preview some Latex snippets present in the file to be parsed by Vulpea. This appears to involve a call to `org-attach` that fails to resolve relative paths as `buffer-file-name` is set by Vulpea only after the call to `insert-file-contents`.

The proposed change inhibits modification hooks when populating the buffer and moves the code setting `buffer-file-name` before `insert-file-contents`, fixing the issue.