### PR TITLE
docs: release v2.3.0

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,6 +9,8 @@
 
 ** Unreleased
 
+** v2.3.0
+
 *Features*
 
 - [[https://github.com/d12frosted/vulpea/issues/277][vulpea#277]] Change the default of =vulpea-db-sync-scan-on-enable= from =nil= to =async=: enabling autosync now scans note directories in the background, so changes made while Emacs was closed (git pulls, cloud sync, external edits) are picked up automatically instead of staying invisible until the files are touched again. Additionally, when the database is empty (e.g. the very first activation), an async scan is performed even when the option is set to =nil= - otherwise the database would stay empty with no indication why. Users of very large collections (10000+ notes) who prefer the old behavior can set the option back to =nil=.

--- a/vulpea.el
+++ b/vulpea.el
@@ -4,7 +4,7 @@
 ;;
 ;; Author: Boris Buliga <boris@d12frosted.io>
 ;; Maintainer: Boris Buliga <boris@d12frosted.io>
-;; Version: 2.2.0
+;; Version: 2.3.0
 ;; Package-Requires: ((emacs "27.2") (org "9.4.4") (emacsql "4.3.0") (s "1.12") (dash "2.19"))
 ;;
 ;; This program is free software; you can redistribute it and/or
@@ -73,7 +73,7 @@
 
 ;;; Version
 
-(defconst vulpea-version "2.2.0"
+(defconst vulpea-version "2.3.0"
   "Version of the vulpea package.
 
 Keep in sync with the Version header in vulpea.el; releases bump


### PR DESCRIPTION
Cut the v2.3.0 release.

- Move the accumulated `Unreleased` changelog entries under a `v2.3.0` heading.
- Bump the `Version` header and the `vulpea-version` constant to 2.3.0.

This release ships the backlog accumulated since v2.2.0 — including the diagnostics/version commands, async scan-on-enable, and the correctness/security fixes merged in #284–#295 (notably the template-expansion code-execution fix and the Emacs 27–28 batch-operation regression).