### PR TITLE
fix: ignore duplicate inputs in *-every queries

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -25,6 +25,7 @@
 
 *Fixes*
 
+- Make =vulpea-db-query-by-tags-every= and =vulpea-db-query-by-links-every= ignore duplicate entries in their input. Because they match on =COUNT(DISTINCT ...)= equal to the number of requested items, a repeated tag or id previously inflated the target count and made the query return nothing; the input is now de-duplicated first.
 - Insert titles and property values containing backslashes verbatim. =vulpea-buffer-prop-set= (and thus =vulpea-buffer-title-set=) and the link-description update used by =vulpea-propagate-title-change= called =replace-match= without the LITERAL flag, so a value containing =\1=, =\&= or =\\= was interpreted as a regexp backreference and corrupted the result. They now replace literally.
 - Stop =vulpea-note-meta-get= / =vulpea-note-meta-get-list= with type =note= from raising =wrong-type-argument= when a metadata id-link points to a note that no longer exists. A dangling link now yields a nil entry instead of crashing, matching the behavior of the buffer-level meta API.
 - Restore compatibility with Emacs 27-28 for batch operations. =vulpea-utils-process-notes= (used by =vulpea-tags-batch-*= and =vulpea-meta-batch-*=) called =kill-matching-buffers-no-ask=, which only exists since Emacs 29.1, so every batch command failed with a void-function error on the supported Emacs 27.2-28. It now uses that function when available and falls back to an internal no-prompt buffer sweep on older Emacsen.

--- a/test/vulpea-db-query-test.el
+++ b/test/vulpea-db-query-test.el
@@ -154,6 +154,20 @@
     (let ((notes (vulpea-db-query-by-tags-every nil)))
       (should (= (length notes) 2)))))
 
+(ert-deftest vulpea-db-query-by-tags-every-duplicate-input ()
+  "Duplicate tags in the input must not suppress results.
+A repeated tag previously inflated the required match count past the
+number of distinct tags any note could have, returning nothing."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--insert-test-note "note1" "Note 1" :tags '("wine" "red"))
+    (vulpea-test--insert-test-note "note2" "Note 2" :tags '("wine"))
+
+    (let ((notes (vulpea-db-query-by-tags-every '("wine" "wine"))))
+      (should (= (length notes) 2))
+      (should (member "note1" (mapcar #'vulpea-note-id notes)))
+      (should (member "note2" (mapcar #'vulpea-note-id notes))))))
+
 (ert-deftest vulpea-db-query-by-tags-none-single ()
   "Test querying by single excluded tag."
   (vulpea-test--with-temp-db
@@ -306,6 +320,19 @@ from being inserted into the normalized tags table."
                                    :links '((:dest "target1" :type "id" :pos 100)))
 
     (let ((notes (vulpea-db-query-by-links-every '("target1" "target2"))))
+      (should (= (length notes) 1))
+      (should (equal (vulpea-note-id (car notes)) "note1")))))
+
+(ert-deftest vulpea-db-query-by-links-every-duplicate-input ()
+  "Duplicate destination ids in the input must not suppress results."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--insert-test-note "note1" "Note 1"
+                                   :links '((:dest "target1" :type "id" :pos 100)))
+    (vulpea-test--insert-test-note "note2" "Note 2"
+                                   :links '((:dest "target2" :type "id" :pos 100)))
+
+    (let ((notes (vulpea-db-query-by-links-every '("target1" "target1"))))
       (should (= (length notes) 1))
       (should (equal (vulpea-note-id (car notes)) "note1")))))
 

--- a/vulpea-db-query.el
+++ b/vulpea-db-query.el
@@ -205,7 +205,11 @@ TAGS is a list of tag strings.
 Returns list of `vulpea-note' structs."
   (if (null tags)
       (vulpea-db-query nil)  ; Return all notes
-    (let* ((tag-count (length tags))
+    ;; De-duplicate: the HAVING clause compares COUNT(DISTINCT tag)
+    ;; against the requested count, so a repeated tag would inflate the
+    ;; target past what any note can match and return nothing.
+    (let* ((tags (seq-uniq tags))
+           (tag-count (length tags))
            (rows (emacsql (vulpea-db)
                           [:select * :from notes
                            :where (in id [:select [note-id]
@@ -288,7 +292,11 @@ LINK-TYPE is optional link type filter.
 Returns list of `vulpea-note' structs."
   (if (null dest-ids)
       (vulpea-db-query nil)
-    (let* ((id-count (length dest-ids))
+    ;; De-duplicate: the HAVING clause compares COUNT(DISTINCT dest)
+    ;; against the requested count, so a repeated id would inflate the
+    ;; target past what any note can match and return nothing.
+    (let* ((dest-ids (seq-uniq dest-ids))
+           (id-count (length dest-ids))
            (rows (if link-type
                      (emacsql (vulpea-db)
                               [:select * :from notes


### PR DESCRIPTION
## What

`vulpea-db-query-by-tags-every` and `vulpea-db-query-by-links-every` now de-duplicate their input before counting.

## Why

Both match notes where `COUNT(DISTINCT ...)` equals the number of requested items. A duplicate in the input (e.g. `("wine" "wine")`) inflated that target above the number of distinct tags/links any note can have, so the query silently returned no results. De-duplicating with `seq-uniq` fixes it.

A regression test for each query confirms duplicates no longer suppress matches.