### PR TITLE
ci: install Emacs via d12frosted/setup-emacs to avoid GitHub API throttling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
   push:
+    branches:
+      - master
     paths-ignore:
       - "**/*.md"
       - "**/*.org"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       ORG_ROAM_V2_PATH: .org-roam
     steps:
-      - uses: purcell/setup-emacs@master
+      - uses: d12frosted/setup-emacs@v1
         with:
           version: ${{ matrix.emacs_version }}
 


### PR DESCRIPTION
Swaps `purcell/setup-emacs@master` for [`d12frosted/setup-emacs@v1`](https://github.com/d12frosted/setup-emacs) — a thin wrapper that installs the same nix-emacs-ci Emacs but via the codeload tarball + the emacs-ci cache, so it never hits the rate-limited `api.github.com` call that's been 429-ing CI lately.

Only the `uses:` line changes; the `version:` matrix is untouched. (We verified in a sandbox that the 429 is a secondary anti-scraping limit on the shared runner IP, which authentication does *not* bypass — so bypassing the API is the actual fix.)