### PR TITLE
fix: collect tags from all #+filetags lines

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -38,6 +38,7 @@
 - [[https://github.com/d12frosted/vulpea/issues/257][vulpea#257]] Extract =#+CATEGORY= keyword at file level as a property. Previously only =:CATEGORY:= in the =:PROPERTIES:= drawer was captured.
 - [[https://github.com/d12frosted/vulpea-journal/issues/9][vulpea-journal#9]] Fix =vulpea-note-properties= returning symbol keys after database round-trip. =json-parse-string= with =:object-type 'alist= produces symbol keys, but the rest of the API uses string keys consistently. Property keys are now converted back to strings in =vulpea-db--row-to-note=.
 - [[https://github.com/d12frosted/vulpea/issues/260][vulpea#260]] Fix first heading with =:ID:= not being indexed when the file has no file-level ID. The file-level property extraction was searching the entire AST for a property drawer, accidentally finding the first heading's drawer and stealing its ID for a bogus file-level note.
+- [[https://github.com/d12frosted/vulpea/issues/250][vulpea#250]] Fix =vulpea-buffer-tags-get= only reading the first =#+filetags= line. When a file has multiple =#+filetags= lines, all lines are now collected and merged. =vulpea-buffer-tags-set= also consolidates multiple lines into a single =#+filetags= line.
 - [[https://github.com/d12frosted/vulpea/issues/263][vulpea#263]] Add =:noquery t= to the fswatch process so Emacs does not prompt about it when exiting.
 
 ** v2.1.0

--- a/test/note-files/with-multiple-filetags.org
+++ b/test/note-files/with-multiple-filetags.org
@@ -1,0 +1,15 @@
+:PROPERTIES:
+:ID:                     bbccddee-1122-3344-5566-778899aabb01
+:END:
+#+title: Multiple filetags
+#+filetags: :mtag1:mtag2:
+#+filetags: :mtag3:
+
+Some content here.
+
+* Heading One
+:PROPERTIES:
+:ID:                     bbccddee-1122-3344-5566-778899aabb02
+:END:
+
+Content under heading one.

--- a/test/vulpea-buffer-test.el
+++ b/test/vulpea-buffer-test.el
@@ -1203,5 +1203,67 @@ gives a descriptive error."
    (should-error (vulpea-buffer-tags-remove "ftag")
                  :type 'user-error)))
 
+;;; Multiple filetags tests
+
+(ert-deftest vulpea-buffer-tags-get-multiple-filetags ()
+  "Test that tags-get collects tags from ALL #+filetags lines."
+  (vulpea-buffer-test--with-temp-buffer
+   ":PROPERTIES:
+:ID: file-id
+:END:
+#+title: Test
+#+filetags: :tag1:tag2:
+#+filetags: :tag3:
+"
+   (goto-char (point-min))
+   (should (equal (vulpea-buffer-tags-get)
+                  '("tag1" "tag2" "tag3")))))
+
+(ert-deftest vulpea-buffer-tags-set-consolidates-multiple-filetags ()
+  "Test that tags-set consolidates multiple #+filetags into one line."
+  (vulpea-buffer-test--with-temp-buffer
+   ":PROPERTIES:
+:ID: file-id
+:END:
+#+title: Test
+#+filetags: :tag1:tag2:
+#+filetags: :tag3:
+"
+   (goto-char (point-min))
+   (vulpea-buffer-tags-set "x" "y" "z")
+   ;; Should have exactly one filetags line
+   (goto-char (point-min))
+   (let ((count 0))
+     (while (re-search-forward "^#\\+filetags:" nil t)
+       (setq count (1+ count)))
+     (should (= count 1)))
+   ;; Should contain correct tags
+   (goto-char (point-min))
+   (should (equal (vulpea-buffer-tags-get)
+                  '("x" "y" "z")))))
+
+(ert-deftest vulpea-buffer-tags-add-with-multiple-filetags ()
+  "Test that tags-add reads all filetags and consolidates into one line."
+  (vulpea-buffer-test--with-temp-buffer
+   ":PROPERTIES:
+:ID: file-id
+:END:
+#+title: Test
+#+filetags: :tag1:tag2:
+#+filetags: :tag3:
+"
+   (goto-char (point-min))
+   (vulpea-buffer-tags-add '("tag4"))
+   ;; Should have exactly one filetags line
+   (goto-char (point-min))
+   (let ((count 0))
+     (while (re-search-forward "^#\\+filetags:" nil t)
+       (setq count (1+ count)))
+     (should (= count 1)))
+   ;; Should have all tags
+   (goto-char (point-min))
+   (should (equal (vulpea-buffer-tags-get)
+                  '("tag1" "tag2" "tag3" "tag4")))))
+
 (provide 'vulpea-buffer-test)
 ;;; vulpea-buffer-test.el ends here

--- a/test/vulpea-tags-test.el
+++ b/test/vulpea-tags-test.el
@@ -123,6 +123,20 @@
      (should (equal (vulpea-tags note)
                     '("tag1" "tag2" "tag3"))))))
 
+(ert-deftest vulpea-tags-get-multiple-filetags ()
+  "Test getting tags from a file with multiple #+filetags lines."
+  (vulpea-tags-test--with-temp-db
+   ;; with-multiple-filetags.org has :mtag1:mtag2: and :mtag3:
+   (should (equal (vulpea-tags "bbccddee-1122-3344-5566-778899aabb01")
+                  '("mtag1" "mtag2" "mtag3")))))
+
+(ert-deftest vulpea-tags-get-heading-inherits-multiple-filetags ()
+  "Test that heading notes inherit tags from all #+filetags lines."
+  (vulpea-tags-test--with-temp-db
+   ;; Heading One in with-multiple-filetags.org should inherit all filetags
+   (should (equal (vulpea-tags "bbccddee-1122-3344-5566-778899aabb02")
+                  '("mtag1" "mtag2" "mtag3")))))
+
 ;;; vulpea-tags-add Tests
 
 (ert-deftest vulpea-tags-add-single-tag ()

--- a/vulpea-buffer.el
+++ b/vulpea-buffer.el
@@ -86,7 +86,9 @@ inherited from the file and parent headings, respecting
 `org-use-tag-inheritance'.  When LOCAL is non-nil, returns only
 the heading's own tags without inheritance."
   (if (= (org-outline-level) 0)
-      (vulpea-buffer-prop-get-list "filetags" "[ :]")
+      (seq-uniq
+       (cl-mapcan (lambda (v) (split-string v "[ :]" t))
+                  (vulpea-buffer-prop-get-all "filetags")))
     (mapcar #'substring-no-properties
             (org-get-tags nil local))))
 
@@ -98,10 +100,12 @@ At heading level, sets heading tags.
 Duplicate tags are automatically removed."
   (let ((tags (seq-uniq tags)))
     (if (= (org-outline-level) 0)
-        (if tags
+        (progn
+          ;; Remove all #+filetags: lines first to consolidate
+          (vulpea-buffer-prop-remove-all "filetags")
+          (when tags
             (vulpea-buffer-prop-set
-             "filetags" (concat ":" (string-join tags ":") ":"))
-          (vulpea-buffer-prop-remove "filetags"))
+             "filetags" (concat ":" (string-join tags ":") ":"))))
       (save-excursion
         (org-back-to-heading t)
         (org-set-tags tags)))))
@@ -277,6 +281,24 @@ If the property is already set, replace its value."
         (unless (string-empty-p value)
           value)))))
 
+(defun vulpea-buffer-prop-get-all (name)
+  "Get all values of buffer property called NAME as a list of strings.
+
+Unlike `vulpea-buffer-prop-get' which returns only the first
+match, this collects values from all lines matching #+NAME:."
+  (let (values)
+    (org-with-point-at 1
+      (let ((case-fold-search t))
+        (while (re-search-forward (concat "^#\\+" name ": \\(.*\\)")
+                                  (point-max) t)
+          (let ((value (string-trim
+                        (buffer-substring-no-properties
+                         (match-beginning 1)
+                         (match-end 1)))))
+            (unless (string-empty-p value)
+              (push value values))))))
+    (nreverse values)))
+
 (defun vulpea-buffer-prop-get-list (name &optional separators)
   "Get a buffer property NAME as a list using SEPARATORS.
 
@@ -294,6 +316,14 @@ If nil it defaults to `split-string-default-separators', normally
     (when (re-search-forward (concat "\\(^#\\+" name ":.*\n?\\)")
                              (point-max) t)
       (replace-match ""))))
+
+(defun vulpea-buffer-prop-remove-all (name)
+  "Remove all buffer properties called NAME."
+  (org-with-point-at 1
+    (let ((case-fold-search t))
+      (while (re-search-forward (concat "\\(^#\\+" name ":.*\n?\\)")
+                                (point-max) t)
+        (replace-match "")))))
 
 
 


### PR DESCRIPTION
## Summary

- Add `vulpea-buffer-prop-get-all` to collect values from all matching keyword lines (unlike `vulpea-buffer-prop-get` which stops at first match)
- Add `vulpea-buffer-prop-remove-all` to remove all occurrences of a keyword
- Fix `vulpea-buffer-tags-get` to merge tags from all `#+filetags:` lines using the new primitive
- Fix `vulpea-buffer-tags-set` to consolidate multiple `#+filetags:` lines into one

Closes #250