### PR TITLE
feat: invalidate DB when tag inheritance settings change

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,6 +9,10 @@
 
 ** Unreleased
 
+*Features*
+
+- [[https://github.com/d12frosted/vulpea/issues/251][vulpea#251]] Automatically detect when global tag inheritance settings (=org-use-tag-inheritance=, =org-tags-exclude-from-inheritance=) change between sessions and trigger a forced re-index. A fingerprint of these settings is stored in the database; on startup, if the fingerprint differs, the file change cache is cleared so all files are re-extracted with the new settings. Per-buffer overrides (e.g. via =.dir-locals.el=) are not tracked — use =vulpea-db-sync-update-directory= with a force argument after changing those.
+
 *Fixes*
 
 - [[https://github.com/d12frosted/vulpea/pull/267][vulpea#267]] Fix =Wrong type argument: hash-table-p= error during async sync. When =org-id-update-id-locations= is running, =org-id-locations= is temporarily an alist. If a vulpea timer fires in that window, =org-id-add-location= fails. Now =org-id-locations= is defensively converted to a hash table before registering IDs.

--- a/test/vulpea-db-test.el
+++ b/test/vulpea-db-test.el
@@ -478,5 +478,112 @@ parent headings top-down, then own tags."
       (should (member "tag2" (vulpea-note-tags note)))
       (should (member "tag3" (vulpea-note-tags note))))))
 
+;;; Tag Inheritance Settings Invalidation Tests
+
+(ert-deftest vulpea-db-tag-settings-fingerprint ()
+  "Test that fingerprint captures tag inheritance settings."
+  ;; Default settings should produce a stable fingerprint
+  (let ((org-use-tag-inheritance t)
+        (org-tags-exclude-from-inheritance nil))
+    (let ((fp1 (vulpea-db--tag-settings-fingerprint))
+          (fp2 (vulpea-db--tag-settings-fingerprint)))
+      (should (equal fp1 fp2))))
+
+  ;; Different settings should produce different fingerprints
+  (let ((fp-default (let ((org-use-tag-inheritance t)
+                          (org-tags-exclude-from-inheritance nil))
+                      (vulpea-db--tag-settings-fingerprint)))
+        (fp-disabled (let ((org-use-tag-inheritance nil)
+                           (org-tags-exclude-from-inheritance nil))
+                       (vulpea-db--tag-settings-fingerprint)))
+        (fp-selective (let ((org-use-tag-inheritance '("foo")))
+                        (vulpea-db--tag-settings-fingerprint)))
+        (fp-excluded (let ((org-use-tag-inheritance t)
+                           (org-tags-exclude-from-inheritance '("bar")))
+                       (vulpea-db--tag-settings-fingerprint))))
+    (should-not (equal fp-default fp-disabled))
+    (should-not (equal fp-default fp-selective))
+    (should-not (equal fp-default fp-excluded))))
+
+(ert-deftest vulpea-db-tag-settings-stored-on-init ()
+  "Test that tag settings fingerprint is stored in schema-registry on init."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (let ((stored (caar (emacsql (vulpea-db)
+                                 [:select [version] :from schema-registry
+                                  :where (= name "tag-inheritance")]))))
+      (should stored)
+      (should (equal stored (vulpea-db--tag-settings-fingerprint))))))
+
+(ert-deftest vulpea-db-tag-settings-change-triggers-reindex ()
+  "Test that changing tag inheritance settings triggers re-index flag."
+  (let ((org-use-tag-inheritance t)
+        (org-tags-exclude-from-inheritance nil))
+    (vulpea-test--with-temp-db
+      ;; Initialize DB with current settings
+      (vulpea-db)
+      (vulpea-db--insert-note
+       :id "test-id"
+       :path "/tmp/test.org"
+       :level 0
+       :pos 0
+       :title "Test Note"
+       :properties nil
+       :modified-at "2025-11-16 10:00:00")
+
+      ;; Close connection
+      (vulpea-db-close)
+      (setq vulpea-db--connection nil)
+      (setq vulpea-db--settings-changed nil)
+
+      ;; Change settings and re-initialize
+      (let ((org-use-tag-inheritance nil))
+        (vulpea-db)
+
+        ;; Flag should be set
+        (should vulpea-db--settings-changed)
+
+        ;; Data should still be there (no full rebuild)
+        (should (emacsql (vulpea-db)
+                         [:select * :from notes :where (= id $s1)]
+                         "test-id"))
+
+        ;; files table should be cleared (to force re-extraction)
+        (should-not (emacsql (vulpea-db)
+                             [:select * :from files]))
+
+        ;; Stored fingerprint should be updated to new settings
+        (let ((stored (caar (emacsql (vulpea-db)
+                                     [:select [version] :from schema-registry
+                                      :where (= name "tag-inheritance")]))))
+          (should (equal stored (vulpea-db--tag-settings-fingerprint))))))))
+
+(ert-deftest vulpea-db-tag-settings-unchanged-no-reindex ()
+  "Test that same tag settings don't trigger re-index."
+  (let ((org-use-tag-inheritance t)
+        (org-tags-exclude-from-inheritance nil))
+    (vulpea-test--with-temp-db
+      ;; Initialize DB
+      (vulpea-db)
+
+      ;; Add a file record
+      (emacsql (vulpea-db)
+               [:insert :into files :values $v1]
+               (list (vector "/tmp/test.org" "abc123" "2025-01-01" 100)))
+
+      ;; Close and re-init with same settings
+      (vulpea-db-close)
+      (setq vulpea-db--connection nil)
+      (setq vulpea-db--settings-changed nil)
+
+      (vulpea-db)
+
+      ;; Flag should not be set
+      (should-not vulpea-db--settings-changed)
+
+      ;; files table should still have data
+      (should (emacsql (vulpea-db)
+                       [:select * :from files])))))
+
 (provide 'vulpea-db-test)
 ;;; vulpea-db-test.el ends here

--- a/vulpea-db-sync.el
+++ b/vulpea-db-sync.el
@@ -326,12 +326,16 @@ a subprocess.  The `blocking' mode still scans synchronously."
         (message "[vulpea-sync] cleanup-deleted-files: %.0fms"
                  (* 1000 (float-time (time-subtract (current-time) t-phase))))))
 
-    ;; If schema was rebuilt, trigger forced re-index
-    (when vulpea-db--schema-rebuilt
-      (setq vulpea-db--schema-rebuilt nil)
-      (message "Vulpea: Schema upgraded, re-indexing all files...")
-      (dolist (dir vulpea-db-sync-directories)
-        (vulpea-db-sync-update-directory dir 'force)))
+    ;; If schema was rebuilt or tag settings changed, trigger forced re-index
+    (when (or vulpea-db--schema-rebuilt vulpea-db--settings-changed)
+      (let ((reason (cond
+                     (vulpea-db--schema-rebuilt "Schema upgraded")
+                     (vulpea-db--settings-changed "Tag inheritance settings changed"))))
+        (setq vulpea-db--schema-rebuilt nil)
+        (setq vulpea-db--settings-changed nil)
+        (message "Vulpea: %s, re-indexing all files..." reason)
+        (dolist (dir vulpea-db-sync-directories)
+          (vulpea-db-sync-update-directory dir 'force))))
 
     (when vulpea-db-sync-debug
       (message "[vulpea-sync] start complete: %.0fms total (sync portion)"

--- a/vulpea-db.el
+++ b/vulpea-db.el
@@ -206,6 +206,10 @@ Uses hybrid approach:
   "Non-nil if schema was rebuilt during last init.
 Checked by `vulpea-db-sync--start' to trigger automatic re-index.")
 
+(defvar vulpea-db--settings-changed nil
+  "Non-nil if tag inheritance settings changed since last init.
+Checked by `vulpea-db-sync--start' to trigger automatic re-index.")
+
 ;;; Core API
 
 (defun vulpea-db ()
@@ -250,6 +254,25 @@ Use with caution!"
     ;; schema-registry doesn't exist → brand new DB, no rebuild needed
     (error nil)))
 
+(defun vulpea-db--tag-settings-fingerprint ()
+  "Compute a fingerprint of the current tag inheritance settings.
+
+Returns the `sxhash' of `org-use-tag-inheritance' and
+`org-tags-exclude-from-inheritance'.  Used to detect when these
+settings change between sessions so the DB can be re-indexed."
+  (sxhash (list org-use-tag-inheritance
+                org-tags-exclude-from-inheritance)))
+
+(defun vulpea-db--tag-settings-changed-p (db)
+  "Return non-nil if tag inheritance settings differ from those stored in DB."
+  (condition-case nil
+      (let ((stored (caar (emacsql db
+                                   [:select [version] :from schema-registry
+                                    :where (= name "tag-inheritance")]))))
+        (and stored
+             (not (equal stored (vulpea-db--tag-settings-fingerprint)))))
+    (error nil)))
+
 (defun vulpea-db--init ()
   "Initialize database connection and schema."
   (let ((db (emacsql-sqlite-builtin vulpea-db-location)))
@@ -271,8 +294,16 @@ Use with caution!"
     ;; Create indices
     (vulpea-db--create-indices db)
 
-    ;; Register schema version
+    ;; Check if tag inheritance settings changed
+    (when (vulpea-db--tag-settings-changed-p db)
+      (emacsql db [:delete :from files])
+      (setq vulpea-db--settings-changed t)
+      (message "Vulpea: Tag inheritance settings changed, re-index needed..."))
+
+    ;; Register schema version and tag settings fingerprint
     (vulpea-db--register-schema db 'core vulpea-db-version)
+    (vulpea-db--register-schema db 'tag-inheritance
+                                (vulpea-db--tag-settings-fingerprint))
 
     db))
 


### PR DESCRIPTION
## Summary

- Store a fingerprint (`sxhash`) of `org-use-tag-inheritance` and `org-tags-exclude-from-inheritance` in the `schema-registry` table
- On DB init, compare the stored fingerprint against current settings — on mismatch, clear the `files` table (forcing re-extraction) and set `vulpea-db--settings-changed`
- `vulpea-db-sync--start` checks the new flag alongside `vulpea-db--schema-rebuilt` and triggers a forced re-index of all directories
- Per-buffer overrides (`.dir-locals.el`) are not tracked — documented as requiring manual `vulpea-db-sync-update-directory` with force

Closes #251