### PR TITLE
docs: fix selection-display backlink-count example

### DIFF
--- a/docs/api-reference.org
+++ b/docs/api-reference.org
@@ -946,13 +946,24 @@ Both functions take a =vulpea-note= and return a string, so you can assemble any
        (propertize (truncate-string-to-width tags 30 nil ?\s) 'face 'org-tag) " "
        (format "%6d" backlinks)))))
 
-;; Build the counts table once (single query), then set the hooks
-(let ((counts (vulpea-db-query-backlink-counts "id")))
-  (setq vulpea-select-describe-fn (my-vulpea-describe counts)
-        vulpea-select-annotate-fn (lambda (_note) "")))
+;; Wrap the finder so the counts are rebuilt fresh on each call, then
+;; dynamically bind the hooks for the duration of that call.
+(defun my-vulpea-find ()
+  (interactive)
+  (let* (;; "id" counts only id: links (the real backlinks); it is
+         ;; effectively optional, since only id: links have a note ID as
+         ;; their destination. Omit it to count every link type.
+         (counts (vulpea-db-query-backlink-counts "id"))
+         (vulpea-select-describe-fn (my-vulpea-describe counts))
+         (vulpea-select-annotate-fn (lambda (_note) "")))
+    (vulpea-find)))
 #+end_src
 
-=vulpea-db-query-backlink-counts= computes every count in one query (see [[*Link Queries][Link Queries]]); building it once and closing over it avoids a per-candidate query. To order candidates by recency rather than display them differently, sort the note list (e.g. by =vulpea-note-modified-at= or =vulpea-note-created-at=) before passing it to =vulpea-select-from=, or let a completion framework such as consult sort on a field - the displayed text does not affect candidate order on its own.
+Compute the counts table *once per invocation*, not inside =describe-fn=. =describe-fn= runs once for every candidate, so querying inside it would issue a query per candidate; building =counts= up front and closing over it keeps it to a single query. Binding it at invocation time (rather than once at startup with =setq=) also keeps the numbers fresh - a value cached at startup would not reflect links added later.
+
+Be aware of the cost: even done this way, the work happens when the finder *opens* - one grouped query over the whole =links= table, plus =describe-fn= (the =truncate-string-to-width= / =propertize= calls) running once per candidate. On a large collection this adds a noticeable delay before the finder appears. It is open-time cost, not per-keystroke lag (candidate strings are precomputed), but it grows with the number of notes, so keep =describe-fn= cheap and only pull in extra data like backlink counts when you actually want them on screen.
+
+To order candidates by recency rather than display them differently, sort the note list (e.g. by =vulpea-note-modified-at= or =vulpea-note-created-at=) before passing it to =vulpea-select-from=, or let a completion framework such as consult sort on a field - the displayed text does not affect candidate order on its own.
 
 ** Completion Category
 

--- a/docs/user-guide.org
+++ b/docs/user-guide.org
@@ -49,6 +49,8 @@ For notes that live in headings, two ready-made describe functions prefix the ti
 
 Because the whole =vulpea-note= is available, you can assemble any layout you like - directory, outline path, tags, timestamps, even a backlink count - into a single aligned row. See [[file:api-reference.org::*Customizing Selection Display][Customizing Selection Display]] in the API reference for a worked multi-column example, and note that the displayed text does not by itself change the order of candidates - sort the note list (e.g. by =vulpea-note-modified-at=) or let your completion framework sort if you want a specific order.
 
+Keep these functions cheap. They run once for every candidate when the finder opens, so heavy work - especially an extra database query per candidate - can make selection slow on large collections. If you need DB-derived data such as a backlink count, compute it once per invocation and close over it rather than querying inside the function (the API reference example shows the pattern).
+
 Selection also reports a =vulpea-note= completion category, so completion UIs and their extensions (marginalia, embark, consult) can recognize note candidates and annotate or act on them. See [[file:api-reference.org::*Completion Category][Completion Category]].
 
 * Creating Links


### PR DESCRIPTION
## What

Correct the worked backlink-count example in the selection-display docs (follow-up to #322).

- Replace the `setq`-at-config-time snippet, which computed counts once and cached them, with a `my-vulpea-find` wrapper that rebuilds counts per invocation and dynamically binds the `describe`/`annotate` hooks.
- Explain the `"id"` link-type argument inline (count only `id:` links; effectively optional) instead of leaving it as a bare string.
- Add a performance note: building counts plus running `describe-fn` per candidate is open-time work that grows with collection size, so keep `describe-fn` cheap and never query inside it. Mirror a short version in the user guide.

## Why

The previous example froze the counts at startup (stale once links change) and gave no hint about cost, which is misleading for anyone copying it. Verified the corrected pattern end to end through `vulpea-select-describe`. Documentation only; no behavior change.