### PR TITLE
fix: add :noquery t to fswatch process

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -38,6 +38,7 @@
 - [[https://github.com/d12frosted/vulpea/issues/257][vulpea#257]] Extract =#+CATEGORY= keyword at file level as a property. Previously only =:CATEGORY:= in the =:PROPERTIES:= drawer was captured.
 - [[https://github.com/d12frosted/vulpea-journal/issues/9][vulpea-journal#9]] Fix =vulpea-note-properties= returning symbol keys after database round-trip. =json-parse-string= with =:object-type 'alist= produces symbol keys, but the rest of the API uses string keys consistently. Property keys are now converted back to strings in =vulpea-db--row-to-note=.
 - [[https://github.com/d12frosted/vulpea/issues/260][vulpea#260]] Fix first heading with =:ID:= not being indexed when the file has no file-level ID. The file-level property extraction was searching the entire AST for a property drawer, accidentally finding the first heading's drawer and stealing its ID for a bogus file-level note.
+- [[https://github.com/d12frosted/vulpea/issues/263][vulpea#263]] Add =:noquery t= to the fswatch process so Emacs does not prompt about it when exiting.
 
 ** v2.1.0
 

--- a/vulpea-db-sync.el
+++ b/vulpea-db-sync.el
@@ -996,6 +996,7 @@ is enabled."
                           "--exclude" "\\.git/"      ; exclude .git directory
                           "--format" "%p|||%f"      ; include event flag with ||| separator
                           ,@(nreverse valid-dirs))
+               :noquery t
                :filter #'vulpea-db-sync--fswatch-filter
                :sentinel #'vulpea-db-sync--fswatch-sentinel))
         (message "Vulpea: Started fswatch monitoring")))))


### PR DESCRIPTION
## Summary

- Add `:noquery t` to the fswatch `make-process` call so Emacs exits without prompting about the running process.
- The scan process already had this flag; this brings fswatch in line.

Closes #263