### PR TITLE
chore: clean up byte-compiler warnings

### DIFF
--- a/vulpea-buffer.el
+++ b/vulpea-buffer.el
@@ -265,7 +265,7 @@ VALUES are quoted and combined into single string using
 If SEPARATORS is non-nil, it should be a regular expression
 matching text that separates, but is not part of, the substrings.
 If nil it defaults to `split-string-default-separators', normally
-\"[ \f\t\n\r\v]+\", and OMIT-NULLS is forced to t.
+\"[ \\f\\t\\n\\r\\v]+\", and OMIT-NULLS is forced to t.
 
 If the property is already set, replace its value."
   (vulpea-buffer-prop-set
@@ -312,7 +312,7 @@ match, this collects values from all lines matching #+NAME:."
 If SEPARATORS is non-nil, it should be a regular expression
 matching text that separates, but is not part of, the substrings.
 If nil it defaults to `split-string-default-separators', normally
-\"[ \f\t\n\r\v]+\", and OMIT-NULLS is forced to t."
+\"[ \\f\\t\\n\\r\\v]+\", and OMIT-NULLS is forced to t."
   (let ((value (vulpea-buffer-prop-get name)))
     (when value
       (split-string-and-unquote value separators))))

--- a/vulpea-db-extract.el
+++ b/vulpea-db-extract.el
@@ -262,7 +262,7 @@ See README.org and bench/PERFORMANCE.md for guidance."
   "Current `vulpea-db-parse-method' while parsing.
 
 This is let-bound during parsing so hook authors can skip expensive
-work, e.g. `(unless (bound-and-true-p 'vulpea-db--active-parse-method) …)'.")
+work by testing it with `bound-and-true-p'.")
 
 (defvar vulpea-db--parse-buffer nil
   "Reusable buffer for parsing org files.
@@ -272,6 +272,10 @@ repeated `org-mode' activation overhead.")
 
 (defvar vulpea-db--parse-buffer-run-hooks t
   "Whether `org-mode' should run hooks when initializing parse buffer.")
+
+(defvar vulpea-db--timing-data nil
+  "Accumulated timing data for profiling.
+Format: ((phase . total-time-ms) ...)")
 
 (defmacro vulpea-db--with-parse-buffer (&rest body)
   "Execute BODY in a reusable parse buffer with `org-mode' initialized.
@@ -431,9 +435,11 @@ Returns the #+TITLE keyword value if present, otherwise the filename base."
            (org-link-display-format title)))
         (file-name-base path))))
 
-(defun vulpea-db--extract-file-node (ast path buffer file-title)
-  "Extract file-level node data from AST at PATH in BUFFER.
+(defun vulpea-db--extract-file-node (ast _path buffer file-title)
+  "Extract file-level node data from AST in BUFFER.
 
+_PATH is accepted for signature symmetry with
+`vulpea-db--extract-heading-nodes' but is not used.
 FILE-TITLE is the title of the file (from #+TITLE or filename).
 
 Returns plist with:
@@ -734,7 +740,7 @@ links from plain (non-note) subtrees."
         (let ((type (org-element-property :type link))
               (path (org-element-property :path link))
               (pos (org-element-property :begin link))
-              (desc (when-let ((contents (org-element-contents link)))
+              (desc (when-let* ((contents (org-element-contents link)))
                       (substring-no-properties
                        (org-element-interpret-data contents)))))
           (when (and type path)
@@ -763,7 +769,7 @@ Descends into child headlines only if they lack an ID property."
         (let ((type (org-element-property :type child))
               (path (org-element-property :path child))
               (pos (org-element-property :begin child))
-              (desc (when-let ((contents (org-element-contents child)))
+              (desc (when-let* ((contents (org-element-contents child)))
                       (substring-no-properties
                        (org-element-interpret-data contents)))))
           (when (and type path)
@@ -954,10 +960,6 @@ Returns updated note-data after all extractors have run."
              :initial-value note-data))
 
 ;;; Update File
-
-(defvar vulpea-db--timing-data nil
-  "Accumulated timing data for profiling.
-Format: ((phase . total-time-ms) ...)")
 
 (defun vulpea-db-update-file (path)
   "Parse and update database for file at PATH.

--- a/vulpea-meta.el
+++ b/vulpea-meta.el
@@ -48,6 +48,11 @@
 (require 'vulpea-buffer)
 (require 'vulpea-select)
 
+;; Defined in vulpea.el, which requires this file; declared here to
+;; avoid a load-time circular dependency.  Reached at runtime via the
+;; `vulpea-utils-process-notes' macro used by the batch operations.
+(declare-function vulpea-visit "vulpea")
+
 (defun vulpea-meta (note-or-id)
   "Get metadata for NOTE-OR-ID.
 

--- a/vulpea-tags.el
+++ b/vulpea-tags.el
@@ -51,6 +51,11 @@
 (require 'vulpea-db-query)
 (require 'vulpea-buffer)
 
+;; Defined in vulpea.el, which requires this file; declared here to
+;; avoid a load-time circular dependency.  Reached at runtime via the
+;; `vulpea-utils-process-notes' macro used by the batch operations.
+(declare-function vulpea-visit "vulpea")
+
 ;;; Per-note tag operations
 
 (defun vulpea-tags (note-or-id)

--- a/vulpea.el
+++ b/vulpea.el
@@ -749,7 +749,10 @@ If OTHER-WINDOW, visit the NOTE in another window."
         (org-back-to-heading t))
       (if (fboundp 'org-fold-show-context)
           (org-fold-show-context)
-        (org-show-context)))))
+        ;; Fallback for Org < 9.6; the function is obsolete there but
+        ;; still the correct entry point, so silence the warning.
+        (with-suppressed-warnings ((obsolete org-show-context))
+          (org-show-context))))))
 
 
 
@@ -883,11 +886,12 @@ BODY is optional body text after the property drawer."
     (when body (list body)))
    "\n"))
 
-(defun vulpea--find-heading-insertion-point (parent-note level after)
+(defun vulpea--find-heading-insertion-point (parent-note _level after)
   "Find buffer position to insert a new heading.
 
 PARENT-NOTE is the parent vulpea-note.
-LEVEL is the heading level to insert.
+_LEVEL is accepted for call-site symmetry but is not used; the
+insertion point is derived from PARENT-NOTE.
 AFTER controls position:
   \\='last (default) - append as last child
   nil - insert as first child
@@ -1226,7 +1230,7 @@ Interactive flow:
          (note (cond
                 ((vulpea-note-p note-or-id) note-or-id)
                 ((stringp note-or-id) (vulpea-db-get-by-id note-or-id))
-                (t (when-let ((id (org-entry-get nil "ID")))
+                (t (when-let* ((id (org-entry-get nil "ID")))
                      (vulpea-db-get-by-id id)))))
          (note (or note
                    (vulpea-select "Note to propagate")))
@@ -1299,7 +1303,7 @@ Interactive flow:
               (plist-get link :source-path)
               (plist-get link :pos)
               new-title)
-             (when-let ((buf (get-file-buffer (plist-get link :source-path))))
+             (when-let* ((buf (get-file-buffer (plist-get link :source-path))))
                (with-current-buffer buf
                  (save-buffer))))
            (message "Updated %d link%s"
@@ -1313,7 +1317,7 @@ Interactive flow:
                  (when (y-or-n-p (format "Update \"%s\" in %s? "
                                          desc (file-name-nondirectory path)))
                    (vulpea--update-link-description path pos new-title)
-                   (when-let ((buf (get-file-buffer path)))
+                   (when-let* ((buf (get-file-buffer path)))
                      (with-current-buffer buf
                        (save-buffer)))
                    (cl-incf updated))))


### PR DESCRIPTION
## What

Resolve every byte-compiler warning so the project compiles cleanly with `--warnings-as-errors`. No behavior change.

## Changes

- **vulpea-buffer.el** — escape the backslashes in two docstrings so they display the `split-string-default-separators` regexp literally instead of embedding form-feed / CR / vertical-tab control characters.
- **vulpea-db-extract.el** — move the `vulpea-db--timing-data` defvar above its first use; mark the unused `PATH` argument of `vulpea-db--extract-file-node` as `_path`; reword the `vulpea-db--active-parse-method` docstring to avoid a bare single quote; use `when-let*` instead of the obsolete `when-let`.
- **vulpea.el** — use `when-let*`; mark the unused `LEVEL` argument of `vulpea--find-heading-insertion-point` as `_level`; wrap the Org < 9.6 `org-show-context` fallback in `with-suppressed-warnings`.
- **vulpea-meta.el**, **vulpea-tags.el** — `declare-function vulpea-visit` (defined in vulpea.el, reached at runtime via the `vulpea-utils-process-notes` macro) to silence the not-known-to-be-defined warning.