### PR TITLE
fix: match directory paths literally in vulpea-db-query-by-directory

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -25,6 +25,7 @@
 
 *Fixes*
 
+- Match directory paths literally in =vulpea-db-query-by-directory=. It built a SQL =LIKE= pattern from the directory name without escaping, so =%= or =_= in a path (e.g. =my_notes=) acted as wildcards and pulled in sibling directories. It now uses =GLOB= with the directory escaped for GLOB's special characters, sharing the escape helper with the sync layer (=vulpea-db--escape-glob-pattern=). Note that matching is now case-sensitive, consistent with file-path semantics.
 - Make =vulpea-db-query-by-tags-every= and =vulpea-db-query-by-links-every= ignore duplicate entries in their input. Because they match on =COUNT(DISTINCT ...)= equal to the number of requested items, a repeated tag or id previously inflated the target count and made the query return nothing; the input is now de-duplicated first.
 - Insert titles and property values containing backslashes verbatim. =vulpea-buffer-prop-set= (and thus =vulpea-buffer-title-set=) and the link-description update used by =vulpea-propagate-title-change= called =replace-match= without the LITERAL flag, so a value containing =\1=, =\&= or =\\= was interpreted as a regexp backreference and corrupted the result. They now replace literally.
 - Stop =vulpea-note-meta-get= / =vulpea-note-meta-get-list= with type =note= from raising =wrong-type-argument= when a metadata id-link points to a note that no longer exists. A dangling link now yields a nil entry instead of crashing, matching the behavior of the buffer-level meta API.

--- a/test/vulpea-db-query-test.el
+++ b/test/vulpea-db-query-test.el
@@ -782,6 +782,30 @@ from being inserted into the normalized tags table."
 
     (should-not (vulpea-db-query-by-directory "/tmp/other"))))
 
+(ert-deftest vulpea-db-query-by-directory-literal-underscore ()
+  "An underscore in the directory must match literally, not as a wildcard.
+With LIKE, the directory name was used as a pattern, so `_' matched any
+single character and pulled in sibling directories."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--insert-test-note "note1" "Note 1" :path "/tmp/my_notes/file1.org")
+    (vulpea-test--insert-test-note "note2" "Note 2" :path "/tmp/myXnotes/file2.org")
+
+    (let ((notes (vulpea-db-query-by-directory "/tmp/my_notes")))
+      (should (= (length notes) 1))
+      (should (equal (vulpea-note-id (car notes)) "note1")))))
+
+(ert-deftest vulpea-db-query-by-directory-glob-special-chars ()
+  "GLOB special characters in the directory are matched literally."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--insert-test-note "note1" "Note 1" :path "/tmp/a[b]/file1.org")
+    (vulpea-test--insert-test-note "note2" "Note 2" :path "/tmp/ab/file2.org")
+
+    (let ((notes (vulpea-db-query-by-directory "/tmp/a[b]")))
+      (should (= (length notes) 1))
+      (should (equal (vulpea-note-id (car notes)) "note1")))))
+
 ;;; Property-Based Query Tests
 
 (ert-deftest vulpea-db-query-by-property-basic ()

--- a/vulpea-db-query.el
+++ b/vulpea-db-query.el
@@ -409,19 +409,24 @@ LEVEL is optional filter: 0 for file-level, 1+ for headings.
 When LEVEL is nil, returns all notes from the directory.
 
 Uses prefix matching on file paths, so includes all subdirectories.
+Matching is case-sensitive.
 
 Returns list of `vulpea-note' structs."
+  ;; Use GLOB rather than LIKE: LIKE would treat % and _ in the
+  ;; directory path as wildcards, pulling in sibling directories.  The
+  ;; directory is escaped for GLOB's own specials (*, ?, [) so it
+  ;; matches literally; the trailing * is the prefix wildcard.
   (let* ((dir (file-name-as-directory directory))
-         (pattern (concat dir "%"))
+         (pattern (concat (vulpea-db--escape-glob-pattern dir) "*"))
          (rows (if level
                    (emacsql (vulpea-db)
                             [:select * :from notes
-                             :where (and (like path $s1)
+                             :where (and (glob path $s1)
                                          (= level $s2))]
                             pattern level)
                  (emacsql (vulpea-db)
                           [:select * :from notes
-                           :where (like path $s1)]
+                           :where (glob path $s1)]
                           pattern))))
     (mapcar #'vulpea-db--row-to-note rows)))
 

--- a/vulpea-db-sync.el
+++ b/vulpea-db-sync.el
@@ -243,15 +243,6 @@ warnings that should always be shown."
   (when vulpea-db-sync-verbose
     (apply #'message format-string args)))
 
-(defun vulpea-db-sync--escape-glob-pattern (str)
-  "Escape special SQLite GLOB characters in STR.
-Escapes *, ?, and [ so they match literally when used with GLOB.
-These are escaped by wrapping in brackets: * -> [*], ? -> [?], [ -> [[]]."
-  (replace-regexp-in-string
-   "[][*?]"
-   (lambda (m) (format "[%s]" m))
-   str))
-
 ;;; Core Functions
 
 (defun vulpea-db-sync--effective-scan-mode ()
@@ -558,7 +549,7 @@ all files under that directory are removed."
                              path
                            (concat path "/")))
              ;; Escape GLOB special characters: *, ?, [
-             (escaped-prefix (vulpea-db-sync--escape-glob-pattern dir-prefix))
+             (escaped-prefix (vulpea-db--escape-glob-pattern dir-prefix))
              (glob-pattern (concat escaped-prefix "*")))
         (dolist (file-path (mapcar #'car
                                    (emacsql db [:select path :from files

--- a/vulpea-db.el
+++ b/vulpea-db.el
@@ -362,6 +362,15 @@ settings change between sessions so the DB can be re-indexed."
   "Return all tracked file extensions (`.org' + extras)."
   (cons ".org" vulpea-db-extra-extensions))
 
+(defun vulpea-db--escape-glob-pattern (str)
+  "Escape special SQLite GLOB characters in STR.
+Escapes *, ?, and [ so they match literally when used with GLOB.
+These are escaped by wrapping in brackets: * -> [*], ? -> [?], [ -> [[]]."
+  (replace-regexp-in-string
+   "[][*?]"
+   (lambda (m) (format "[%s]" m))
+   str))
+
 ;;; CRUD Operations
 
 (defun vulpea-db--plist-to-alist (plist)


### PR DESCRIPTION
## What

`vulpea-db-query-by-directory` now matches the directory prefix with `GLOB` and an escaped pattern instead of an unescaped `LIKE` pattern.

## Why

The query built `<dir>%` and passed it to `LIKE` without escaping, so `%` or `_` in the directory path (e.g. a directory named `my_notes`) acted as SQL wildcards and matched sibling directories like `myXnotes`. Switching to `GLOB` — already used for path matching in the sync layer — and escaping GLOB's specials (`*`, `?`, `[`) makes the directory match literally.

The GLOB-escaping helper is moved to `vulpea-db.el` as `vulpea-db--escape-glob-pattern` and shared with the sync layer, which previously carried an identical private copy.

## Note

Matching is now case-sensitive (GLOB), which is consistent with file-path semantics; the previous `LIKE` was case-insensitive for ASCII.

Tests cover a literal underscore and GLOB special characters in the directory name.