### PR TITLE
feat: add vulpea-db-query-stale-notes for stale note detection

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,6 +9,10 @@
 
 ** Unreleased
 
+*Features*
+
+- [[https://github.com/d12frosted/vulpea/issues/215][vulpea#215]] Add =vulpea-db-query-stale-notes=: return notes whose file has not been modified within the last N days, using the modification time recorded in the =files= table during sync. All notes in a stale file are returned (heading-level notes share their file's mtime), ordered oldest file first - useful for surfacing notes that may need review or archiving.
+
 ** v2.3.0
 
 *Features*

--- a/docs/api-reference.org
+++ b/docs/api-reference.org
@@ -203,6 +203,18 @@ Find notes that share the same title:
 
 Returns list of =(TITLE . NOTES)= groups where each group has two or more notes with the same title. Optional LEVEL argument restricts to notes at a specific heading level (0 for file-level).
 
+** Stale Notes
+
+Find notes whose file has not been modified within the last N days:
+
+#+begin_src emacs-lisp
+;; notes untouched for more than 90 days
+(vulpea-db-query-stale-notes 90)
+;; => (#s(vulpea-note ...) ...)
+#+end_src
+
+Uses the modification time recorded in the =files= table during sync. All notes in a stale file are returned (a heading-level note shares its file's mtime), ordered oldest file first. Useful for surfacing notes that may need review or archiving.
+
 * Link Queries
 
 Query links directly from the database. All functions return plists with =:source=, =:dest=, =:type=, and =:pos= keys.
@@ -882,6 +894,7 @@ For advanced use cases, direct database access:
 | =vulpea-db-query-orphan-notes=        | Notes with no incoming ID links      |
 | =vulpea-db-query-isolated-notes=      | Notes with no connections at all     |
 | =vulpea-db-query-title-collisions=    | Notes sharing the same title         |
+| =vulpea-db-query-stale-notes=         | Notes in files unmodified for N days |
 | =vulpea-db-query-links=               | All links as plists                  |
 | =vulpea-db-query-links-by-type=       | Links filtered by type               |
 | =vulpea-db-query-links-from=          | Outgoing links from a note           |

--- a/test/vulpea-db-query-test.el
+++ b/test/vulpea-db-query-test.el
@@ -931,6 +931,43 @@ be returned with string keys after JSON round-trip through the DB."
       (should (= (length notes) 1))
       (should (equal (vulpea-note-id (car notes)) "note1")))))
 
+;;; Stale Note Queries
+
+(ert-deftest vulpea-db-query-stale-notes-basic ()
+  "Returns notes whose file was last modified more than DAYS days ago."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (let ((now (float-time)))
+      (vulpea-test--insert-test-note "fresh" "Fresh" :path "/tmp/fresh.org")
+      (vulpea-test--insert-test-note "stale" "Stale" :path "/tmp/stale.org")
+      ;; fresh: modified 1 day ago; stale: modified 100 days ago
+      (vulpea-db--update-file-hash "/tmp/fresh.org" "h1" (- now (* 1 86400)) 10)
+      (vulpea-db--update-file-hash "/tmp/stale.org" "h2" (- now (* 100 86400)) 10)
+      (let ((notes (vulpea-db-query-stale-notes 30)))
+        (should (= (length notes) 1))
+        (should (equal (vulpea-note-id (car notes)) "stale"))))))
+
+(ert-deftest vulpea-db-query-stale-notes-all-in-file-oldest-first ()
+  "Returns every note in a stale file, with the oldest file's notes first."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (let ((now (float-time)))
+      ;; older file with two notes (file-level + heading)
+      (vulpea-test--insert-test-note "old-file" "Old File" :path "/tmp/old.org")
+      (vulpea-test--insert-test-note "old-head" "Old Heading"
+                                     :path "/tmp/old.org" :level 1 :pos 50)
+      ;; newer (but still stale) file with one note
+      (vulpea-test--insert-test-note "mid-file" "Mid File" :path "/tmp/mid.org")
+      (vulpea-db--update-file-hash "/tmp/old.org" "h1" (- now (* 200 86400)) 10)
+      (vulpea-db--update-file-hash "/tmp/mid.org" "h2" (- now (* 50 86400)) 10)
+      (let* ((notes (vulpea-db-query-stale-notes 30))
+             (ids (mapcar #'vulpea-note-id notes)))
+        (should (= (length notes) 3))
+        ;; newest stale file sorts last; both notes of the oldest file precede it
+        (should (equal (car (last ids)) "mid-file"))
+        (should (member "old-file" (butlast ids)))
+        (should (member "old-head" (butlast ids)))))))
+
 ;;; Dead Link Detection Tests
 
 (ert-deftest vulpea-db-query-dead-links-found ()

--- a/vulpea-db-query.el
+++ b/vulpea-db-query.el
@@ -475,6 +475,36 @@ Returns list of `vulpea-note' structs."
                          date))))
     (mapcar #'vulpea-db--row-to-note rows)))
 
+;;; Stale Note Queries
+
+(defun vulpea-db-query-stale-notes (days)
+  "Get notes whose file has not been modified within the last DAYS days.
+
+DAYS is a number; a note is considered stale when its file's last
+modification time is older than DAYS days ago.
+
+Uses the modification time recorded in the `files' table during
+sync (the real filesystem mtime), joined to the notes from each
+file.  All notes in a stale file are returned - a heading-level
+note shares its file's modification time.  Results are ordered
+oldest file first, which suits review and archiving workflows.
+
+Note: the mtime is the value captured at the last sync.  A file
+modified but not yet synced keeps its previous mtime until the
+next sync.
+
+Returns list of `vulpea-note' structs."
+  (let* ((cutoff (- (float-time) (* days 86400)))
+         (rows (emacsql (vulpea-db)
+                        [:select [notes:*]
+                         :from notes
+                         :inner :join files
+                         :on (= notes:path files:path)
+                         :where (< files:mtime $s1)
+                         :order :by files:mtime]
+                        cutoff)))
+    (mapcar #'vulpea-db--row-to-note rows)))
+
 ;;; Property-Based Queries
 
 (defun vulpea-db-query-by-property (key value)


### PR DESCRIPTION
Closes #215.

## What

Adds `vulpea-db-query-stale-notes (DAYS)` — returns notes whose file has not been modified within the last `DAYS` days.

## How

Joins the `notes` table to the `files` table on path and filters on `files.mtime` — the real filesystem modification time captured during sync (the issue's preferred option, avoiding per-file `file-attributes` calls). All notes in a stale file are returned (a heading-level note shares its file's mtime), ordered oldest file first to suit review/archiving workflows.

No schema change: the `files` table already stores `mtime`, and the `notes.path`→`files.path` join is exact.

## Naming

The issue sketched the API as `vulpea-query-stale-notes`; I implemented it as `vulpea-db-query-stale-notes` to match the established `vulpea-db-query-*` namespace that all sibling query functions use. Happy to rename/alias if you'd prefer the shorter form (it could also be the first member of a future higher-level `vulpea-query-*` facade, cf. #166).

Includes tests (basic stale-vs-fresh, and all-notes-in-file with oldest-first ordering) and api-reference docs.