### PR TITLE
feat: add schema definition system (#213)

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -11,6 +11,7 @@
 
 *Features*
 
+- [[https://github.com/d12frosted/vulpea/issues/213][vulpea#213]] Add a schema definition system (=vulpea-schema=): declare structured expectations for a class of notes - a predicate selecting which notes a schema applies to, plus field specs declaring metadata keys with types, required-ness, and allowed values. =:required= and =:one-of= accept a function of the note for conditional rules and dependent enums. Includes the registry (=vulpea-schema-define=, =vulpea-schema-get=, =vulpea-schema-list=, =vulpea-schema-unregister=), =vulpea-schema-applies-p=, and =vulpea-schema-field-value=. Validation against a schema is added separately.
 - [[https://github.com/d12frosted/vulpea/issues/215][vulpea#215]] Add =vulpea-db-query-stale-notes=: return notes whose file has not been modified within the last N days, using the modification time recorded in the =files= table during sync. All notes in a stale file are returned (heading-level notes share their file's mtime), ordered oldest file first - useful for surfacing notes that may need review or archiving.
 
 ** v2.3.0

--- a/docs/api-reference.org
+++ b/docs/api-reference.org
@@ -858,6 +858,59 @@ For advanced use cases, direct database access:
 
 → See [[file:plugin-guide.org][Plugin Guide]] for custom tables and extractors.
 
+* Schemas
+
+A schema describes the structured expectations for a class of notes: a
+predicate selecting which notes it applies to, and a list of field specs
+declaring the metadata those notes should carry.
+
+#+begin_src emacs-lisp
+(vulpea-schema-define 'wine
+  :predicate (lambda (note) (member "wine" (vulpea-note-tags note)))
+  :fields
+  '((:key "producer" :type note   :required t)
+    (:key "name"     :type string :required t)
+    (:key "colour"   :type symbol :required t :one-of (red white rose))
+    (:key "grapes"   :type note   :multiple t)
+    (:key "vintage"  :type number)
+    ;; required only for sparkling wines
+    (:key "carbonation method" :type symbol
+          :required (lambda (note)
+                      (eq (vulpea-note-meta-get note "carbonation" 'symbol)
+                          'sparkling)))))
+#+end_src
+
+Field spec keys:
+
+| Key         | Meaning                                                          |
+|-------------+-----------------------------------------------------------------|
+| =:key=      | metadata key string (required)                                  |
+| =:type=     | =string= (default), =number=, =symbol=, =note=, or =link=       |
+| =:required= | =t=/=nil=, or a function =(note)= → boolean                     |
+| =:one-of=   | a list of allowed values, or a function =(note)= → list         |
+| =:multiple= | non-nil when the field holds a list of values                   |
+| =:validate= | optional function =(value note)= → =t= or an error string       |
+
+The =:type= vocabulary matches =vulpea-note-meta-get=, so values are read
+the same way everywhere. Use a function for =:required= or =:one-of= when
+the rule depends on another field (e.g. allowed sweetness levels that
+vary by carbonation). To read a sibling field inside such a function,
+call =vulpea-note-meta-get= directly so you control the value type.
+
+Registry and helpers:
+
+| Function                                  | Description                            |
+|-------------------------------------------+----------------------------------------|
+| =vulpea-schema-define=                    | Define and register a schema           |
+| =vulpea-schema-get=                       | Retrieve a schema by name              |
+| =vulpea-schema-list=                      | List registered schema names           |
+| =vulpea-schema-unregister=                | Remove a schema from the registry      |
+| =vulpea-schema-applies-p=                 | Does a schema's predicate match a note |
+| =vulpea-schema-field-value=               | Read a field's value with its type     |
+
+Validating notes against a schema (reporting missing or invalid fields)
+is a separate layer, added on top of these definitions.
+
 * Quick Reference Tables
 
 ** Core Functions

--- a/test/vulpea-schema-test.el
+++ b/test/vulpea-schema-test.el
@@ -1,0 +1,113 @@
+;;; vulpea-schema-test.el --- Tests for vulpea-schema -*- lexical-binding: t; -*-
+;;
+;; Copyright (c) 2015-2026 Boris Buliga <boris@d12frosted.io>
+;;
+;; Author: Boris Buliga <boris@d12frosted.io>
+;; Maintainer: Boris Buliga <boris@d12frosted.io>
+;;
+;; License: GPLv3
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; Commentary:
+;;
+;; Tests for the schema definition layer (`vulpea-schema').
+;;
+;;; Code:
+
+(require 'ert)
+(require 'vulpea-schema)
+(require 'vulpea-note)
+
+(defmacro vulpea-schema-test--with-registry (&rest body)
+  "Run BODY with a fresh, isolated schema registry."
+  (declare (indent 0))
+  `(let ((vulpea-schema--registry (make-hash-table :test 'eq)))
+     ,@body))
+
+;;; Definition and registry
+
+(ert-deftest vulpea-schema-define-registers-and-retrieves ()
+  "A defined schema is stored and retrievable by name."
+  (vulpea-schema-test--with-registry
+    (let ((schema (vulpea-schema-define 'test-schema
+                    :predicate (lambda (_n) t)
+                    :fields '((:key "name" :required t)))))
+      (should (vulpea-schema-p schema))
+      (should (eq (vulpea-schema-name schema) 'test-schema))
+      (should (eq (vulpea-schema-get 'test-schema) schema))
+      (should (memq 'test-schema (vulpea-schema-list))))))
+
+(ert-deftest vulpea-schema-define-replaces-existing ()
+  "Re-defining a schema with the same name replaces it."
+  (vulpea-schema-test--with-registry
+    (vulpea-schema-define 'dup :predicate #'ignore :fields nil)
+    (vulpea-schema-define 'dup :predicate (lambda (_n) t)
+                          :fields '((:key "x")))
+    (should (= (length (vulpea-schema-list)) 1))
+    (should (vulpea-schema-applies-p (make-vulpea-note) 'dup))))
+
+(ert-deftest vulpea-schema-define-validates-inputs ()
+  "Invalid schema definitions are rejected."
+  (vulpea-schema-test--with-registry
+    (should-error (vulpea-schema-define "not-a-symbol" :predicate #'ignore))
+    (should-error (vulpea-schema-define 'x :predicate "not-a-function"))
+    ;; field without a string :key
+    (should-error (vulpea-schema-define 'x :predicate #'ignore
+                                        :fields '((:type symbol))))))
+
+(ert-deftest vulpea-schema-unregister-removes ()
+  "Unregistering a schema removes it from the registry."
+  (vulpea-schema-test--with-registry
+    (vulpea-schema-define 'gone :predicate #'ignore :fields nil)
+    (should (vulpea-schema-get 'gone))
+    (vulpea-schema-unregister 'gone)
+    (should-not (vulpea-schema-get 'gone))
+    (should-not (memq 'gone (vulpea-schema-list)))))
+
+(ert-deftest vulpea-schema-resolve-accepts-name-or-object ()
+  "`vulpea-schema--resolve' accepts a name or a schema object."
+  (vulpea-schema-test--with-registry
+    (let ((schema (vulpea-schema-define 'r :predicate #'ignore :fields nil)))
+      (should (eq (vulpea-schema--resolve 'r) schema))
+      (should (eq (vulpea-schema--resolve schema) schema))
+      (should-error (vulpea-schema--resolve 'nonexistent)))))
+
+;;; Predicate
+
+(ert-deftest vulpea-schema-applies-p-runs-predicate ()
+  "`vulpea-schema-applies-p' runs the schema predicate against a note."
+  (vulpea-schema-test--with-registry
+    (vulpea-schema-define 'tagged-wine
+      :predicate (lambda (n) (member "wine" (vulpea-note-tags n)))
+      :fields nil)
+    (should (vulpea-schema-applies-p
+             (make-vulpea-note :tags '("wine")) 'tagged-wine))
+    (should-not (vulpea-schema-applies-p
+                 (make-vulpea-note :tags '("beer")) 'tagged-wine))))
+
+;;; Field access
+
+(ert-deftest vulpea-schema-field-value-reads-typed ()
+  "`vulpea-schema-field-value' reads a field with its declared type."
+  (let ((note (make-vulpea-note
+               :meta '(("name" "Chardonnay")
+                       ("vintage" "2019")
+                       ("colour" "white")))))
+    (should (equal (vulpea-schema-field-value note '(:key "name")) "Chardonnay"))
+    (should (equal (vulpea-schema-field-value note '(:key "vintage" :type number)) 2019))
+    (should (eq (vulpea-schema-field-value note '(:key "colour" :type symbol)) 'white))
+    ;; a bare key string defaults to the string type
+    (should (equal (vulpea-schema-field-value note "name") "Chardonnay"))
+    ;; missing field yields nil
+    (should-not (vulpea-schema-field-value note '(:key "absent")))))
+
+(ert-deftest vulpea-schema-field-value-multiple ()
+  "A :multiple field reads all of its values as a list."
+  (let ((note (make-vulpea-note
+               :meta '(("grapes" "Chardonnay" "Pinot Noir")))))
+    (should (equal (vulpea-schema-field-value note '(:key "grapes" :multiple t))
+                   '("Chardonnay" "Pinot Noir")))))
+
+(provide 'vulpea-schema-test)
+;;; vulpea-schema-test.el ends here

--- a/vulpea-schema.el
+++ b/vulpea-schema.el
@@ -1,0 +1,175 @@
+;;; vulpea-schema.el --- Note schema definition and validation -*- lexical-binding: t; -*-
+;;
+;; Copyright (c) 2015-2026 Boris Buliga <boris@d12frosted.io>
+;;
+;; Author: Boris Buliga <boris@d12frosted.io>
+;; Maintainer: Boris Buliga <boris@d12frosted.io>
+;;
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program. If not, see
+;; <http://www.gnu.org/licenses/>.
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; Created: 12 Jun 2026
+;;
+;; URL: https://github.com/d12frosted/vulpea
+;;
+;; License: GPLv3
+;;
+;;; Commentary:
+;;
+;; Declarative schemas for vulpea notes.
+;;
+;; A schema describes the structured expectations for a class of notes:
+;; which notes it applies to (a predicate) and which metadata fields they
+;; should carry, with types, required-ness, and allowed values.
+;;
+;; This file provides schema definition and the registry.  The validation
+;; engine (`vulpea-schema-validate' and friends) is layered on top in the
+;; same module.
+;;
+;; A field spec is a plist with keys:
+;;
+;;   :key       metadata key string (required)
+;;   :type      value type: `string' (default), `number', `symbol',
+;;              `note', or `link'.  Values are read with
+;;              `vulpea-note-meta-get', so the type vocabulary matches the
+;;              rest of vulpea.
+;;   :required  t/nil, or a function (note) -> boolean for conditional
+;;              requiredness (e.g. required only for sparkling wines).
+;;   :one-of    a list of allowed values, or a function (note) -> list for
+;;              a dependent enum (e.g. sweetness levels depend on
+;;              carbonation).
+;;   :multiple  non-nil when the field holds a list of values.
+;;   :validate  optional function (value note) -> t, or an error message
+;;              string, for arbitrary checks.
+;;
+;; Example:
+;;
+;;   (vulpea-schema-define 'wine
+;;     :predicate (lambda (note) (member "wine" (vulpea-note-tags note)))
+;;     :fields
+;;     '((:key "producer" :type note   :required t)
+;;       (:key "name"     :type string :required t)
+;;       (:key "colour"   :type symbol :required t :one-of (red white rose))
+;;       (:key "grapes"   :type note   :multiple t)
+;;       (:key "carbonation method" :type symbol
+;;             :required (lambda (note)
+;;                         (eq (vulpea-note-meta-get note "carbonation" 'symbol)
+;;                             'sparkling)))))
+;;
+;; To read a sibling field inside a :required / :one-of function, use
+;; `vulpea-note-meta-get' directly so you control the value type.
+;;
+;;; Code:
+
+(require 'cl-lib)
+(require 'vulpea-note)
+
+;;; Schema structure
+
+(cl-defstruct (vulpea-schema (:constructor vulpea-schema--create)
+                             (:copier nil))
+  "A schema describing structured expectations for a class of notes.
+
+Slots:
+  name      - symbol identifying the schema
+  predicate - function (note) -> non-nil selecting notes it applies to
+  fields    - list of field spec plists (see Commentary)"
+  name
+  predicate
+  fields)
+
+;;; Registry
+
+(defvar vulpea-schema--registry (make-hash-table :test 'eq)
+  "Registry of defined schemas, keyed by name symbol.")
+
+(cl-defun vulpea-schema-define (name &key predicate fields)
+  "Define and register a schema called NAME.
+
+PREDICATE is a function (note) -> non-nil when the schema applies to
+the note.  FIELDS is a list of field spec plists (see Commentary for
+the supported keys).
+
+Registering a schema with an existing NAME replaces it.  Returns the
+`vulpea-schema' object."
+  (unless (symbolp name)
+    (error "Schema name must be a symbol: %S" name))
+  (unless (functionp predicate)
+    (error "Schema :predicate must be a function"))
+  (dolist (field fields)
+    (unless (and (plist-member field :key)
+                 (stringp (plist-get field :key)))
+      (error "Schema field must have a string :key: %S" field)))
+  (let ((schema (vulpea-schema--create
+                 :name name
+                 :predicate predicate
+                 :fields fields)))
+    (puthash name schema vulpea-schema--registry)
+    schema))
+
+(defun vulpea-schema-get (name)
+  "Return the registered schema called NAME, or nil."
+  (gethash name vulpea-schema--registry))
+
+(defun vulpea-schema-list ()
+  "Return the list of registered schema names."
+  (let (names)
+    (maphash (lambda (k _v) (push k names)) vulpea-schema--registry)
+    (nreverse names)))
+
+(defun vulpea-schema-unregister (name)
+  "Remove the schema called NAME from the registry."
+  (remhash name vulpea-schema--registry))
+
+(defun vulpea-schema--resolve (schema-or-name)
+  "Return a `vulpea-schema' from SCHEMA-OR-NAME.
+
+SCHEMA-OR-NAME is either a `vulpea-schema' object or the symbol name of
+a registered schema.  Signals an error when a name is not registered."
+  (cond
+   ((vulpea-schema-p schema-or-name) schema-or-name)
+   ((symbolp schema-or-name)
+    (or (vulpea-schema-get schema-or-name)
+        (error "No schema registered as %S" schema-or-name)))
+   (t (error "Not a schema or schema name: %S" schema-or-name))))
+
+;;; Field access
+
+(defun vulpea-schema-field-value (note field)
+  "Return the value of FIELD for NOTE, read with the field's declared type.
+
+FIELD is a field spec plist or a bare metadata key string (in which
+case the type defaults to `string').  Reads from the note's
+already-extracted metadata via `vulpea-note-meta-get'.  When the field
+spec is :multiple, returns a list of values."
+  (let* ((spec (if (stringp field) (list :key field) field))
+         (key (plist-get spec :key))
+         (type (or (plist-get spec :type) 'string)))
+    (if (plist-get spec :multiple)
+        (vulpea-note-meta-get-list note key type)
+      (vulpea-note-meta-get note key type))))
+
+;;; Predicate
+
+(defun vulpea-schema-applies-p (note schema-or-name)
+  "Return non-nil when SCHEMA-OR-NAME's predicate matches NOTE.
+
+SCHEMA-OR-NAME is a `vulpea-schema' object or a registered schema name."
+  (let ((schema (vulpea-schema--resolve schema-or-name)))
+    (funcall (vulpea-schema-predicate schema) note)))
+
+(provide 'vulpea-schema)
+;;; vulpea-schema.el ends here

--- a/vulpea.el
+++ b/vulpea.el
@@ -66,6 +66,7 @@
 (require 'vulpea-db-sync)
 (require 'vulpea-meta)
 (require 'vulpea-note)
+(require 'vulpea-schema)
 (require 'vulpea-select)
 (require 'vulpea-tags)
 (require 'vulpea-utils)


### PR DESCRIPTION
Part of #213. The definition + registry layer of the schema system; the validation engine (#214) lands on top separately.

## What

New `vulpea-schema.el` module for declaring structured expectations for a class of notes:

```elisp
(vulpea-schema-define '\''wine
  :predicate (lambda (note) (member "wine" (vulpea-note-tags note)))
  :fields
  '\''((:key "producer" :type note   :required t)
    (:key "colour"   :type symbol :required t :one-of (red white rose))
    (:key "grapes"   :type note   :multiple t)
    (:key "carbonation method" :type symbol
          :required (lambda (note)
                      (eq (vulpea-note-meta-get note "carbonation" '\''symbol) '\''sparkling)))))
```

- **Field specs are plists.** `:required` and `:one-of` accept either a literal (t/list) or a **function of the note**, so conditional requiredness and dependent enums are expressible while the common case stays plain data. This is the shape the vino research showed is necessary (sweetness depends on carbonation; carbonation-method required only for sparkling).
- `:type` reuses the existing `vulpea-note-meta-get` vocabulary (`string`/`number`/`symbol`/`note`/`link`); values are read off the already-extracted note struct — **no new parsing.**
- Registry: `vulpea-schema-define` / `-get` / `-list` / `-unregister`, plus `vulpea-schema-applies-p` and `vulpea-schema-field-value`.

## Scope

Definition only — no validation engine yet (that is #214). Required from `vulpea.el`. Includes unit tests (registry, input validation, predicate, typed/multiple field reads) and an api-reference `Schemas` section.

The API shape is the main thing to review here before validation is built on top.