### PR TITLE
feat: add vulpea-version and drawer case-insensitivity tests

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -11,6 +11,7 @@
 
 *Features*
 
+- [[https://github.com/d12frosted/vulpea/issues/277][vulpea#277]] Add =vulpea-version= - a constant with the release version and an interactive function reporting the most precise version available: =git describe= output when running from a git checkout (e.g. =v2.2.0-15-g2938416=), the installed package version including the commit for MELPA snapshot installs (e.g. =20260610.1234 (commit 2938416)=), with the constant as a fallback. Please include its output in bug reports.
 - [[https://github.com/d12frosted/vulpea/issues/270][vulpea#270]] Add =vulpea-db-sync-verbose= (default =t=) to control routine sync status reporting in the echo area. When set to =nil=, messages such as =Vulpea: Syncing N files...= and =Vulpea: Sync complete= are suppressed — useful to avoid distraction on every save when autosync is enabled. Errors and warnings are always shown; low-level timing diagnostics remain controlled by =vulpea-db-sync-debug=.
 - [[https://github.com/d12frosted/vulpea/issues/251][vulpea#251]] Automatically detect when global tag inheritance settings (=org-use-tag-inheritance=, =org-tags-exclude-from-inheritance=) change between sessions and trigger a forced re-index. A fingerprint of these settings is stored in the database; on startup, if the fingerprint differs, the file change cache is cleared so all files are re-extracted with the new settings. Per-buffer overrides (e.g. via =.dir-locals.el=) are not tracked — use =vulpea-db-sync-update-directory= with a force argument after changing those.
 

--- a/docs/api-reference.org
+++ b/docs/api-reference.org
@@ -792,6 +792,13 @@ Both functions support =:candidates-fn= to customize the source of candidates, a
 * Utility Functions
 
 #+begin_src emacs-lisp
+;; Report vulpea version (M-x vulpea-version interactively).
+;; Returns "git describe" output from a checkout, package version
+;; (with commit for MELPA snapshots) when installed, or the
+;; `vulpea-version' constant as a fallback.
+(vulpea-version)
+;; => "v2.2.0" or "v2.2.0-15-g2938416" or "20260610.1234 (commit 2938416)"
+
 ;; Convert title to URL-friendly slug
 (vulpea-title-to-slug "My Note Title")
 ;; => "my-note-title"

--- a/docs/troubleshooting.org
+++ b/docs/troubleshooting.org
@@ -315,14 +315,15 @@ If none of these solutions work:
 1. *Check existing issues:* [[https://github.com/d12frosted/vulpea/issues][GitHub Issues]]
 
 2. *Open new issue* with:
-   - Vulpea version (branch/commit)
-   - Emacs version
+   - Vulpea version (=M-x vulpea-version=)
+   - Emacs and Org versions (=M-x emacs-version=, =M-x org-version=)
    - Steps to reproduce
    - Error messages (from =*Messages*= buffer)
 
 3. *Debug info:*
 
    #+begin_src emacs-lisp
+   (message "Vulpea version: %s" (vulpea-version))
    (message "Vulpea dirs: %S" vulpea-db-sync-directories)
    (message "DB location: %s" vulpea-db-location)
    (message "Note count: %d" (vulpea-db-count-notes))

--- a/test/vulpea-db-extract-test.el
+++ b/test/vulpea-db-extract-test.el
@@ -113,6 +113,90 @@ mark regions as read-only during org-mode hooks."
       (delete-file path1)
       (delete-file path2))))
 
+;;; Drawer Case Sensitivity Tests
+;; https://github.com/d12frosted/vulpea/issues/277
+
+(ert-deftest vulpea-db-extract-file-node-lowercase-drawer ()
+  "Test file node extraction with lowercase :properties: drawer.
+Org treats drawer names case-insensitively, so vulpea must too.
+Regression test for https://github.com/d12frosted/vulpea/issues/277."
+  (let ((path (vulpea-test--create-temp-org-file
+               ":properties:\n:ID: lowercase-drawer-id\n:end:\n#+TITLE: Lowercase Drawer\n")))
+    (unwind-protect
+        (let* ((ctx (vulpea-db--parse-file path))
+               (node (vulpea-parse-ctx-file-node ctx)))
+          (should node)
+          (should (equal (plist-get node :id) "lowercase-drawer-id"))
+          (should (equal (plist-get node :title) "Lowercase Drawer")))
+      (delete-file path))))
+
+(ert-deftest vulpea-db-extract-file-node-lowercase-drawer-all-methods ()
+  "Test lowercase :properties: drawer across all parse methods.
+Regression test for https://github.com/d12frosted/vulpea/issues/277."
+  (let ((path (vulpea-test--create-temp-org-file
+               ":properties:\n:ID: lowercase-methods-id\n:end:\n#+TITLE: Lowercase Methods\n")))
+    (unwind-protect
+        (dolist (method '(single-temp-buffer temp-buffer find-file))
+          (let* ((vulpea-db-parse-method method)
+                 (ctx (vulpea-db--parse-file path))
+                 (node (vulpea-parse-ctx-file-node ctx)))
+            (should node)
+            (should (equal (plist-get node :id) "lowercase-methods-id"))))
+      (delete-file path))))
+
+(ert-deftest vulpea-db-extract-file-node-lowercase-id-key ()
+  "Test file node extraction with lowercase :id: property key.
+Org treats property names case-insensitively, so vulpea must too.
+Regression test for https://github.com/d12frosted/vulpea/issues/277."
+  (let ((path (vulpea-test--create-temp-org-file
+               ":PROPERTIES:\n:id: lowercase-key-id\n:END:\n#+TITLE: Lowercase Key\n")))
+    (unwind-protect
+        (let* ((ctx (vulpea-db--parse-file path))
+               (node (vulpea-parse-ctx-file-node ctx)))
+          (should node)
+          (should (equal (plist-get node :id) "lowercase-key-id")))
+      (delete-file path))))
+
+(ert-deftest vulpea-db-extract-file-node-mixed-case-drawer ()
+  "Test file node extraction with mixed-case :Properties: drawer.
+Regression test for https://github.com/d12frosted/vulpea/issues/277."
+  (let ((path (vulpea-test--create-temp-org-file
+               ":Properties:\n:ID: mixed-case-drawer-id\n:End:\n#+TITLE: Mixed Case Drawer\n")))
+    (unwind-protect
+        (let* ((ctx (vulpea-db--parse-file path))
+               (node (vulpea-parse-ctx-file-node ctx)))
+          (should node)
+          (should (equal (plist-get node :id) "mixed-case-drawer-id")))
+      (delete-file path))))
+
+(ert-deftest vulpea-db-extract-heading-nodes-lowercase-drawer ()
+  "Test heading node extraction with lowercase :properties: drawer.
+Regression test for https://github.com/d12frosted/vulpea/issues/277."
+  (let ((path (vulpea-test--create-temp-org-file
+               "#+TITLE: File\n\n* Heading\n:properties:\n:ID: lowercase-heading-id\n:end:\n\nBody.\n")))
+    (unwind-protect
+        (let* ((vulpea-db-index-heading-level t)
+               (ctx (vulpea-db--parse-file path))
+               (nodes (vulpea-parse-ctx-heading-nodes ctx)))
+          (should (= (length nodes) 1))
+          (should (equal (plist-get (car nodes) :id) "lowercase-heading-id")))
+      (delete-file path))))
+
+(ert-deftest vulpea-db-extract-lowercase-drawer-indexed-in-db ()
+  "Test end-to-end indexing of a file with lowercase :properties: drawer.
+Regression test for https://github.com/d12frosted/vulpea/issues/277."
+  (vulpea-test--with-temp-db
+    (let ((path (vulpea-test--create-temp-org-file
+                 ":properties:\n:ID: lowercase-db-id\n:end:\n#+TITLE: Lowercase In DB\n")))
+      (unwind-protect
+          (progn
+            (vulpea-db)
+            (vulpea-db-update-file path)
+            (let ((note (vulpea-db-get-by-id "lowercase-db-id")))
+              (should note)
+              (should (equal (vulpea-note-title note) "Lowercase In DB"))))
+        (delete-file path)))))
+
 ;;; Heading Node Tests
 
 (ert-deftest vulpea-db-extract-heading-nodes ()

--- a/test/vulpea-version-test.el
+++ b/test/vulpea-version-test.el
@@ -1,0 +1,85 @@
+;;; vulpea-version-test.el --- Tests for vulpea-version -*- lexical-binding: t; -*-
+;;
+;; Copyright (c) 2015-2026 Boris Buliga <boris@d12frosted.io>
+;;
+;; Author: Boris Buliga <boris@d12frosted.io>
+;; Maintainer: Boris Buliga <boris@d12frosted.io>
+;;
+;; Created: 10 Jun 2026
+;;
+;; URL: https://github.com/d12frosted/vulpea
+;;
+;; License: GPLv3
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; Commentary:
+;;
+;; Tests for `vulpea-version' (constant and function).
+;;
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'lisp-mnt)
+(require 'vulpea)
+
+(defun vulpea-version-test--source-file ()
+  "Return path to vulpea.el source file."
+  (concat (file-name-sans-extension (locate-library "vulpea")) ".el"))
+
+(ert-deftest vulpea-version-constant-matches-header ()
+  "The `vulpea-version' constant must match the Version header."
+  (should (equal vulpea-version
+                 (lm-version (vulpea-version-test--source-file)))))
+
+(ert-deftest vulpea-version-returns-non-empty-string ()
+  "Function `vulpea-version' returns a non-empty string."
+  (let ((version (vulpea-version)))
+    (should (stringp version))
+    (should (> (length version) 0))))
+
+(ert-deftest vulpea-version-git-describe ()
+  "From a git checkout, version comes from \"git describe\"."
+  (skip-unless (and (executable-find "git")
+                    (locate-dominating-file
+                     (vulpea-version-test--source-file) ".git")))
+  (let ((git-version (vulpea-version--git)))
+    (should (stringp git-version))
+    (should (> (length git-version) 0))
+    ;; Git information takes precedence over everything else.
+    (should (equal (vulpea-version) git-version))))
+
+(ert-deftest vulpea-version-fallback-to-constant ()
+  "Without git checkout and package install, fall back to the constant."
+  (cl-letf (((symbol-function 'vulpea-version--git) #'ignore)
+            ((symbol-function 'vulpea-version--package) #'ignore))
+    (should (equal (vulpea-version) vulpea-version))))
+
+(ert-deftest vulpea-version-package-nil-when-not-installed ()
+  "Package version resolution returns nil when vulpea is not in
+`package-alist' (e.g. running from a checkout)."
+  (let ((package-alist nil))
+    (should (null (vulpea-version--package)))))
+
+(ert-deftest vulpea-version-show-messages ()
+  "With SHOW non-nil, version is displayed in the echo area."
+  (let (captured)
+    (cl-letf (((symbol-function 'message)
+               (lambda (fmt &rest args)
+                 (setq captured (apply #'format fmt args)))))
+      (vulpea-version t))
+    (should (stringp captured))
+    (should (string-prefix-p "vulpea " captured))))
+
+(ert-deftest vulpea-version-no-message-without-show ()
+  "Without SHOW, nothing is displayed in the echo area."
+  (let (captured)
+    (cl-letf (((symbol-function 'message)
+               (lambda (fmt &rest args)
+                 (setq captured (apply #'format fmt args)))))
+      (vulpea-version))
+    (should (null captured))))
+
+(provide 'vulpea-version-test)
+;;; vulpea-version-test.el ends here

--- a/vulpea.el
+++ b/vulpea.el
@@ -57,6 +57,7 @@
 ;;
 ;;; Code:
 
+(require 'package)
 (require 'org-capture)
 (require 'org-id)
 (require 'vulpea-buffer)
@@ -69,6 +70,67 @@
 (require 'vulpea-tags)
 (require 'vulpea-utils)
 (require 's)
+
+;;; Version
+
+(defconst vulpea-version "2.2.0"
+  "Version of the vulpea package.
+
+Keep in sync with the Version header in vulpea.el; releases bump
+both. For precise version information including commits past a
+release, use the function `vulpea-version' instead.")
+
+(defun vulpea-version--git ()
+  "Return version from \"git describe\", or nil if unavailable.
+
+Works when vulpea is loaded from a git checkout and git is
+available. The result looks like \"v2.2.0\" exactly on a release
+tag, \"v2.2.0-15-g2938416\" when 15 commits past it, with a
+\"-dirty\" suffix when there are uncommitted changes."
+  (when-let* ((file (locate-library "vulpea"))
+              (dir (locate-dominating-file file ".git"))
+              ((executable-find "git")))
+    (with-temp-buffer
+      (let ((default-directory dir))
+        (when (eql 0 (ignore-errors
+                       (call-process "git" nil t nil "describe"
+                                     "--tags" "--dirty" "--always")))
+          (string-trim (buffer-string)))))))
+
+(defun vulpea-version--package ()
+  "Return version of the installed vulpea package, or nil.
+
+For MELPA snapshot installs the result looks like
+\"20260610.1234 (commit 2938416)\"."
+  (when-let* ((desc (cadr (assq 'vulpea package-alist)))
+              (version (package-version-join
+                        (package-desc-version desc))))
+    (if-let* ((commit (cdr (assq :commit (package-desc-extras desc)))))
+        (format "%s (commit %s)"
+                version (substring commit 0 (min 7 (length commit))))
+      version)))
+
+(defun vulpea-version (&optional show)
+  "Return the vulpea version with as much precision as available.
+
+The version is resolved in the following order:
+
+1. \"git describe\" output when running from a git checkout,
+   e.g. \"v2.2.0\" or \"v2.2.0-15-g2938416\".
+2. Installed package version, including the commit for MELPA
+   snapshot installs, e.g. \"20260610.1234 (commit 2938416)\".
+3. The `vulpea-version' constant as a fallback.
+
+When SHOW is non-nil (always when called interactively), also
+display the version in the echo area. Please include this
+version in bug reports."
+  (interactive (list t))
+  (let ((version (or (vulpea-version--git)
+                     (vulpea-version--package)
+                     vulpea-version)))
+    (when show
+      (message "vulpea %s" version))
+    version))
 
 ;;; Customization
 


### PR DESCRIPTION
## What

Two changes prompted by #277:

1. **Regression tests for drawer case-insensitivity.** The issue claims that notes with an uppercase `:ID:` inside a lowercase `:properties:` drawer are not indexed. This does not reproduce on master: org-element treats drawer names case-insensitively and vulpea upcases property keys before lookup. New tests pin this behavior down — lowercase and mixed-case drawers, lowercase `:id:` key, file-level and heading-level notes, all three parse methods, and end-to-end DB indexing — so it stays that way.

2. **`vulpea-version`.** Debugging #277 requires knowing exactly which vulpea the reporter runs, and there was no good way to ask for that. This adds a `vulpea-version` constant (release version, kept in sync with the `Version` header — enforced by a test) and an interactive `vulpea-version` function that reports the most precise version available, resolved in order:
   - `git describe` when running from a checkout, e.g. `v2.2.0-15-g2938416-dirty` — distinguishes an exact release from N commits past it;
   - installed package version, including the commit hash MELPA bakes into package metadata, e.g. `20260610.1234 (commit 2938416)`;
   - the constant as a fallback.

The troubleshooting guide and API reference now point bug reporters at `M-x vulpea-version`.

## Related

- #277
