### PR TITLE
fix: make vulpea-buffer-prop-get case-fold and quote the name

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -25,6 +25,7 @@
 
 *Fixes*
 
+- Make =vulpea-buffer-prop-get= bind =case-fold-search= (like its sibling readers) so a property is found regardless of the caller's setting, and quote the property name so a regexp-special character in it is matched literally rather than as part of the search pattern.
 - Match directory paths literally in =vulpea-db-query-by-directory=. It built a SQL =LIKE= pattern from the directory name without escaping, so =%= or =_= in a path (e.g. =my_notes=) acted as wildcards and pulled in sibling directories. It now uses =GLOB= with the directory escaped for GLOB's special characters, sharing the escape helper with the sync layer (=vulpea-db--escape-glob-pattern=). Note that matching is now case-sensitive, consistent with file-path semantics.
 - Make =vulpea-db-query-by-tags-every= and =vulpea-db-query-by-links-every= ignore duplicate entries in their input. Because they match on =COUNT(DISTINCT ...)= equal to the number of requested items, a repeated tag or id previously inflated the target count and made the query return nothing; the input is now de-duplicated first.
 - Insert titles and property values containing backslashes verbatim. =vulpea-buffer-prop-set= (and thus =vulpea-buffer-title-set=) and the link-description update used by =vulpea-propagate-title-change= called =replace-match= without the LITERAL flag, so a value containing =\1=, =\&= or =\\= was interpreted as a regexp backreference and corrupted the result. They now replace literally.

--- a/test/vulpea-buffer-test.el
+++ b/test/vulpea-buffer-test.el
@@ -610,6 +610,23 @@ corrupts the stored value."
     (vulpea-buffer-prop-set "title" "a\\1b")
     (should (equal (vulpea-buffer-prop-get "title") "a\\1b"))))
 
+(ert-deftest vulpea-buffer-prop-get-case-insensitive-when-fold-disabled ()
+  "prop-get must find a property regardless of ambient `case-fold-search'.
+Its sibling readers bind `case-fold-search' to t; prop-get must too."
+  (with-temp-buffer
+    (org-mode)
+    (insert "#+TITLE: Hello\n")
+    (let ((case-fold-search nil))
+      (should (equal (vulpea-buffer-prop-get "title") "Hello")))))
+
+(ert-deftest vulpea-buffer-prop-get-quotes-regexp-special-name ()
+  "A property NAME with regexp specials must be matched literally.
+An unquoted name would let \".\" match a different property line."
+  (with-temp-buffer
+    (org-mode)
+    (insert "#+myXprop: wrong\n#+my.prop: value-a\n")
+    (should (equal (vulpea-buffer-prop-get "my.prop") "value-a"))))
+
 (ert-deftest vulpea-buffer-prop-remove ()
   "Test removing existing property."
   (let ((id "5093fc4e-8c63-4e60-a1da-83fc7ecd5db7"))

--- a/vulpea-buffer.el
+++ b/vulpea-buffer.el
@@ -274,14 +274,19 @@ If the property is already set, replace its value."
 (defun vulpea-buffer-prop-get (name)
   "Get a buffer property called NAME as a string."
   (org-with-point-at 1
-    (when (re-search-forward (concat "^#\\+" name ": \\(.*\\)")
-                             (point-max) t)
-      (let ((value (string-trim
-                    (buffer-substring-no-properties
-                     (match-beginning 1)
-                     (match-end 1)))))
-        (unless (string-empty-p value)
-          value)))))
+    ;; Bind `case-fold-search' (like the sibling readers) so the property
+    ;; is found regardless of the caller's setting, and quote NAME so a
+    ;; regexp-special character in it is matched literally.
+    (let ((case-fold-search t))
+      (when (re-search-forward
+             (concat "^#\\+" (regexp-quote name) ": \\(.*\\)")
+             (point-max) t)
+        (let ((value (string-trim
+                      (buffer-substring-no-properties
+                       (match-beginning 1)
+                       (match-end 1)))))
+          (unless (string-empty-p value)
+            value))))))
 
 (defun vulpea-buffer-prop-get-all (name)
   "Get all values of buffer property called NAME as a list of strings.


### PR DESCRIPTION
## What

`vulpea-buffer-prop-get` now binds `case-fold-search` to t and `regexp-quote`s the property name.

## Why

- **Case folding:** the sibling readers (`vulpea-buffer-prop-get-all`, `vulpea-buffer-prop-remove-all`) bind `case-fold-search` to t, but `prop-get` did not. A caller that had `case-fold-search` set to nil would get case-sensitive matching and miss e.g. `#+TITLE` when asking for `title`.
- **Name quoting:** the name was interpolated into the search regexp unquoted, so a regexp-special character in it (e.g. a `.`) could match a different property line.

Tests cover both cases.

The sibling prop helpers share the same name-quoting gap for regexp-special names; aligning them is left out of this focused change.