### PR TITLE
docs: list third-party packages and notable configurations in README

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -21,6 +21,7 @@
 
 - Add a ready-made Doom Emacs module in the =doom/= directory (install as =:tools vulpea= by symlinking it to =$DOOMDIR/modules/tools/vulpea=). It installs vulpea via =package!=, enables =vulpea-db-autosync-mode= on first input after startup, binds the main commands under =SPC n v=, and adds =doom doctor= checks that warn when =fswatch= / =fd= are not visible to Emacs (the stale =doom env= pitfall). See =doom/README.org=.
 - Add Doom Emacs guidance: installation via =package!= with a recommended =config.el= example (getting started, README), Doom-specific pitfalls in troubleshooting (=doom env= must be re-run after installing =fswatch= / =fd=, updating requires =doom sync -u=, =org-directory= is set by Doom's org module), and a note on how to verify external tools are visible to Emacs via =executable-find=.
+- Expand the README ecosystem section with third-party packages (=embark-vulpea=, =vulpea-field=, =publicatorg=) and grow the real-world usage section with applications built on Vulpea (=claude-orgmode=, =emacs-org-serve=) and notable user configurations.
 
 *Fixes*
 

--- a/README.org
+++ b/README.org
@@ -154,11 +154,25 @@ Companion packages that extend Vulpea:
 - [[https://github.com/d12frosted/vulpea-journal][vulpea-journal]] - Daily journaling with calendar integration. Creates one note per day with sidebar widgets for navigation, calendar view, and "on this day" from previous years.
 - [[https://github.com/fabcontigiani/consult-vulpea][consult-vulpea]] - Consult integration for Vulpea. Provides =consult-vulpea-find= and =consult-vulpea-insert= with live preview and consult's narrowing features.
 - [[https://github.com/fabcontigiani/citar-vulpea][citar-vulpea]] - Citar integration for Vulpea. Minor mode for managing bibliographic notes, linking citation library entries to Vulpea notes.
+- [[https://github.com/fabcontigiani/embark-vulpea][embark-vulpea]] - Embark actions and export for Vulpea notes.
+- [[https://github.com/jwiegley/vulpea-field][vulpea-field]] - Extension for easily adding new database fields.
+- [[https://github.com/d12frosted/publicatorg][publicatorg]] - Make your Vulpea notes public.
 
 ** Real-World Usage
 
+Applications built on Vulpea:
+
 - [[https://github.com/d12frosted/vino][vino]] - Wine cellar management with rich metadata
-- [[https://github.com/d12frosted/environment][d12frosted/environment]] - Personal configuration (13k+ notes)
+- [[https://github.com/majorgreys/claude-orgmode][claude-orgmode]] - Connects Claude with org-mode notes
+- [[https://github.com/smclaren727/emacs-org-serve][emacs-org-serve]] - Go service that reads the Vulpea database directly and serves an Org vault as JSON + PWA to mobile devices
+
+Notable user configurations:
+
+- [[https://github.com/d12frosted/environment][d12frosted/environment]] - Personal configuration (13k+ notes), including the task management setup from the [[https://www.d12frosted.io/posts/2020-06-23-task-management-with-roam-vol1][Task Management]] blog series
+- [[https://github.com/jwiegley/dot-emacs][jwiegley/dot-emacs]]
+- [[https://github.com/chrisbarrett/emacs-d][chrisbarrett/emacs-d]]
+- [[https://github.com/d4ncer/.emacs.d][d4ncer/.emacs.d]]
+- [[https://github.com/benthamite/dotfiles][benthamite/dotfiles]]
 
 ** What's New in v2
 


### PR DESCRIPTION
## What

Expands the README **Ecosystem** section with third-party packages built on Vulpea:

- [embark-vulpea](https://github.com/fabcontigiani/embark-vulpea) — Embark actions and export for Vulpea notes
- [vulpea-field](https://github.com/jwiegley/vulpea-field) — extension for adding new database fields
- [publicatorg](https://github.com/d12frosted/publicatorg) — publishing Vulpea notes

Restructures **Real-World Usage** into two groups:

- Applications built on Vulpea: vino, [claude-orgmode](https://github.com/majorgreys/claude-orgmode), and [emacs-org-serve](https://github.com/smclaren727/emacs-org-serve) (a Go service consuming the Vulpea database from outside Emacs)
- Notable user configurations: d12frosted/environment, jwiegley/dot-emacs, chrisbarrett/emacs-d, d4ncer/.emacs.d, benthamite/dotfiles

## Why

Showcases that Vulpea works as a foundation for third-party tooling — including consumers of the SQLite database outside Emacs — which supports the v2 positioning as a database layer rather than an application.