### PR TITLE
fix: reset parse buffer state even when parsing errors

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -25,6 +25,7 @@
 
 *Fixes*
 
+- Always reset the shared parse buffer's state after parsing a file, even when extraction errors. Previously a parse error left =buffer-file-name= pointing at the file on the reused parse buffer, which could mark it modified and interfere with file-change tracking on a later save. The cleanup now runs in an =unwind-protect=.
 - Make =vulpea-buffer-prop-get= bind =case-fold-search= (like its sibling readers) so a property is found regardless of the caller's setting, and quote the property name so a regexp-special character in it is matched literally rather than as part of the search pattern.
 - Match directory paths literally in =vulpea-db-query-by-directory=. It built a SQL =LIKE= pattern from the directory name without escaping, so =%= or =_= in a path (e.g. =my_notes=) acted as wildcards and pulled in sibling directories. It now uses =GLOB= with the directory escaped for GLOB's special characters, sharing the escape helper with the sync layer (=vulpea-db--escape-glob-pattern=). Note that matching is now case-sensitive, consistent with file-path semantics.
 - Make =vulpea-db-query-by-tags-every= and =vulpea-db-query-by-links-every= ignore duplicate entries in their input. Because they match on =COUNT(DISTINCT ...)= equal to the number of requested items, a repeated tag or id previously inflated the target count and made the query return nothing; the input is now de-duplicated first.

--- a/test/vulpea-db-extract-test.el
+++ b/test/vulpea-db-extract-test.el
@@ -1964,5 +1964,21 @@ File abc / * Parent (no ID) / ** Mention [[id:foo][person]] (no ID) -> abc -> fo
           (should (equal (plist-get (vulpea-parse-ctx-file-node ctx) :id) "enc-id")))
       (delete-file path))))
 
+(ert-deftest vulpea-db--parse-with-temp-buffer-clears-state-on-error ()
+  "A parse error must not leave the reused buffer associated with the file.
+Otherwise the shared parse buffer keeps a stale `buffer-file-name' that
+could be picked up by file-change tracking on a later save."
+  (let ((path (vulpea-test--create-temp-org-file
+               ":PROPERTIES:\n:ID: parse-err\n:END:\n#+title: T\n")))
+    (unwind-protect
+        (progn
+          (cl-letf (((symbol-function 'vulpea-db--extract-file-node)
+                     (lambda (&rest _) (error "boom"))))
+            (should-error (vulpea-db--parse-with-temp-buffer path t)))
+          (when (buffer-live-p vulpea-db--parse-buffer)
+            (should (null (buffer-local-value 'buffer-file-name
+                                              vulpea-db--parse-buffer)))))
+      (delete-file path))))
+
 (provide 'vulpea-db-extract-test)
 ;;; vulpea-db-extract-test.el ends here

--- a/vulpea-db-extract.el
+++ b/vulpea-db-extract.el
@@ -297,69 +297,71 @@ If RERUN-ORG-MODE is non-nil, `org-mode' (and its hooks) are executed
 after loading PATH so file-local keywords and hooks are respected."
   (let ((vulpea-db--parse-buffer-run-hooks rerun-org-mode))
     (vulpea-db--with-parse-buffer
-      (let* ((t0 (current-time))
+      (unwind-protect
+          (let* ((t0 (current-time))
 
-             ;; Required in case of relative `org-attach-dir'
-             (_ (setq buffer-file-name path
-                      default-directory (file-name-directory path)))
+                 ;; Required in case of relative `org-attach-dir'
+                 (_ (setq buffer-file-name path
+                          default-directory (file-name-directory path)))
 
-             (_ (let ((inhibit-read-only t)
-                      (inhibit-modification-hooks t))
-                  (erase-buffer)
-                  (insert-file-contents path)))
+                 (_ (let ((inhibit-read-only t)
+                          (inhibit-modification-hooks t))
+                      (erase-buffer)
+                      (insert-file-contents path)))
 
-             ;; Reset org-element cache after replacing buffer
-             ;; contents with inhibit-modification-hooks.  Without
-             ;; this, the cache retains stale positions from the
-             ;; previous file and org-element-parse-buffer hits
-             ;; "Invalid search bound" or marker errors.
-             (_ (when (fboundp 'org-element-cache-reset)
-                  (org-element-cache-reset)))
+                 ;; Reset org-element cache after replacing buffer
+                 ;; contents with inhibit-modification-hooks.  Without
+                 ;; this, the cache retains stale positions from the
+                 ;; previous file and org-element-parse-buffer hits
+                 ;; "Invalid search bound" or marker errors.
+                 (_ (when (fboundp 'org-element-cache-reset)
+                      (org-element-cache-reset)))
 
-             (t1 (current-time))
-             (_ (when rerun-org-mode
-                  (let ((delay-mode-hooks nil))
-                    (org-mode))))
-             (t2 (current-time))
-             (content (buffer-string))
-             (ast (org-element-parse-buffer))
-             (t3 (current-time))
-             (attrs (file-attributes path))
-             (mtime (float-time (file-attribute-modification-time attrs)))
-             (size (file-attribute-size attrs))
-             (hash (secure-hash 'sha256 content))
-             (file-title (vulpea-db--extract-file-title ast path))
-             (file-node (vulpea-db--extract-file-node ast path (current-buffer) file-title))
-             (heading-nodes (vulpea-db--extract-heading-nodes ast path (current-buffer) file-title))
-             (t4 (current-time)))
+                 (t1 (current-time))
+                 (_ (when rerun-org-mode
+                      (let ((delay-mode-hooks nil))
+                        (org-mode))))
+                 (t2 (current-time))
+                 (content (buffer-string))
+                 (ast (org-element-parse-buffer))
+                 (t3 (current-time))
+                 (attrs (file-attributes path))
+                 (mtime (float-time (file-attribute-modification-time attrs)))
+                 (size (file-attribute-size attrs))
+                 (hash (secure-hash 'sha256 content))
+                 (file-title (vulpea-db--extract-file-title ast path))
+                 (file-node (vulpea-db--extract-file-node ast path (current-buffer) file-title))
+                 (heading-nodes (vulpea-db--extract-heading-nodes ast path (current-buffer) file-title))
+                 (t4 (current-time)))
 
-        ;; Accumulate detailed timing if enabled
-        (when vulpea-db--timing-data
-          (let ((io-time (* 1000 (float-time (time-subtract t1 t0))))
-                (org-mode-time (* 1000 (float-time (time-subtract t2 t1))))
-                (parse-ast-time (* 1000 (float-time (time-subtract t3 t2))))
-                (extract-time (* 1000 (float-time (time-subtract t4 t3)))))
-            (dolist (entry `((parse-io . ,io-time)
-                             (parse-org-mode . ,org-mode-time)
-                             (parse-ast . ,parse-ast-time)
-                             (parse-extract . ,extract-time)))
-              (let ((existing (assoc (car entry) vulpea-db--timing-data)))
-                (if existing
-                    (setcdr existing (+ (cdr existing) (cdr entry)))
-                  (push entry vulpea-db--timing-data))))))
+            ;; Accumulate detailed timing if enabled
+            (when vulpea-db--timing-data
+              (let ((io-time (* 1000 (float-time (time-subtract t1 t0))))
+                    (org-mode-time (* 1000 (float-time (time-subtract t2 t1))))
+                    (parse-ast-time (* 1000 (float-time (time-subtract t3 t2))))
+                    (extract-time (* 1000 (float-time (time-subtract t4 t3)))))
+                (dolist (entry `((parse-io . ,io-time)
+                                 (parse-org-mode . ,org-mode-time)
+                                 (parse-ast . ,parse-ast-time)
+                                 (parse-extract . ,extract-time)))
+                  (let ((existing (assoc (car entry) vulpea-db--timing-data)))
+                    (if existing
+                        (setcdr existing (+ (cdr existing) (cdr entry)))
+                      (push entry vulpea-db--timing-data))))))
 
-        ;; Clear buffer state to avoid file change tracking
+            (make-vulpea-parse-ctx
+             :path path
+             :ast ast
+             :file-node file-node
+             :heading-nodes heading-nodes
+             :hash hash
+             :mtime mtime
+             :size size))
+        ;; Always clear buffer state - even when parsing above errors -
+        ;; so the reused parse buffer is not left associated with PATH
+        ;; (which would mark it modified and risk file-change tracking).
         (setq buffer-file-name nil)
-        (set-buffer-modified-p nil)
-
-        (make-vulpea-parse-ctx
-         :path path
-         :ast ast
-         :file-node file-node
-         :heading-nodes heading-nodes
-         :hash hash
-         :mtime mtime
-         :size size)))))
+        (set-buffer-modified-p nil)))))
 
 (defun vulpea-db--parse-file (path)
   "Parse org file at PATH and return parse context.


### PR DESCRIPTION
## What

`vulpea-db--parse-with-temp-buffer` now clears the reused parse buffer's `buffer-file-name` and modified flag in an `unwind-protect`, so the cleanup runs even when extraction signals an error.

## Why

The function sets `buffer-file-name` on the shared parse buffer (needed for relative `org-attach-dir` resolution) and previously cleared it only on the success path. If `org-element-parse-buffer` or an extractor threw, the buffer was left associated with the file — marking it modified and risking interference with file-change tracking the next time that scratch buffer was touched.

A test injects a parse error and asserts `buffer-file-name` is cleared afterward.