### PR TITLE
docs: add citar-vulpea to ecosystem section

### DIFF
--- a/README.org
+++ b/README.org
@@ -148,6 +148,7 @@ Companion packages that extend Vulpea:
 - [[https://github.com/d12frosted/vulpea-ui][vulpea-ui]] - Sidebar infrastructure and widget framework. Provides a per-frame sidebar with outline, backlinks, forward links, and stats widgets. Easy API for creating custom widgets.
 - [[https://github.com/d12frosted/vulpea-journal][vulpea-journal]] - Daily journaling with calendar integration. Creates one note per day with sidebar widgets for navigation, calendar view, and "on this day" from previous years.
 - [[https://github.com/fabcontigiani/consult-vulpea][consult-vulpea]] - Consult integration for Vulpea. Provides =consult-vulpea-find= and =consult-vulpea-insert= with live preview and consult's narrowing features.
+- [[https://github.com/fabcontigiani/citar-vulpea][citar-vulpea]] - Citar integration for Vulpea. Minor mode for managing bibliographic notes, linking citation library entries to Vulpea notes.
 
 ** Real-World Usage
 


### PR DESCRIPTION
Adds [citar-vulpea](https://github.com/fabcontigiani/citar-vulpea) to the Ecosystem section of the README. It's a minor mode integrating citar bibliography management with the Vulpea note database, letting users manage bibliographic notes linked to citation library entries.

FYI to the author, [Fabio Contigiani](https://github.com/fabcontigiani) (fabcontigiani) — who also authored consult-vulpea, already listed in the ecosystem.