### PR TITLE
docs: add Doom Emacs integration guidance

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -15,6 +15,10 @@
 - [[https://github.com/d12frosted/vulpea/issues/270][vulpea#270]] Add =vulpea-db-sync-verbose= (default =t=) to control routine sync status reporting in the echo area. When set to =nil=, messages such as =Vulpea: Syncing N files...= and =Vulpea: Sync complete= are suppressed — useful to avoid distraction on every save when autosync is enabled. Errors and warnings are always shown; low-level timing diagnostics remain controlled by =vulpea-db-sync-debug=.
 - [[https://github.com/d12frosted/vulpea/issues/251][vulpea#251]] Automatically detect when global tag inheritance settings (=org-use-tag-inheritance=, =org-tags-exclude-from-inheritance=) change between sessions and trigger a forced re-index. A fingerprint of these settings is stored in the database; on startup, if the fingerprint differs, the file change cache is cleared so all files are re-extracted with the new settings. Per-buffer overrides (e.g. via =.dir-locals.el=) are not tracked — use =vulpea-db-sync-update-directory= with a force argument after changing those.
 
+*Documentation*
+
+- Add Doom Emacs guidance: installation via =package!= with a recommended =config.el= example (getting started, README), Doom-specific pitfalls in troubleshooting (=doom env= must be re-run after installing =fswatch= / =fd=, updating requires =doom sync -u=, =org-directory= is set by Doom's org module), and a note on how to verify external tools are visible to Emacs via =executable-find=.
+
 *Fixes*
 
 - [[https://github.com/d12frosted/vulpea/issues/275][vulpea#275]] Make external file monitoring setup idempotent. =vulpea-db-sync--setup-fswatch= and =vulpea-db-sync--setup-polling= now no-op when a process or timer is already running, so repeated activation no longer spawns orphaned =fswatch= processes or leaks polling timers. Orphaned =fswatch= processes were particularly persistent because the sentinel re-launches them on exit; legitimate sentinel-driven restarts are unaffected, since the sentinel clears the process handle before restarting.

--- a/README.org
+++ b/README.org
@@ -96,7 +96,12 @@ Available on [[https://melpa.org/#/vulpea][MELPA]]:
 
 ;; Using elpaca
 (elpaca vulpea)
+
+;; Using Doom Emacs - add to packages.el, then run 'doom sync'
+(package! vulpea)
 #+end_src
+
+Doom users: see the [[file:docs/getting-started.org][Getting Started guide]] for a complete =config.el= example and a note about =doom env= (required for =fswatch= / =fd= detection).
 
 Or clone manually:
 

--- a/docs/getting-started.org
+++ b/docs/getting-started.org
@@ -5,6 +5,58 @@ This guide walks you through installing Vulpea, setting up your first database, 
 
 * Installation
 
+** From MELPA
+
+Vulpea is available on [[https://melpa.org/#/vulpea][MELPA]]:
+
+#+begin_src emacs-lisp
+;; Using package.el (after adding MELPA to package-archives)
+(package-install 'vulpea)
+
+;; Using use-package
+(use-package vulpea)
+
+;; Using straight.el
+(straight-use-package 'vulpea)
+
+;; Using elpaca
+(elpaca vulpea)
+#+end_src
+
+** Doom Emacs
+
+Add to =packages.el=:
+
+#+begin_src emacs-lisp
+(package! vulpea)
+#+end_src
+
+Configure in =config.el=:
+
+#+begin_src emacs-lisp
+(use-package! vulpea
+  ;; load on first input after startup instead of blocking startup
+  :defer t :after-call doom-first-input-hook
+  :init
+  ;; Vulpea derives its defaults from `org-directory'. Doom's :lang org
+  ;; module sets it to ~/org/ - override here if your notes live elsewhere,
+  ;; or set `vulpea-db-sync-directories' explicitly.
+  ;; (setq vulpea-db-sync-directories (list "~/notes/"))
+  :config
+  (vulpea-db-autosync-mode +1))
+#+end_src
+
+Then run =doom sync= and restart Emacs. To update Vulpea later, use =doom sync -u= (you can check what you are running with =M-x vulpea-version=).
+
+*Important:* Doom captures your shell environment (including =PATH=) into an env file. If you install =fswatch= or =fd= (see below) /after/ generating it, GUI Emacs won't see them and Vulpea silently falls back to slower methods. Re-run =doom env= and restart Emacs, then verify with:
+
+#+begin_src emacs-lisp
+(executable-find "fswatch") ; should return a path, not nil
+(executable-find "fd")
+#+end_src
+
+If you use Doom's =:lang org +roam2= module: Vulpea 2.x is fully independent of org-roam - they can run side by side, each with its own database. Vulpea reads =ROAM_ALIASES= by default, so aliases keep working (see [[file:migration.org][Migration]]).
+
 ** From Source
 
 #+begin_src bash

--- a/docs/troubleshooting.org
+++ b/docs/troubleshooting.org
@@ -185,6 +185,22 @@ apt install fswatch       # Debian/Ubuntu
 pacman -S fswatch         # Arch
 #+end_src
 
+*** Make sure Emacs can find fswatch
+
+Vulpea locates =fswatch= (and =fd=) via =executable-find=, which uses Emacs's own =PATH= - not your shell's. GUI Emacs often starts with a minimal =PATH=, so the tools may be installed yet invisible. Check:
+
+#+begin_src emacs-lisp
+(executable-find "fswatch") ; should return a path, not nil
+(executable-find "fd")
+#+end_src
+
+If either returns =nil=:
+
+- *Doom Emacs:* Doom snapshots your environment into an env file. Re-run =doom env= after installing the tools, then restart Emacs.
+- *Other setups:* use [[https://github.com/purcell/exec-path-from-shell][exec-path-from-shell]] or add the install location to =exec-path= manually.
+
+With =vulpea-db-sync-external-method= set to ='auto= (the default), a missing =fswatch= causes a /silent/ fallback to polling - the only trace is a one-line message in =*Messages*= at startup.
+
 *** Configure external detection
 
 #+begin_src emacs-lisp
@@ -295,6 +311,16 @@ Vulpea v2 is independent from org-roam. Both can coexist:
 - They maintain separate databases
 - No configuration overlap
 - Use either or both for queries
+
+** With Doom Emacs
+
+See the [[file:getting-started.org][Getting Started guide]] for the recommended =packages.el= / =config.el= setup. Common Doom-specific pitfalls:
+
+1. *=fswatch= / =fd= not detected:* Doom snapshots your shell environment into an env file, so tools installed afterwards are invisible to GUI Emacs. Re-run =doom env= and restart. See [[*Make sure Emacs can find fswatch][Make sure Emacs can find fswatch]].
+
+2. *Running an old version:* =package!= installs a MELPA snapshot that is only updated when you run =doom sync -u= - just restarting Emacs does not update packages. Check what you are actually running with =M-x vulpea-version= before reporting bugs.
+
+3. *=org-directory= mismatch:* Doom's =:lang org= module sets =org-directory= (default =~/org/=), and Vulpea derives its defaults from it at load time. If your notes live elsewhere, set =org-directory= (or =vulpea-db-sync-directories=) in =config.el= /before/ Vulpea loads.
 
 ** With Other Packages
 


### PR DESCRIPTION
Vulpea had no Doom Emacs documentation at all, even though the bug report template lists Doom as an install method and the reporter in #277 is a Doom user. This PR fills that gap; it is docs-only, no code changes.

## What changed

**README**: the installation snippet now includes Doom's `package!`, with a pointer to the full guide.

**Getting Started**: the installation section now leads with MELPA (previously it only documented installing from source) and adds a dedicated Doom Emacs section:
- `packages.el` + recommended `config.el` example using `use-package!` with `:after-call doom-first-input-hook`, so Vulpea loads right after startup without blocking it
- a note that Doom's `:lang org` module sets `org-directory` (which Vulpea derives its defaults from at load time)
- the `doom env` gotcha: tools installed after the env file is generated are invisible to GUI Emacs, so `fswatch`/`fd` silently are not picked up until `doom env` is re-run
- update flow (`doom sync -u`) and a nudge to check `M-x vulpea-version` — relevant after #278
- coexistence with `:lang org +roam2` (independent databases, `ROAM_ALIASES` read by default)

**Troubleshooting**:
- new "Make sure Emacs can find fswatch" entry under External Changes Not Detected — `executable-find` checks, `doom env` / `exec-path-from-shell` fixes, and a warning that `'auto` falls back to polling silently
- new "With Doom Emacs" subsection under Compatibility Issues covering the three Doom-specific pitfalls (PATH, stale package version, `org-directory` mismatch)

**CHANGELOG**: documentation entry under Unreleased.

## Why

The Doom failure modes are exactly the silent-missing-notes class of problem behind #277: a Doom user can have `fswatch` installed yet unused (stale `doom env`), or be running a weeks-old snapshot without realizing (`package!` never auto-updates). Both now have documented diagnosis paths.

Related: #277, #278.