### PR TITLE
feat: add Doom Emacs module

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -19,6 +19,7 @@
 
 *Documentation*
 
+- Add a ready-made Doom Emacs module in the =doom/= directory (install as =:tools vulpea= by symlinking it to =$DOOMDIR/modules/tools/vulpea=). It installs vulpea via =package!=, enables =vulpea-db-autosync-mode= on first input after startup, binds the main commands under =SPC n v=, and adds =doom doctor= checks that warn when =fswatch= / =fd= are not visible to Emacs (the stale =doom env= pitfall). See =doom/README.org=.
 - Add Doom Emacs guidance: installation via =package!= with a recommended =config.el= example (getting started, README), Doom-specific pitfalls in troubleshooting (=doom env= must be re-run after installing =fswatch= / =fd=, updating requires =doom sync -u=, =org-directory= is set by Doom's org module), and a note on how to verify external tools are visible to Emacs via =executable-find=.
 
 *Fixes*

--- a/Eldev
+++ b/Eldev
@@ -15,8 +15,9 @@
 ;; Tell checkdoc not to demand two spaces after a period.
 (setq sentence-end-double-space nil)
 
-;; Exclude bench directory from linting
-(setf eldev-standard-excludes `(:or ,eldev-standard-excludes "bench/"))
+;; Exclude bench directory from linting and the Doom module (it uses
+;; Doom-only macros and cannot be loaded outside Doom)
+(setf eldev-standard-excludes `(:or ,eldev-standard-excludes "bench/" "doom/"))
 
 ;; Teach linter how to properly indent emacsql vectors
 (eldev-add-extra-dependencies 'lint 'emacsql)

--- a/docs/getting-started.org
+++ b/docs/getting-started.org
@@ -48,6 +48,8 @@ Configure in =config.el=:
 
 Then run =doom sync= and restart Emacs. To update Vulpea later, use =doom sync -u= (you can check what you are running with =M-x vulpea-version=).
 
+*Prefer a ready-made module?* The repository ships a Doom module ([[file:../doom/README.org][doom/]]) that does all of the above and adds =SPC n v= keybindings plus =doom doctor= checks for =fswatch= / =fd=. Symlink it to =$DOOMDIR/modules/tools/vulpea= and add =:tools vulpea= to your =doom!= block - see [[file:../doom/README.org][its README]].
+
 *Important:* Doom captures your shell environment (including =PATH=) into an env file. If you install =fswatch= or =fd= (see below) /after/ generating it, GUI Emacs won't see them and Vulpea silently falls back to slower methods. Re-run =doom env= and restart Emacs, then verify with:
 
 #+begin_src emacs-lisp

--- a/doom/README.org
+++ b/doom/README.org
@@ -1,0 +1,77 @@
+#+title:    :tools vulpea
+#+subtitle: Note management on top of org-mode
+
+* Description
+This module integrates [[https://github.com/d12frosted/vulpea][Vulpea]] into Doom Emacs:
+
+- Installs Vulpea and enables =vulpea-db-autosync-mode= shortly after startup
+  (on first input, so it never blocks startup). With the default
+  =vulpea-db-sync-scan-on-enable=, the first activation also builds the
+  database in the background - no manual scan needed.
+- Binds the main commands under =SPC n v= (next to org-roam's =SPC n r=).
+- Hooks into =doom doctor= to warn when =fswatch= or =fd= are not visible to
+  Emacs - the most common Doom-specific pitfall (a stale =doom env= file).
+
+** Module flags
+/This module has no flags./
+
+** Packages
+- [[https://github.com/d12frosted/vulpea][vulpea]]
+
+* Installation
+This is a third-party module living in the Vulpea repository. Place it in your
+=$DOOMDIR/modules= tree under =tools/vulpea=, either by symlinking a clone:
+
+#+begin_src sh
+git clone https://github.com/d12frosted/vulpea ~/path/to/vulpea
+mkdir -p ~/.config/doom/modules/tools
+ln -s ~/path/to/vulpea/doom ~/.config/doom/modules/tools/vulpea
+#+end_src
+
+or by copying the =doom/= directory there. Then enable it in your =doom!=
+block in =init.el=:
+
+#+begin_src emacs-lisp
+:tools
+vulpea
+#+end_src
+
+and run =doom sync=.
+
+Note: the module installs the =vulpea= package from MELPA via =package!=; the
+clone above is only the module definition, not the package itself.
+
+For best performance also install [[https://github.com/emcrisostomo/fswatch][fswatch]] and [[https://github.com/sharkdp/fd][fd]], then run =doom env= so
+Emacs sees them (=doom doctor= will remind you if they are missing).
+
+* Usage
+| Binding     | Description                                            |
+|-------------+--------------------------------------------------------|
+| =SPC n v f= | Find note (=vulpea-find=)                              |
+| =SPC n v b= | Find backlink (=vulpea-find-backlink=)                 |
+| =SPC n v i= | Insert link (=vulpea-insert=)                          |
+| =SPC n v p= | Propagate title change (=vulpea-propagate-title-change=) |
+| =SPC n v r= | Rename tag everywhere (=vulpea-tags-batch-rename=)     |
+| =SPC n v s= | Full scan (=vulpea-db-sync-full-scan=)                 |
+| =SPC n v d= | Diagnostics (=vulpea-doctor=)                          |
+
+* Configuration
+Vulpea derives its defaults from =org-directory= at load time. Doom's
+=:lang org= module sets it to =~/org/= - if your notes live elsewhere, set it
+(or =vulpea-db-sync-directories=) in your =config.el=:
+
+#+begin_src emacs-lisp
+(setq org-directory "~/notes/")
+;; or, independently of org-directory:
+;; (setq vulpea-db-sync-directories (list "~/notes/"))
+#+end_src
+
+All other options are documented in the [[https://github.com/d12frosted/vulpea/blob/master/docs/configuration.org][configuration guide]].
+
+This module coexists with =:lang org +roam= - Vulpea and org-roam maintain
+separate databases and do not conflict.
+
+* Troubleshooting
+Run =M-x vulpea-doctor= (or =SPC n v d=) - it reports versions, configuration,
+database and sync state, and flags common problems. See also the
+[[https://github.com/d12frosted/vulpea/blob/master/docs/troubleshooting.org][troubleshooting guide]], which has a section on Doom-specific pitfalls.

--- a/doom/config.el
+++ b/doom/config.el
@@ -1,0 +1,22 @@
+;;; tools/vulpea/config.el -*- lexical-binding: t; -*-
+
+(use-package! vulpea
+  ;; Load on first input after startup instead of blocking startup.
+  ;; Vulpea derives its defaults from `org-directory' at load time, so
+  ;; set `org-directory' (or `vulpea-db-sync-directories') in your
+  ;; config.el if your notes live somewhere else.
+  :defer t
+  :after-call doom-first-input-hook
+  :config
+  (vulpea-db-autosync-mode +1))
+
+(map! :leader
+      (:prefix ("n" . "notes")
+       (:prefix ("v" . "vulpea")
+        :desc "Find note"              "f" #'vulpea-find
+        :desc "Find backlink"          "b" #'vulpea-find-backlink
+        :desc "Insert link"            "i" #'vulpea-insert
+        :desc "Propagate title change" "p" #'vulpea-propagate-title-change
+        :desc "Rename tag everywhere"  "r" #'vulpea-tags-batch-rename
+        :desc "Full scan"              "s" #'vulpea-db-sync-full-scan
+        :desc "Doctor"                 "d" #'vulpea-doctor)))

--- a/doom/doctor.el
+++ b/doom/doctor.el
@@ -1,0 +1,8 @@
+;; -*- lexical-binding: t; no-byte-compile: t; -*-
+;;; tools/vulpea/doctor.el
+
+(unless (executable-find "fswatch")
+  (warn! "Couldn't find fswatch. Vulpea will detect external file changes (git, cloud sync) via polling, which is slower. If fswatch is installed, run 'doom env' to refresh Emacs's PATH."))
+
+(unless (executable-find "fd")
+  (warn! "Couldn't find fd. Vulpea's directory scans will fall back to find, which is much slower on large note collections. If fd is installed, run 'doom env' to refresh Emacs's PATH."))

--- a/doom/packages.el
+++ b/doom/packages.el
@@ -1,0 +1,4 @@
+;; -*- no-byte-compile: t; -*-
+;;; tools/vulpea/packages.el
+
+(package! vulpea)


### PR DESCRIPTION
Adds a ready-made Doom Emacs module in `doom/`, installable as `:tools vulpea` by symlinking the directory to `$DOOMDIR/modules/tools/vulpea`. This is the self-hosted path discussed for Doom integration: ship the module from vulpea's own repo now, and propose it upstream to `doomemacs/modules` later if demand shows (their module library is curated and mid-v3 restructure, so a cold PR there would likely stall - and Doom v3's module-sources mechanism makes third-party modules first-class anyway).

## What the module does

- **`packages.el`** - installs `vulpea` from MELPA via `package!`
- **`config.el`** - loads vulpea on first input after startup (`:after-call doom-first-input-hook`, so startup is never blocked) and enables `vulpea-db-autosync-mode`; with the new `scan-on-enable` default the first activation also builds the database automatically. Binds the main commands under `SPC n v` (find, backlink, insert, propagate-title, tag-rename, full scan, doctor) - deliberately next to org-roam's `SPC n r`, with which it coexists.
- **`doctor.el`** - hooks into `doom doctor`: warns when `fswatch` or `fd` are not visible to Emacs, including the 'run `doom env`' hint. This surfaces the stale-env pitfall in the tool Doom users already run when something is off.
- **`README.org`** - Doom-module-style docs: description, installation (symlink + `doom!` block), keybinding table, configuration notes (`org-directory` interaction), troubleshooting pointers.

The file layout and idioms follow the official `doomemacs/modules` conventions (studied `lang/org` contrib/roam, doctor.el, and the default `SPC n` bindings).

## Repo integration

- `Eldev` excludes `doom/` from linting/compilation - the files use Doom-only macros (`use-package!`, `map!`, `warn!`) and cannot load outside Doom. They are syntax-validated (parens/read) instead; full suite still 594/595 (same pre-existing skip), `eldev lint` clean.
- getting-started's Doom section now points to the module as the batteries-included alternative to the manual `config.el` snippet.
- CHANGELOG entry under Unreleased.

Related: #281, #282.