### PR TITLE
fix: reset org-element cache between file parses

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -16,6 +16,7 @@
 *Fixes*
 
 - [[https://github.com/d12frosted/vulpea/pull/267][vulpea#267]] Fix =Wrong type argument: hash-table-p= error during async sync. When =org-id-update-id-locations= is running, =org-id-locations= is temporarily an alist. If a vulpea timer fires in that window, =org-id-add-location= fails. Now =org-id-locations= is defensively converted to a hash table before registering IDs.
+- Fix =org-element= parser errors (="Invalid search bound"=, =wrong-type-argument integer-or-marker-p=) when building the database from scratch. The reusable parse buffer replaces its contents with =inhibit-modification-hooks= set, leaving the =org-element= cache stale from the previous file. Now =org-element-cache-reset= is called after each buffer replacement.
 
 ** v2.2.0
 

--- a/vulpea-db-extract.el
+++ b/vulpea-db-extract.el
@@ -307,6 +307,15 @@ after loading PATH so file-local keywords and hooks are respected."
                       (inhibit-modification-hooks t))
                   (erase-buffer)
                   (insert-file-contents path)))
+
+             ;; Reset org-element cache after replacing buffer
+             ;; contents with inhibit-modification-hooks.  Without
+             ;; this, the cache retains stale positions from the
+             ;; previous file and org-element-parse-buffer hits
+             ;; "Invalid search bound" or marker errors.
+             (_ (when (fboundp 'org-element-cache-reset)
+                  (org-element-cache-reset)))
+
              (t1 (current-time))
              (_ (when rerun-org-mode
                   (let ((delay-mode-hooks nil))


### PR DESCRIPTION
## Summary

- Fix org-element parser errors ("Invalid search bound", `wrong-type-argument integer-or-marker-p nil`) that occur when building the database from scratch
- The reusable `*vulpea-parse*` buffer replaces its contents with `inhibit-modification-hooks` set to `t`, which prevents org-element's cache from being invalidated — on the next parse, stale positions from the previous file cause errors
- Call `org-element-cache-reset` after each buffer content replacement to clear the stale cache before `org-element-parse-buffer` runs