### PR TITLE
fix: insert backslash-containing text literally with replace-match

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -25,6 +25,7 @@
 
 *Fixes*
 
+- Insert titles and property values containing backslashes verbatim. =vulpea-buffer-prop-set= (and thus =vulpea-buffer-title-set=) and the link-description update used by =vulpea-propagate-title-change= called =replace-match= without the LITERAL flag, so a value containing =\1=, =\&= or =\\= was interpreted as a regexp backreference and corrupted the result. They now replace literally.
 - Stop =vulpea-note-meta-get= / =vulpea-note-meta-get-list= with type =note= from raising =wrong-type-argument= when a metadata id-link points to a note that no longer exists. A dangling link now yields a nil entry instead of crashing, matching the behavior of the buffer-level meta API.
 - Restore compatibility with Emacs 27-28 for batch operations. =vulpea-utils-process-notes= (used by =vulpea-tags-batch-*= and =vulpea-meta-batch-*=) called =kill-matching-buffers-no-ask=, which only exists since Emacs 29.1, so every batch command failed with a void-function error on the supported Emacs 27.2-28. It now uses that function when available and falls back to an internal no-prompt buffer sweep on older Emacsen.
 - Build the internal =sqlite_master= existence checks (=vulpea-db--table-exists-p=, =vulpea-db--index-exists-p=) with emacsql parameters instead of string interpolation, so an object name can never break out of the query. These are only called with internal identifiers today, so this is hardening rather than a user-facing fix.

--- a/test/vulpea-buffer-test.el
+++ b/test/vulpea-buffer-test.el
@@ -599,6 +599,17 @@ Creates a temp file with ID and CONTENT, adds it to temp DB, then executes BODY.
                        (vulpea-buffer-prop-get "title"))
                      "Title 2")))))
 
+(ert-deftest vulpea-buffer-prop-set-preserves-backslashes ()
+  "A property value with backslashes must be stored verbatim.
+Without a literal replacement, a sequence like \\1 in the value is
+interpreted by `replace-match' as a match-group backreference and
+corrupts the stored value."
+  (with-temp-buffer
+    (org-mode)
+    (insert "#+title: old value\n")
+    (vulpea-buffer-prop-set "title" "a\\1b")
+    (should (equal (vulpea-buffer-prop-get "title") "a\\1b"))))
+
 (ert-deftest vulpea-buffer-prop-remove ()
   "Test removing existing property."
   (let ((id "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7"))

--- a/test/vulpea-test.el
+++ b/test/vulpea-test.el
@@ -1503,6 +1503,60 @@ Guards against arbitrary code execution from untrusted note titles."
       (when (file-exists-p linking-path)
         (delete-file linking-path)))))
 
+(ert-deftest vulpea-update-link-description-preserves-backslashes ()
+  "Updating a description with backslashes must insert it verbatim.
+Without a literal replacement, \\1 is treated by `replace-match' as a
+match-group backreference and corrupts the link."
+  (let* ((target-id "target-note-id")
+         (new-desc "a\\1b")
+         (linking-content
+          (format ":PROPERTIES:\n:ID: linking-id\n:END:\n#+TITLE: Linking Note\n\nSee [[id:%s][Old Description]]." target-id))
+         (linking-path (vulpea-test--create-temp-org-file linking-content)))
+    (unwind-protect
+        (progn
+          (with-current-buffer (find-file-noselect linking-path)
+            (goto-char (point-min))
+            (re-search-forward "\\[\\[id:")
+            (let ((link-pos (match-beginning 0)))
+              (vulpea--update-link-description linking-path link-pos new-desc)
+              (save-buffer)))
+          (with-temp-buffer
+            (insert-file-contents linking-path)
+            (should (string-match-p
+                     (regexp-quote (format "[[id:%s][%s]]" target-id new-desc))
+                     (buffer-string)))))
+      (when (get-file-buffer linking-path)
+        (kill-buffer (get-file-buffer linking-path)))
+      (when (file-exists-p linking-path)
+        (delete-file linking-path)))))
+
+(ert-deftest vulpea-update-link-description-bare-preserves-backslashes ()
+  "Adding a backslash description to a bare link must insert it verbatim.
+Covers the bare-link branch, where \\& would otherwise be expanded to
+the whole match."
+  (let* ((target-id "target-note-id")
+         (new-desc "x\\&y")
+         (linking-content
+          (format ":PROPERTIES:\n:ID: linking-id\n:END:\n#+TITLE: Linking Note\n\nSee [[id:%s]]." target-id))
+         (linking-path (vulpea-test--create-temp-org-file linking-content)))
+    (unwind-protect
+        (progn
+          (with-current-buffer (find-file-noselect linking-path)
+            (goto-char (point-min))
+            (re-search-forward "\\[\\[id:")
+            (let ((link-pos (match-beginning 0)))
+              (vulpea--update-link-description linking-path link-pos new-desc)
+              (save-buffer)))
+          (with-temp-buffer
+            (insert-file-contents linking-path)
+            (should (string-match-p
+                     (regexp-quote (format "[[id:%s][%s]]" target-id new-desc))
+                     (buffer-string)))))
+      (when (get-file-buffer linking-path)
+        (kill-buffer (get-file-buffer linking-path)))
+      (when (file-exists-p linking-path)
+        (delete-file linking-path)))))
+
 ;;;; Integration Tests for Incoming Links
 
 (ert-deftest vulpea-get-incoming-links-with-descriptions ()

--- a/vulpea-buffer.el
+++ b/vulpea-buffer.el
@@ -243,7 +243,9 @@ If the property is already set, replace its value."
     (let ((case-fold-search t))
       (if (re-search-forward (concat "^#\\+" name ":\\(.*\\)")
                              (point-max) t)
-          (replace-match (concat "#+" name ": " value) 'fixedcase)
+          ;; LITERAL (3rd arg) so backslashes in VALUE are inserted
+          ;; verbatim rather than interpreted as backreferences.
+          (replace-match (concat "#+" name ": " value) 'fixedcase t)
         (while (and (not (eobp))
                     (looking-at "^[#:]"))
           (if (save-excursion (end-of-line) (eobp))

--- a/vulpea.el
+++ b/vulpea.el
@@ -492,11 +492,13 @@ descriptions [[id:xxx][old]]."
        ;; Link with existing description: [[id:xxx][old]]
        ((looking-at "\\(\\[\\[id:[^]]+\\]\\)\\[\\([^]]*\\)\\]\\]")
         (let ((link-part (match-string 1)))
-          (replace-match (concat link-part "[" new-description "]]"))))
+          ;; LITERAL (3rd arg) so backslashes in NEW-DESCRIPTION are not
+          ;; interpreted as match-group backreferences.
+          (replace-match (concat link-part "[" new-description "]]") t t)))
        ;; Bare link without description: [[id:xxx]]
        ((looking-at "\\(\\[\\[id:[^]]+\\)\\]\\]")
         (let ((link-part (match-string 1)))
-          (replace-match (concat link-part "][" new-description "]]"))))))))
+          (replace-match (concat link-part "][" new-description "]]") t t)))))))
 
 (defun vulpea--default-directory ()
   "Return the default directory for creating new notes.


### PR DESCRIPTION
## What

`vulpea-buffer-prop-set` (used by `vulpea-buffer-title-set`) and `vulpea--update-link-description` (used by `vulpea-propagate-title-change`) now pass the LITERAL flag to `replace-match`.

## Why

Without LITERAL, `replace-match` interprets backslash sequences in the replacement text — `\1` becomes a captured group, `\&` the whole match, `\\` a single backslash. So a title, property value, or link description containing a backslash (a Windows path, a regexp snippet, etc.) was silently corrupted. All three call sites now replace literally; a fixed-case flag is kept so the inserted text is not case-folded.

Regression tests cover the property setter and both link-description branches (existing description and bare link).