### PR TITLE
fix: make database node exclusion property more robust

### DIFF
--- a/vulpea-db-extract.el
+++ b/vulpea-db-extract.el
@@ -449,7 +449,7 @@ Returns plist with:
 
 Returns nil if:
 - File has no ID property in property drawer
-- File has VULPEA_IGNORE property set to non-nil value
+- File has `vulpea-db-exclude-property' set to t
 - File is archived (when `vulpea-db-exclude-archived' is non-nil)"
   (let* ((keywords (org-element-map ast 'keyword
                      (lambda (kw)
@@ -465,7 +465,7 @@ Returns nil if:
                                  (list (cons "CATEGORY" category-kw)))
                        properties))
          (id (cdr (assoc "ID" properties)))
-         (ignored (cdr (assoc "VULPEA_IGNORE" properties)))
+         (ignored (equal "t" (cdr (assoc vulpea-db-exclude-property properties))))
          (filetags (cl-mapcan (lambda (kw)
                                 (when (string= "FILETAGS" (car kw))
                                   (split-string (cdr kw) ":" t)))
@@ -525,7 +525,7 @@ Each plist has same structure as file-node.
 
 Skips headings that:
 - Have no ID property
-- Have VULPEA_IGNORE property set to non-nil value
+- Have `vulpea-db-exclude-property' set to t
 - Are archived (when `vulpea-db-exclude-archived' is non-nil)
 
 Respects `vulpea-db-index-heading-level' setting."
@@ -543,7 +543,7 @@ Respects `vulpea-db-index-heading-level' setting."
         (lambda (headline)
           (when-let* ((id (org-element-property :ID headline)))
             (let* ((properties (vulpea-db--extract-properties ast headline))
-                   (ignored (cdr (assoc "VULPEA_IGNORE" properties)))
+                   (ignored (equal "t" (cdr (assoc vulpea-db-exclude-property properties))))
                    (archived (vulpea-db--archived-p headline properties filetags)))
               ;; Only index if not explicitly ignored and not archived
               (unless (or ignored archived)

--- a/vulpea-db-extract.el
+++ b/vulpea-db-extract.el
@@ -449,7 +449,7 @@ Returns plist with:
 
 Returns nil if:
 - File has no ID property in property drawer
-- File has `vulpea-db-exclude-property' set to t
+- File has `vulpea-db-exclude-property' set to non-nil value.
 - File is archived (when `vulpea-db-exclude-archived' is non-nil)"
   (let* ((keywords (org-element-map ast 'keyword
                      (lambda (kw)
@@ -465,7 +465,7 @@ Returns nil if:
                                  (list (cons "CATEGORY" category-kw)))
                        properties))
          (id (cdr (assoc "ID" properties)))
-         (ignored (equal "t" (cdr (assoc vulpea-db-exclude-property properties))))
+         (ignored (org-not-nil (cdr (assoc vulpea-db-exclude-property properties))))
          (filetags (cl-mapcan (lambda (kw)
                                 (when (string= "FILETAGS" (car kw))
                                   (split-string (cdr kw) ":" t)))
@@ -525,7 +525,7 @@ Each plist has same structure as file-node.
 
 Skips headings that:
 - Have no ID property
-- Have `vulpea-db-exclude-property' set to t
+- Have `vulpea-db-exclude-property' set to non-nil value.
 - Are archived (when `vulpea-db-exclude-archived' is non-nil)
 
 Respects `vulpea-db-index-heading-level' setting."
@@ -543,7 +543,7 @@ Respects `vulpea-db-index-heading-level' setting."
         (lambda (headline)
           (when-let* ((id (org-element-property :ID headline)))
             (let* ((properties (vulpea-db--extract-properties ast headline))
-                   (ignored (equal "t" (cdr (assoc vulpea-db-exclude-property properties))))
+                   (ignored (org-not-nil (cdr (assoc vulpea-db-exclude-property properties))))
                    (archived (vulpea-db--archived-p headline properties filetags)))
               ;; Only index if not explicitly ignored and not archived
               (unless (or ignored archived)

--- a/vulpea-db.el
+++ b/vulpea-db.el
@@ -87,6 +87,18 @@ to be queried. Excluding them keeps the database cleaner and faster."
   :type 'boolean
   :group 'vulpea-db)
 
+(defcustom vulpea-db-exclude-property "VULPEA_IGNORE"
+  "Property name to exclude a node from the database.
+
+Entries are only excluded if they:
+- Have this property and its value is set to t
+- Any value other than t does not exclude the entry.
+
+You can change this to any property name you prefer, such as
+\"ROAM_EXCLUDE\" for org-roam compatibility."
+  :type 'string
+  :group 'vulpea-db)
+
 (defcustom vulpea-db-extra-extensions nil
   "List of extra file extensions to track besides .org files.
 


### PR DESCRIPTION
Enhances the exclusion of nodes from the database using node properties. 

Adds a user customizable option: `vulpea-db-exclude-property` to control the property name that signifies a node should not be included into the database.
- Avoids hard-coded value to increase customizability.
- Adds org-roam compatibility with no cost by enabling the use of the same exclusion property `ROAM_EXCLUDE` if desired with pre-existing notes.

Fixes a bug where the value of the `VULPEA_IGNORE` property had no effect on the node being included in the database. If the property was present with any value or no value, it would always be excluded. Org returns property values as strings even if they appear as booleans or nonexistent in the buffer. Since any non-nil value satisfies conditionals, this returned string caused the node to always be excluded regardless of its content. This is fixed by adding explicit value checks for "t" into the `vulpea-db--extract-*-node` functions.

With these changes, the value of the `vulpea-db-exclude-property` actually dictates if the node is included in the database or not.