### PR TITLE
fix: invalidate file cache when extractor changes via parser epoch

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -16,6 +16,10 @@
 - [[https://github.com/d12frosted/vulpea/issues/213][vulpea#213]] Add a schema definition system (=vulpea-schema=): declare structured expectations for a class of notes - a predicate selecting which notes a schema applies to, plus field specs declaring metadata keys with types, required-ness, and allowed values. =:required= and =:one-of= accept a function of the note for conditional rules and dependent enums. Includes the registry (=vulpea-schema-define=, =vulpea-schema-get=, =vulpea-schema-list=, =vulpea-schema-unregister=), =vulpea-schema-applies-p=, and =vulpea-schema-field-value=. Validation against a schema is added separately.
 - [[https://github.com/d12frosted/vulpea/issues/215][vulpea#215]] Add =vulpea-db-query-stale-notes=: return notes whose file has not been modified within the last N days, using the modification time recorded in the =files= table during sync. All notes in a stale file are returned (heading-level notes share their file's mtime), ordered oldest file first - useful for surfacing notes that may need review or archiving.
 
+*Fixes*
+
+- [[https://github.com/d12frosted/vulpea/issues/277][vulpea#277]] Invalidate the file change-detection cache when the note extractor changes, via a new parser epoch (=vulpea-db-parser-epoch=). Previously a file that was once indexed while producing no note (e.g. a partially-synced cloud file, or an older Vulpea version that failed to extract its =ID=) had that "no note" result cached, so later scans kept skipping it and the note stayed invisible until the file was edited or a force scan was run. Bumping the parser epoch now clears the cache and re-extracts every file once, without discarding the database. Existing databases predating this mechanism are treated as stale and re-extracted on first open, so the fix applies retroactively on upgrade.
+
 ** v2.3.0
 
 *Features*

--- a/docs/sync-architecture.org
+++ b/docs/sync-architecture.org
@@ -287,6 +287,23 @@ vulpea-db-sync--update-file-if-changed(path)
 ;; Use after changing vulpea-db-index-heading-level
 #+end_src
 
+** Automatic cache invalidation
+
+On database access Vulpea clears the change-detection cache (forcing a
+re-extraction of all files on the next scan) when any of these change
+since the database was last opened:
+
+- the schema version (=vulpea-db-version=) - also rebuilds the database;
+- the tag inheritance fingerprint (=org-use-tag-inheritance=,
+  =org-tags-exclude-from-inheritance=);
+- the parser epoch (=vulpea-db-parser-epoch=), bumped whenever the
+  extractor changes what it produces from the same file content.
+
+The parser epoch is what heals notes that an older Vulpea failed to
+index: upgrading past an epoch bump re-extracts every file once,
+without discarding the database. Existing databases predating the
+epoch mechanism are treated as stale and re-extracted on first open.
+
 
 * Performance Characteristics
 

--- a/docs/troubleshooting.org
+++ b/docs/troubleshooting.org
@@ -256,6 +256,37 @@ Rebuild the database:
 
 Or with =C-u= prefix: =C-u M-x vulpea-db-sync-full-scan=
 
+** Notes Missing After an Upgrade or External Sync
+
+*** Symptom
+
+Some notes never show up in =vulpea-find=, even after a normal sync.
+Editing and re-saving an affected file (or running a force scan)
+makes it appear.
+
+*** Cause
+
+Vulpea keeps a per-file change-detection cache (mtime/size/hash) and
+skips files that have not changed since they were last seen.  If a
+file was once indexed while it produced no note - for example a
+partially-synced cloud file, or an older Vulpea version that failed to
+extract its =ID= - that "no note" result was cached.  A normal scan
+then keeps skipping the file (its content has not changed), so it
+stays invisible until the file is edited.
+
+*** Solution
+
+Vulpea now invalidates this cache automatically when its extraction
+logic changes (the parser epoch), so upgrading re-extracts every file
+once and heals such notes.  To fix it immediately without waiting:
+
+#+begin_src emacs-lisp
+;; Force complete re-index, ignoring the change-detection cache
+(vulpea-db-sync-full-scan 'force)
+#+end_src
+
+Or with =C-u= prefix: =C-u M-x vulpea-db-sync-full-scan=
+
 ** Database Corruption
 
 *** Symptom

--- a/test/vulpea-db-test.el
+++ b/test/vulpea-db-test.el
@@ -617,5 +617,106 @@ parent headings top-down, then own tags."
       (should (emacsql (vulpea-db)
                        [:select * :from files])))))
 
+;;; Parser Epoch Tests
+;; https://github.com/d12frosted/vulpea/issues/277
+
+(ert-deftest vulpea-db-parser-epoch-stored-on-init ()
+  "Parser epoch is stored in schema-registry on init."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (let ((stored (caar (emacsql (vulpea-db)
+                                 [:select [version] :from schema-registry
+                                  :where (= name "parser-epoch")]))))
+      (should stored)
+      (should (equal stored vulpea-db-parser-epoch)))))
+
+(ert-deftest vulpea-db-parser-epoch-change-triggers-reindex ()
+  "Changing the parser epoch clears the files cache and flags a
+re-index, while preserving the notes table."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-db--insert-note
+     :id "epoch-id" :path "/tmp/epoch.org" :level 0 :pos 0
+     :title "Epoch Note" :properties nil
+     :modified-at "2025-11-16 10:00:00")
+    (emacsql (vulpea-db)
+             [:insert :into files :values $v1]
+             (list (vector "/tmp/epoch.org" "hash" "2025-01-01" 100)))
+    ;; Simulate a DB written by an older parser epoch
+    (vulpea-db--register-schema (vulpea-db) 'parser-epoch
+                                (1- vulpea-db-parser-epoch))
+    (vulpea-db-close)
+    (setq vulpea-db--connection nil
+          vulpea-db--parser-changed nil)
+
+    (vulpea-db)
+
+    ;; Flag should be set
+    (should vulpea-db--parser-changed)
+    ;; Notes preserved (no full rebuild)
+    (should (emacsql (vulpea-db)
+                     [:select * :from notes :where (= id $s1)] "epoch-id"))
+    ;; files cache cleared to force re-extraction
+    (should-not (emacsql (vulpea-db) [:select * :from files]))
+    ;; Stored epoch updated to current
+    (should (equal (caar (emacsql (vulpea-db)
+                                  [:select [version] :from schema-registry
+                                   :where (= name "parser-epoch")]))
+                   vulpea-db-parser-epoch))))
+
+(ert-deftest vulpea-db-parser-epoch-unchanged-no-reindex ()
+  "Same parser epoch leaves the files cache intact."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (emacsql (vulpea-db)
+             [:insert :into files :values $v1]
+             (list (vector "/tmp/epoch.org" "hash" "2025-01-01" 100)))
+    (vulpea-db-close)
+    (setq vulpea-db--connection nil
+          vulpea-db--parser-changed nil)
+
+    (vulpea-db)
+
+    (should-not vulpea-db--parser-changed)
+    (should (emacsql (vulpea-db) [:select * :from files]))))
+
+(ert-deftest vulpea-db-parser-epoch-missing-with-cached-files-triggers ()
+  "An existing DB with cached files but no recorded parser epoch is
+treated as stale, so upgrading to an epoch-aware vulpea re-extracts
+all files once.  Regression test for
+https://github.com/d12frosted/vulpea/issues/277."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (emacsql (vulpea-db)
+             [:insert :into files :values $v1]
+             (list (vector "/tmp/epoch.org" "hash" "2025-01-01" 100)))
+    ;; Simulate a pre-epoch database: no parser-epoch row
+    (emacsql (vulpea-db)
+             [:delete :from schema-registry :where (= name "parser-epoch")])
+    (vulpea-db-close)
+    (setq vulpea-db--connection nil
+          vulpea-db--parser-changed nil)
+
+    (vulpea-db)
+
+    (should vulpea-db--parser-changed)
+    (should-not (emacsql (vulpea-db) [:select * :from files]))))
+
+(ert-deftest vulpea-db-parser-epoch-missing-brand-new-db-no-trigger ()
+  "A brand-new DB (empty files cache) does not trigger a parser
+re-index even before an epoch is recorded."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    ;; Drop the freshly-registered epoch but keep the files cache empty
+    (emacsql (vulpea-db)
+             [:delete :from schema-registry :where (= name "parser-epoch")])
+    (vulpea-db-close)
+    (setq vulpea-db--connection nil
+          vulpea-db--parser-changed nil)
+
+    (vulpea-db)
+
+    (should-not vulpea-db--parser-changed)))
+
 (provide 'vulpea-db-test)
 ;;; vulpea-db-test.el ends here

--- a/vulpea-db-sync.el
+++ b/vulpea-db-sync.el
@@ -363,13 +363,18 @@ a subprocess.  The `blocking' mode still scans synchronously."
         (message "[vulpea-sync] cleanup-deleted-files: %.0fms"
                  (* 1000 (float-time (time-subtract (current-time) t-phase))))))
 
-    ;; If schema was rebuilt or tag settings changed, trigger forced re-index
-    (when (or vulpea-db--schema-rebuilt vulpea-db--settings-changed)
+    ;; If schema was rebuilt, tag settings changed, or the parser epoch
+    ;; changed, trigger forced re-index
+    (when (or vulpea-db--schema-rebuilt
+              vulpea-db--settings-changed
+              vulpea-db--parser-changed)
       (let ((reason (cond
                      (vulpea-db--schema-rebuilt "Schema upgraded")
-                     (vulpea-db--settings-changed "Tag inheritance settings changed"))))
+                     (vulpea-db--settings-changed "Tag inheritance settings changed")
+                     (vulpea-db--parser-changed "Parser updated"))))
         (setq vulpea-db--schema-rebuilt nil)
         (setq vulpea-db--settings-changed nil)
+        (setq vulpea-db--parser-changed nil)
         (vulpea-db-sync--message "Vulpea: %s, re-indexing all files..." reason)
         (dolist (dir vulpea-db-sync-directories)
           (vulpea-db-sync-update-directory dir 'force))))

--- a/vulpea-db.el
+++ b/vulpea-db.el
@@ -108,7 +108,24 @@ Example:
 ;;; Constants
 
 (defconst vulpea-db-version 3
-  "Current database schema version.")
+  "Current database schema version.
+
+Bumping this triggers a full database rebuild (the file is deleted
+and recreated).  Use it only for incompatible schema changes.  For
+changes to extraction logic that keep the schema intact, bump
+`vulpea-db-parser-epoch' instead - it re-extracts files without
+discarding the database.")
+
+(defconst vulpea-db-parser-epoch 1
+  "Epoch of the note extraction logic.
+
+Increment this whenever the parser/extractor in `vulpea-db-extract'
+changes what it produces from the same file content (e.g. a bug fix
+that makes more notes recognizable).  On the next database access the
+file change cache is cleared and all files are re-extracted, so users
+pick up the improved parsing without a manual force scan or a full
+schema rebuild.  Unlike `vulpea-db-version', the database and its
+notes are preserved.")
 
 (defconst vulpea-db--schema
   '(;; Materialized view table (denormalized for fast retrieval)
@@ -210,6 +227,10 @@ Checked by `vulpea-db-sync--start' to trigger automatic re-index.")
   "Non-nil if tag inheritance settings changed since last init.
 Checked by `vulpea-db-sync--start' to trigger automatic re-index.")
 
+(defvar vulpea-db--parser-changed nil
+  "Non-nil if the parser epoch changed since last init.
+Checked by `vulpea-db-sync--start' to trigger automatic re-index.")
+
 ;;; Core API
 
 (defun vulpea-db ()
@@ -273,6 +294,22 @@ settings change between sessions so the DB can be re-indexed."
              (not (equal stored (vulpea-db--tag-settings-fingerprint)))))
     (error nil)))
 
+(defun vulpea-db--parser-epoch-changed-p (db)
+  "Return non-nil if the epoch stored in DB differs from the current one.
+
+When no epoch is recorded, the result depends on whether DB already
+has cached files: an existing database (non-empty `files' table) is
+treated as stale so upgrading to an epoch-aware vulpea re-extracts it
+once, while a brand-new database (empty `files' table) is left alone."
+  (condition-case nil
+      (let ((stored (caar (emacsql db
+                                   [:select [version] :from schema-registry
+                                    :where (= name "parser-epoch")]))))
+        (if stored
+            (not (equal stored vulpea-db-parser-epoch))
+          (< 0 (caar (emacsql db [:select (funcall count *) :from files])))))
+    (error nil)))
+
 (defun vulpea-db--init ()
   "Initialize database connection and schema."
   ;; Ensure the parent directory exists, otherwise emacsql fails with an
@@ -303,10 +340,20 @@ settings change between sessions so the DB can be re-indexed."
       (setq vulpea-db--settings-changed t)
       (message "Vulpea: Tag inheritance settings changed, re-index needed..."))
 
-    ;; Register schema version and tag settings fingerprint
+    ;; Check if the parser epoch changed (extraction logic updated, or
+    ;; an existing pre-epoch database).  Clearing the files cache forces
+    ;; every file to be re-extracted, healing notes that an older parser
+    ;; failed to recognize. See vulpea#277.
+    (when (vulpea-db--parser-epoch-changed-p db)
+      (emacsql db [:delete :from files])
+      (setq vulpea-db--parser-changed t)
+      (message "Vulpea: Parser updated, re-index needed..."))
+
+    ;; Register schema version, tag settings fingerprint and parser epoch
     (vulpea-db--register-schema db 'core vulpea-db-version)
     (vulpea-db--register-schema db 'tag-inheritance
                                 (vulpea-db--tag-settings-fingerprint))
+    (vulpea-db--register-schema db 'parser-epoch vulpea-db-parser-epoch)
 
     db))
 


### PR DESCRIPTION
## What

Adds a **parser epoch** to invalidate the file change-detection cache when vulpea's extraction logic changes, mirroring the existing tag-settings fingerprint mechanism (#251).

- New `vulpea-db-parser-epoch` constant. Maintainers bump it whenever the extractor in `vulpea-db-extract` changes what it produces from the same file content.
- On database access, if the stored epoch differs from the current one, the `files` cache is cleared and a re-index is flagged (`vulpea-db--parser-changed`), so the next scan re-extracts every file. The notes table is preserved — no full rebuild.
- Existing databases predating the mechanism (no stored epoch) are treated as stale **only when they already hold cached files**, so upgrading heals them on first open; a brand-new database is left alone to avoid a redundant scan.

## Why

The `files` cache records a file's mtime/size/hash even when the file yields **no note** (`vulpea-db-update-file` writes the hash row unconditionally). Every routine scan path — the async startup queue and a plain `vulpea-db-sync-full-scan` — then skips that file because its content is unchanged. So a file that was once indexed while producing no note (a partially-synced cloud file, or an **older vulpea version that failed to extract its `ID`**) stays permanently invisible until the file is edited or a *force* scan is run. The cache was previously invalidated only on schema-version (#243) or tag-settings (#251) changes — never on a parser change.

This is the most likely mechanism behind #277: notes were missing despite a normal sync, and editing a file (which changed its content and forced a re-parse) made them reappear — the edit, not the drawer capitalization, was what mattered.

## Related

- #277
