### PR TITLE
docs: point schema docs at the vulpea-ui widget and dashboard

### DIFF
--- a/docs/api-reference.org
+++ b/docs/api-reference.org
@@ -1375,6 +1375,23 @@ from =vulpea-schema-includes= (the names a schema now retains from its
 The whole scan is one query plus an in-memory pass, so it stays sub-second
 for collections of several thousand notes.
 
+** In vulpea-ui
+
+Everything above is headless; [[https://github.com/d12frosted/vulpea-ui][vulpea-ui]] is where schemas get a UI, so
+in practice you rarely call these functions by hand:
+
+- The sidebar *schema health widget* shows the current note's violations
+  (=vulpea-schema-note-violations=) and offers one-key quick-fixes
+  (=vulpea-schema-fix-violation=).
+- The *schema dashboard* (=M-x vulpea-ui-schema-dashboard=) renders
+  =vulpea-schema-collection-health= across the whole collection: every
+  schema with its covered and invalid counts and its =:include=
+  relationships, expanding each invalid note to its violations to fix or
+  jump to them.
+
+(=vulpea-schema-flymake-mode= above is vulpea's own and needs no UI
+package - it flags the same violations inline as you edit.)
+
 * Quick Reference Tables
 
 ** Core Functions

--- a/docs/comparison.org
+++ b/docs/comparison.org
@@ -272,7 +272,7 @@ Not designed for this use case. Focused on interactive note-taking.
 
 Designed as a foundation with API stability and expressiveness as core values:
 
-- *vulpea-ui* - Per-frame sidebar with a widget framework. Built-in widgets: outline, backlinks with context previews, unlinked mentions, forward links, and stats - plus an API for your own.
+- *vulpea-ui* - Per-frame sidebar with a widget framework, plus standalone views. Built-in widgets: outline, backlinks with context previews, unlinked mentions, forward links, stats, and schema health - plus a collection-wide schema dashboard and an API for your own.
 - *vulpea-journal* - Daily or monthly journaling with a calendar widget, date navigation, a "created today" list, and an "on this day" view of past years - all rendered as vulpea-ui sidebar widgets, no custom window management.
 - *vino* - Wine cellar management with ratings, producers, regions
 


### PR DESCRIPTION
Follow-up to the ecosystem note (#347): that pointed at vulpea-ui from the README, but the actual schema docs in `api-reference.org` are headless-only, so someone reading about `vulpea-schema-note-violations` / `vulpea-schema-collection-health` gets no hint that a UI exists.

Adds a short "In vulpea-ui" subsection at the end of the Schemas section tying the functions to where you actually use them: the sidebar health widget (note-violations + quick-fixes) and the schema dashboard (collection-health). Also refreshed the stale vulpea-ui line in `comparison.org`, which still listed the old widget set with no schema mention.

Docs only.