### PR TITLE
fix: match alias property name case-insensitively

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -19,6 +19,7 @@
 *Fixes*
 
 - [[https://github.com/d12frosted/vulpea/issues/277][vulpea#277]] Invalidate the file change-detection cache when the note extractor changes, via a new parser epoch (=vulpea-db-parser-epoch=). Previously a file that was once indexed while producing no note (e.g. a partially-synced cloud file, or an older Vulpea version that failed to extract its =ID=) had that "no note" result cached, so later scans kept skipping it and the note stayed invisible until the file was edited or a force scan was run. Bumping the parser epoch now clears the cache and re-extracts every file once, without discarding the database. Existing databases predating this mechanism are treated as stale and re-extracted on first open, so the fix applies retroactively on upgrade.
+- [[https://github.com/d12frosted/vulpea/issues/277][vulpea#277]] Upcase =vulpea-buffer-alias-property= before looking it up during extraction. Property keys are stored upcased, so a lowercase or mixed-case alias property name (e.g. =(setq vulpea-buffer-alias-property "roam_aliases")=) previously caused aliases to be silently dropped. The default =ALIASES= and the common =ROAM_ALIASES= were unaffected.
 
 ** v2.3.0
 

--- a/test/vulpea-db-extract-test.el
+++ b/test/vulpea-db-extract-test.el
@@ -309,6 +309,24 @@ handled correctly when mixed together."
           (should (member "Blauburgunder" aliases)))
       (delete-file path))))
 
+(ert-deftest vulpea-db-extract-aliases-lowercase-property-name ()
+  "Test alias extraction when `vulpea-buffer-alias-property' is lowercase.
+
+Property keys are upcased during extraction, so the lookup must
+upcase the configured property name too, otherwise aliases silently
+fail to extract. Regression test for
+https://github.com/d12frosted/vulpea/issues/277."
+  (let ((vulpea-buffer-alias-property "roam_aliases")
+        (path (vulpea-test--create-temp-org-file
+               (format ":PROPERTIES:\n:ID: %s\n:ROAM_ALIASES: Alias1 Alias2\n:END:\n#+TITLE: Main Title\n" (org-id-new)))))
+    (unwind-protect
+        (let* ((ctx (vulpea-db--parse-file path))
+               (node (vulpea-parse-ctx-file-node ctx))
+               (aliases (plist-get node :aliases)))
+          (should (member "Alias1" aliases))
+          (should (member "Alias2" aliases)))
+      (delete-file path))))
+
 (ert-deftest vulpea-db-extract-heading-aliases ()
   "Test alias extraction on heading-level notes."
   (let ((path (vulpea-test--create-temp-org-file

--- a/vulpea-db-extract.el
+++ b/vulpea-db-extract.el
@@ -663,8 +663,13 @@ Respects `vulpea-db-index-heading-level' setting:
 
 Looks for property defined by `vulpea-buffer-alias-property'.
 Handles both quoted aliases (with spaces) and unquoted aliases properly.
-Strips org links and emphasis markers from each alias."
-  (when-let* ((aliases-str (cdr (assoc vulpea-buffer-alias-property properties))))
+Strips org links and emphasis markers from each alias.
+
+The property name is upcased before lookup because PROPERTIES keys
+are stored upcased, so a lowercase or mixed-case
+`vulpea-buffer-alias-property' still matches."
+  (when-let* ((aliases-str (cdr (assoc (upcase vulpea-buffer-alias-property)
+                                       properties))))
     (setq aliases-str (string-trim aliases-str))
     (let ((result nil)
           (pos 0))


### PR DESCRIPTION
## What

Upcases `vulpea-buffer-alias-property` before looking it up in the extracted properties alist (`vulpea-db--extract-aliases`).

## Why

Property keys are stored upcased during extraction (`(upcase ...)`), but the alias lookup compared against the raw value of `vulpea-buffer-alias-property` with a case-sensitive `assoc`. The default `"ALIASES"` and the common org-roam `"ROAM_ALIASES"` are already uppercase, so they worked — but a user who set the variable to a lowercase or mixed-case name (e.g. `"roam_aliases"`) would get their aliases silently dropped, with no error. Found while investigating #277.

## Related

- #277
