### PR TITLE
feat: add vulpea-buffer-meta-change-functions hook

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -7,6 +7,12 @@
 :ID:                     e3f3602c-426e-451e-bcb5-b59b99e3b10e
 :END:
 
+** Unreleased
+
+*Features*
+
+- Add =vulpea-buffer-meta-change-functions=, an abnormal hook run whenever buffer metadata changes through =vulpea-buffer-meta-set=, =vulpea-buffer-meta-set-batch=, =vulpea-buffer-meta-remove= or =vulpea-buffer-meta-clean=. Each handler is called with =PROP=, =OLD= and =NEW=, where =OLD= and =NEW= are the property's lists of string values before and after the change (adding a property yields an empty =OLD=; removing one yields an empty =NEW=). It fires once per affected property and only for real changes, and it reports the outermost operation only - the nested removal that =vulpea-buffer-meta-set= performs and the clean/set churn of =vulpea-buffer-meta-sort= are coalesced, and a pure reorder fires nothing. =OLD= and =NEW= are computed only while the hook is non-nil, so an empty hook adds no overhead, and handlers run with re-entrant notification inhibited. This is the supported way to observe metadata mutations without advising the buffer API.
+
 ** v2.4.0
 
 *Features*

--- a/docs/api-reference.org
+++ b/docs/api-reference.org
@@ -519,6 +519,20 @@ These operate on the current buffer (must be an org file).
 
 When setting multiple metadata properties, prefer =vulpea-meta-set-batch= over multiple =vulpea-meta-set= calls - it's significantly faster (up to 10x for 20 properties) since it only parses the file once.
 
+To observe metadata mutations without advising the buffer API, add a function to the abnormal hook =vulpea-buffer-meta-change-functions=. It runs whenever metadata changes through =vulpea-buffer-meta-set=, =vulpea-buffer-meta-set-batch=, =vulpea-buffer-meta-remove= or =vulpea-buffer-meta-clean=:
+
+#+begin_src emacs-lisp
+;; Log every metadata change during a batch operation
+(defun my/log-meta-change (prop old new)
+  ;; OLD and NEW are lists of string values; adding a property gives
+  ;; an empty OLD, removing one gives an empty NEW.
+  (message "%s: %S -> %S" prop old new))
+
+(add-hook 'vulpea-buffer-meta-change-functions #'my/log-meta-change)
+#+end_src
+
+Each handler is called with =PROP=, =OLD= and =NEW=. The hook fires once per affected property and only for real changes; it reports the outermost operation only, so the nested removal performed by =vulpea-buffer-meta-set= and the clean/set churn of =vulpea-buffer-meta-sort= do not produce extra events (a pure reorder fires nothing). =OLD= and =NEW= are computed only while the hook is non-nil, so an empty hook adds no overhead.
+
 ** Heading-Level Metadata
 
 Both file-level and heading-level notes can have their own metadata. The metadata API automatically scopes operations to the correct level based on the note's =level= attribute.
@@ -750,6 +764,61 @@ When you need to query updated data right away:
 (vulpea-note-meta-get (vulpea-db-get-by-id id) "status")
 ;; => "done"
 #+end_src
+
+** Tracking What Changed
+
+When a script rewrites metadata across many notes - say a periodic job
+that refreshes wine prices from shop data - you often want an audit
+trail of exactly what moved. =vulpea-buffer-meta-change-functions=
+makes this a few lines: collect the changes during the run, then print
+them. Because the hook reports the property's =OLD= and =NEW= values,
+no diffing of your own is needed.
+
+#+begin_src emacs-lisp
+;; A tiny change log built on the metadata-change hook.
+(defvar my/meta-changes nil
+  "Hash of note id -> list of (PROP OLD NEW).")
+
+(defun my/meta-record (prop old new)
+  "Collect a change of PROP from OLD to NEW under the note at point."
+  (when-let* ((id (save-excursion (goto-char (point-min)) (org-id-get))))
+    (push (list prop old new) (gethash id my/meta-changes))))
+
+(defun my/meta-log-start ()
+  (setq my/meta-changes (make-hash-table :test 'equal))
+  (add-hook 'vulpea-buffer-meta-change-functions #'my/meta-record))
+
+(defun my/meta-log-stop ()
+  (remove-hook 'vulpea-buffer-meta-change-functions #'my/meta-record))
+
+(defun my/meta-log-report ()
+  (maphash
+   (lambda (id changes)
+     (message "* %s" (vulpea-note-title (vulpea-db-get-by-id id)))
+     (dolist (it (reverse changes))
+       (message "  %s: %S -> %S" (nth 0 it) (nth 1 it) (nth 2 it))))
+   my/meta-changes))
+#+end_src
+
+Wrap the batch update between =start= and =stop=, then report:
+
+#+begin_src emacs-lisp
+(my/meta-log-start)
+(unwind-protect
+    (dolist (note (vulpea-db-query-by-tags-every '("wine" "cellar")))
+      (when-let* ((price (my/shop-price-for note)))   ; your data source
+        (vulpea-utils-with-note note
+          (vulpea-buffer-meta-set "price" price)
+          (save-buffer))))
+  (my/meta-log-stop))
+
+(my/meta-log-report)
+;; * Château Test 2019
+;;   price: ("18.50") -> ("21.00")
+#+end_src
+
+Only notes whose =price= actually changed appear: a no-op
+=vulpea-buffer-meta-set= (same value) fires nothing.
 
 * Selection Interface
 

--- a/test/vulpea-buffer-test.el
+++ b/test/vulpea-buffer-test.el
@@ -1293,5 +1293,164 @@ gives a descriptive error."
    (should (equal (vulpea-buffer-tags-get)
                   '("tag1" "tag2" "tag3" "tag4")))))
 
+;;; vulpea-buffer-meta-change-functions Tests
+
+(ert-deftest vulpea-buffer-meta-change-set-new-prop ()
+  "Setting a brand new prop fires the hook with empty OLD."
+  (vulpea-buffer-test--with-temp-buffer
+   "#+title: T
+
+- a :: 1
+"
+   (let* ((events nil)
+          (vulpea-buffer-meta-change-functions
+           (list (lambda (prop old new) (push (list prop old new) events)))))
+     (vulpea-buffer-meta-set "b" "2")
+     (should (equal (nreverse events)
+                    '(("b" nil ("2"))))))))
+
+(ert-deftest vulpea-buffer-meta-change-set-existing-prop ()
+  "Changing an existing prop fires the hook with OLD and NEW."
+  (vulpea-buffer-test--with-temp-buffer
+   "#+title: T
+
+- a :: 1
+"
+   (let* ((events nil)
+          (vulpea-buffer-meta-change-functions
+           (list (lambda (prop old new) (push (list prop old new) events)))))
+     (vulpea-buffer-meta-set "a" "2")
+     (should (equal (nreverse events)
+                    '(("a" ("1") ("2"))))))))
+
+(ert-deftest vulpea-buffer-meta-change-set-multi-value ()
+  "Setting a list value reports OLD and NEW as lists of strings."
+  (vulpea-buffer-test--with-temp-buffer
+   "#+title: T
+
+- a :: 1
+"
+   (let* ((events nil)
+          (vulpea-buffer-meta-change-functions
+           (list (lambda (prop old new) (push (list prop old new) events)))))
+     (vulpea-buffer-meta-set "a" '("x" "y"))
+     (should (equal (nreverse events)
+                    '(("a" ("1") ("x" "y"))))))))
+
+(ert-deftest vulpea-buffer-meta-change-set-no-op-silent ()
+  "Setting a prop to its current value fires nothing."
+  (vulpea-buffer-test--with-temp-buffer
+   "#+title: T
+
+- a :: 1
+"
+   (let* ((events nil)
+          (vulpea-buffer-meta-change-functions
+           (list (lambda (prop old new) (push (list prop old new) events)))))
+     (vulpea-buffer-meta-set "a" "1")
+     (should (null events)))))
+
+(ert-deftest vulpea-buffer-meta-change-set-existing-fires-once ()
+  "Changing an existing prop fires exactly once.
+
+`vulpea-buffer-meta-set' removes the prop internally before
+re-inserting it; that nested removal must not produce a second
+event."
+  (vulpea-buffer-test--with-temp-buffer
+   "#+title: T
+
+- a :: 1
+"
+   (let* ((events nil)
+          (vulpea-buffer-meta-change-functions
+           (list (lambda (prop old new) (push (list prop old new) events)))))
+     (vulpea-buffer-meta-set "a" "2")
+     (should (= (length events) 1)))))
+
+(ert-deftest vulpea-buffer-meta-change-remove ()
+  "Removing a prop fires the hook with empty NEW."
+  (vulpea-buffer-test--with-temp-buffer
+   "#+title: T
+
+- a :: x
+- a :: y
+"
+   (let* ((events nil)
+          (vulpea-buffer-meta-change-functions
+           (list (lambda (prop old new) (push (list prop old new) events)))))
+     (vulpea-buffer-meta-remove "a")
+     (should (equal (nreverse events)
+                    '(("a" ("x" "y") nil)))))))
+
+(ert-deftest vulpea-buffer-meta-change-clean ()
+  "Cleaning fires one event per existing prop, in document order."
+  (vulpea-buffer-test--with-temp-buffer
+   "#+title: T
+
+- a :: 1
+- b :: 2
+"
+   (let* ((events nil)
+          (vulpea-buffer-meta-change-functions
+           (list (lambda (prop old new) (push (list prop old new) events)))))
+     (vulpea-buffer-meta-clean)
+     (should (equal (nreverse events)
+                    '(("a" ("1") nil)
+                      ("b" ("2") nil)))))))
+
+(ert-deftest vulpea-buffer-meta-change-sort-silent ()
+  "Sorting reorders props without firing any change event."
+  (vulpea-buffer-test--with-temp-buffer
+   "#+title: T
+
+- a :: 1
+- b :: 2
+"
+   (let* ((events nil)
+          (vulpea-buffer-meta-change-functions
+           (list (lambda (prop old new) (push (list prop old new) events)))))
+     (vulpea-buffer-meta-sort '("b" "a"))
+     (should (null events)))))
+
+(ert-deftest vulpea-buffer-meta-change-batch ()
+  "Batch set fires one event per changed prop."
+  (vulpea-buffer-test--with-temp-buffer
+   "#+title: T
+
+- a :: 1
+"
+   (let* ((events nil)
+          (vulpea-buffer-meta-change-functions
+           (list (lambda (prop old new) (push (list prop old new) events)))))
+     (vulpea-buffer-meta-set-batch '(("a" . "2") ("c" . "new")))
+     (should (equal (nreverse events)
+                    '(("a" ("1") ("2"))
+                      ("c" nil ("new"))))))))
+
+(ert-deftest vulpea-buffer-meta-change-no-hook-no-error ()
+  "Mutations work normally when no hook function is registered."
+  (vulpea-buffer-test--with-temp-buffer
+   "#+title: T
+
+- a :: 1
+"
+   (let ((vulpea-buffer-meta-change-functions nil))
+     (vulpea-buffer-meta-set "a" "2")
+     (should (equal (vulpea-buffer-meta-get "a" 'string) "2")))))
+
+(ert-deftest vulpea-buffer-meta-change-inhibit ()
+  "Binding the inhibit flag suppresses events."
+  (vulpea-buffer-test--with-temp-buffer
+   "#+title: T
+
+- a :: 1
+"
+   (let* ((events nil)
+          (vulpea-buffer-meta-change-functions
+           (list (lambda (prop old new) (push (list prop old new) events)))))
+     (let ((vulpea-buffer-meta--inhibit-change t))
+       (vulpea-buffer-meta-set "a" "2"))
+     (should (null events)))))
+
 (provide 'vulpea-buffer-test)
 ;;; vulpea-buffer-test.el ends here

--- a/vulpea-buffer.el
+++ b/vulpea-buffer.el
@@ -67,6 +67,29 @@ You can change this to any property name you prefer, such as
   :type 'string
   :group 'vulpea)
 
+(defcustom vulpea-buffer-meta-change-functions nil
+  "Abnormal hook run when buffer metadata changes.
+
+Each function is called with three arguments: PROP, OLD and NEW.
+PROP is the affected metadata property name (a string).  OLD and
+NEW are the lists of its string values before and after the
+change.  Adding a property yields an empty OLD; removing one
+yields an empty NEW.
+
+The hook fires once per affected property, in the buffer that was
+modified, and only for actual changes (when OLD and NEW differ).
+It reports the outermost public operation only: the nested
+mutations performed by `vulpea-buffer-meta-set' and
+`vulpea-buffer-meta-sort' do not produce extra events, and a
+reorder via `vulpea-buffer-meta-sort' produces none at all.
+
+OLD and NEW are computed only while this hook is non-nil, so an
+empty hook adds no overhead.  Handlers run with re-entrant
+notification inhibited, so a handler that itself mutates metadata
+does not trigger the hook recursively."
+  :type 'hook
+  :group 'vulpea)
+
 (defun vulpea-buffer-title-get ()
   "Get TITLE in current buffer."
   (vulpea-buffer-prop-get "title"))
@@ -334,6 +357,27 @@ If nil it defaults to `split-string-default-separators', normally
 
 
 
+(defvar vulpea-buffer-meta--inhibit-change nil
+  "When non-nil, suppress `vulpea-buffer-meta-change-functions'.
+
+Bound to t while a higher-level metadata operation performs nested
+mutations, so the change hook fires once for the outermost call.")
+
+(defun vulpea-buffer-meta--notify-p ()
+  "Return non-nil when a metadata change should be reported."
+  (and vulpea-buffer-meta-change-functions
+       (not vulpea-buffer-meta--inhibit-change)))
+
+(defun vulpea-buffer-meta--notify (prop old new)
+  "Report a metadata change of PROP from OLD to NEW.
+
+OLD and NEW are lists of string values.  Does nothing when they
+are equal.  Re-entrant notification is inhibited while the hook
+runs."
+  (unless (equal old new)
+    (let ((vulpea-buffer-meta--inhibit-change t))
+      (run-hook-with-args 'vulpea-buffer-meta-change-functions prop old new))))
+
 (defun vulpea-buffer-meta (&optional bound)
   "Get metadata from the current buffer.
 
@@ -567,7 +611,10 @@ which case VALUE is added at the end of the meta.
 BOUND controls the scope - see `vulpea-buffer-meta' for details.
 When BOUND is \\='heading or a position, operates within that
 heading's subtree."
-  (let* ((values (if (listp value) value (list value)))
+  (let* ((notify (vulpea-buffer-meta--notify-p))
+         (old (and notify (vulpea-buffer-meta-get-list prop 'string bound)))
+         (vulpea-buffer-meta--inhibit-change t)
+         (values (if (listp value) value (list value)))
          (meta (vulpea-buffer-meta--get (vulpea-buffer-meta bound) prop))
          (buffer (plist-get meta :buffer))
          (pl (plist-get meta :pl))
@@ -630,7 +677,10 @@ heading's subtree."
            (insert "- " prop " :: "
                    (vulpea-buffer-meta-format val)
                    "\n"))
-         values))))))
+         values))))
+    (when notify
+      (vulpea-buffer-meta--notify
+       prop old (vulpea-buffer-meta-get-list prop 'string bound)))))
 
 (defun vulpea-buffer-meta--insertion-point (buffer bound)
   "Find the insertion point for new metadata.
@@ -693,7 +743,15 @@ Example:
       (\"priority\" . 1)
       (\"tags\" . (\"a\" \"b\" \"c\"))))"
   (when props-alist
-    (let* ((meta (vulpea-buffer-meta bound))
+    (let* ((notify (vulpea-buffer-meta--notify-p))
+           (olds (and notify
+                      (let ((m (vulpea-buffer-meta bound)))
+                        (mapcar
+                         (lambda (pair)
+                           (cons (car pair)
+                                 (vulpea-buffer-meta-get-list! m (car pair) 'string)))
+                         props-alist))))
+           (meta (vulpea-buffer-meta bound))
            (buffer (plist-get meta :buffer))
            (pl (plist-get meta :pl))
            (items-all (when pl (org-element-map pl 'item #'identity)))
@@ -767,12 +825,21 @@ Example:
               (dolist (val values)
                 (insert "- " prop " :: "
                         (vulpea-buffer-meta-format val)
-                        "\n"))))))))))
+                        "\n")))))))
+      (when notify
+        (let ((m (vulpea-buffer-meta bound)))
+          (dolist (pair props-alist)
+            (vulpea-buffer-meta--notify
+             (car pair)
+             (cdr (assoc (car pair) olds))
+             (vulpea-buffer-meta-get-list! m (car pair) 'string))))))))
 
 (defun vulpea-buffer-meta-remove (prop &optional bound)
   "Delete values of PROP from current buffer.
 BOUND controls the scope - see `vulpea-buffer-meta' for details."
-  (let* ((meta (vulpea-buffer-meta--get (vulpea-buffer-meta bound) prop))
+  (let* ((notify (vulpea-buffer-meta--notify-p))
+         (old (and notify (vulpea-buffer-meta-get-list prop 'string bound)))
+         (meta (vulpea-buffer-meta--get (vulpea-buffer-meta bound) prop))
          (items (plist-get meta :items))
          (pl (plist-get meta :pl)))
     (when (car items)
@@ -785,16 +852,28 @@ BOUND controls the scope - see `vulpea-buffer-meta' for details."
            (when-let* ((begin (org-element-property :begin item))
                        (end (org-element-property :end item)))
              (delete-region begin end)))
-         (seq-reverse items))))))
+         (seq-reverse items))))
+    (when notify
+      (vulpea-buffer-meta--notify prop old nil))))
 
 (defun vulpea-buffer-meta-clean (&optional bound)
   "Delete all meta from current buffer.
 BOUND controls the scope - see `vulpea-buffer-meta' for details."
-  (when-let* ((meta (vulpea-buffer-meta bound))
-              (pl (plist-get meta :pl)))
-    (delete-region
-     (org-element-property :begin pl)
-     (org-element-property :end pl))))
+  (let* ((notify (vulpea-buffer-meta--notify-p))
+         (snapshot
+          (and notify
+               (let ((meta (vulpea-buffer-meta bound)))
+                 (mapcar (lambda (p)
+                           (cons p (vulpea-buffer-meta-get-list! meta p 'string)))
+                         (vulpea-buffer-meta-props meta))))))
+    (when-let* ((meta (vulpea-buffer-meta bound))
+                (pl (plist-get meta :pl)))
+      (delete-region
+       (org-element-property :begin pl)
+       (org-element-property :end pl)))
+    (when notify
+      (dolist (it snapshot)
+        (vulpea-buffer-meta--notify (car it) (cdr it) nil)))))
 
 (defun vulpea-buffer-meta-format (value)
   "Format a VALUE depending on it's type."
@@ -823,7 +902,8 @@ BOUND controls the scope - see `vulpea-buffer-meta' for details."
 
 Whatever is not part of PROPS is left in the same order but appended to
 the end after PROPS."
-  (let* ((meta (vulpea-buffer-meta))
+  (let* ((vulpea-buffer-meta--inhibit-change t)
+         (meta (vulpea-buffer-meta))
          (props-all (->> (org-element-map (plist-get meta :pl) 'item #'identity)
                          (--map (substring-no-properties
                                  (org-element-interpret-data


### PR DESCRIPTION
## What

Adds `vulpea-buffer-meta-change-functions`, an abnormal hook run whenever buffer metadata changes through `vulpea-buffer-meta-set`, `vulpea-buffer-meta-set-batch`, `vulpea-buffer-meta-remove` or `vulpea-buffer-meta-clean` (and therefore through the file-level `vulpea-meta-*` API, which delegates to these).

Handlers are called with `PROP`, `OLD` and `NEW`, where `OLD` and `NEW` are the property's lists of string values before and after the change. Adding a property yields an empty `OLD`; removing one yields an empty `NEW`.

Semantics:
- Fires **once per affected property**, and **only for real changes** (`OLD` and `NEW` differ).
- Reports the **outermost operation only**. A `vulpea-buffer-meta--inhibit-change` guard coalesces nested mutations, so the removal `meta-set` performs internally and the clean/set churn of `meta-sort` produce no extra events; a pure reorder fires nothing.
- `OLD`/`NEW` are computed **only while the hook is non-nil**, so an empty hook adds no overhead.

Includes the hook in the API reference's Metadata section and a worked "track what changed" recipe under *Modifying Notes Programmatically*.

## Why

Today the only way to observe metadata mutations is to advise the buffer API. That couples observers to vulpea's *internal* call signatures — and they drift: when `bound` was added in `dc172f6` (heading-level metadata), `meta-set` began calling `(meta-remove prop bound)` internally, silently breaking any advice wrapper with the old arity. A first-class hook decouples observers from internals and removes that class of breakage.

A natural consumer is a periodic enrichment job (e.g. rewriting note metadata from an external source) that wants an audit trail of what changed — which is the recipe added to the docs.