### PR TITLE
fix: create parent directory of vulpea-db-location on init

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -15,6 +15,7 @@
 
 *Fixes*
 
+- [[https://github.com/d12frosted/vulpea/issues/271][vulpea#271]] Create the parent directory of =vulpea-db-location= during database initialization if it does not exist. Previously, pointing =vulpea-db-location= at a not-yet-existing subdirectory caused emacsql to fail with an opaque =(sqlitep nil)= error.
 - [[https://github.com/d12frosted/vulpea/pull/267][vulpea#267]] Fix =Wrong type argument: hash-table-p= error during async sync. When =org-id-update-id-locations= is running, =org-id-locations= is temporarily an alist. If a vulpea timer fires in that window, =org-id-add-location= fails. Now =org-id-locations= is defensively converted to a hash table before registering IDs.
 - Fix =org-element= parser errors (="Invalid search bound"=, =wrong-type-argument integer-or-marker-p=) when building the database from scratch. The reusable parse buffer replaces its contents with =inhibit-modification-hooks= set, leaving the =org-element= cache stale from the previous file. Now =org-element-cache-reset= is called after each buffer replacement.
 

--- a/test/vulpea-db-test.el
+++ b/test/vulpea-db-test.el
@@ -34,6 +34,27 @@
       (should (equal (caar (emacsql db [:pragma foreign-keys]))
                      1)))))
 
+(ert-deftest vulpea-db-init-creates-parent-directory ()
+  "Test that initialization creates a missing parent directory.
+
+See https://github.com/d12frosted/vulpea/issues/271."
+  (let* ((temp-dir (make-temp-file "vulpea-test-" t))
+         (nested-dir (expand-file-name "nested/data" temp-dir))
+         (vulpea-db-location (expand-file-name "vulpea.db" nested-dir))
+         (vulpea-db--connection nil))
+    (unwind-protect
+        (progn
+          ;; Parent directory does not exist yet.
+          (should-not (file-exists-p nested-dir))
+          ;; Initialization should create it and succeed.
+          (let ((db (vulpea-db)))
+            (should (emacsql-live-p db))
+            (should (file-directory-p nested-dir))
+            (should (file-exists-p vulpea-db-location))))
+      (when vulpea-db--connection
+        (vulpea-db-close))
+      (delete-directory temp-dir t))))
+
 (ert-deftest vulpea-db-schema-creation ()
   "Test all tables and indices are created."
   (vulpea-test--with-temp-db

--- a/vulpea-db.el
+++ b/vulpea-db.el
@@ -275,6 +275,9 @@ settings change between sessions so the DB can be re-indexed."
 
 (defun vulpea-db--init ()
   "Initialize database connection and schema."
+  ;; Ensure the parent directory exists, otherwise emacsql fails with an
+  ;; opaque `(sqlitep nil)' error. See vulpea#271.
+  (make-directory (file-name-directory vulpea-db-location) t)
   (let ((db (emacsql-sqlite-builtin vulpea-db-location)))
     ;; Enable foreign keys
     (emacsql db [:pragma (= foreign-keys on)])


### PR DESCRIPTION
## Summary

Initializing the database fails with an opaque `(sqlitep nil)` error when `vulpea-db-location` points at a subdirectory that does not exist yet. `vulpea-db--init` passed the location straight to `emacsql-sqlite-builtin`, which cannot create missing parent directories.

This adds a `make-directory ... t` call at the start of `vulpea-db--init` so the parent directory chain is created when needed. It is a no-op when the directory already exists, so the default location is unaffected.

Closes #271.

## Changes

- `vulpea-db.el`: ensure the parent directory of `vulpea-db-location` exists before opening the connection.
- `test/vulpea-db-test.el`: add a regression test that initializes the DB at a nested, non-existent path.
- `CHANGELOG.org`: note the fix.