### PR TITLE
Fix heading-level scoping in schema authoring, batch meta, and title links

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,6 +9,13 @@
 
 ** Unreleased
 
+*Fixes*
+
+- [[https://github.com/d12frosted/vulpea/issues/356][vulpea#356]] Fix =vulpea-schema-insert-fields= inserting fields at the top of the file instead of into the note at point. With point inside a heading it now writes the fields into that heading's subtree (after the property drawer), and only falls back to file-level metadata when point is before the first heading. The synthetic note it builds while authoring is scoped the same way - it reads the note-at-point's title, tags, and existing field values from the heading rather than the file - so the missing-field computation no longer re-prompts for (and duplicate-inserts) a field the heading already carries. Thanks to =@alexjp= for the report.
+- [[https://github.com/d12frosted/vulpea/issues/356][vulpea#356]] Fix the same scope mismatch in =vulpea-schema-fix-violation=. It reads the violating note at point (heading-scoped) but wrote the correction with a file-level scope by default, so applying a one-key fix to a heading-level violation could rewrite an unrelated file-level value and leave the actual violation in place. Its =BOUND= now defaults to \\='heading (matching =vulpea-schema-insert-fields=), so the fix lands in the note it was read from; pass \\='buffer to force file-level scope.
+- Fix =vulpea-meta-batch-set= and =vulpea-meta-batch-remove= writing at file scope for heading-level notes. Both operated on whole-file metadata regardless of the note's level, so setting a field across a batch of heading notes inserted it at the top of each file, and removing a field could delete a same-named /file-level/ value while leaving the heading's in place - even though =vulpea-utils-process-notes= already parks point on the heading. They now scope to the heading's subtree for heading-level notes, matching the single-note =vulpea-meta-set= / =vulpea-meta-remove=. Surfaced by an audit of heading-level behaviour; the batch helpers had only ever been tested against file-level notes.
+- Fix the stored position of a link in a heading's title being off by one when the heading carries a priority cookie (=[#A]=). The extractor counted =[#X]= as four characters and dropped the trailing space, so every such title-link's =:pos= was one short - enough that =vulpea-propagate-title-change= silently skipped those links (it landed on the space before the link and the match failed). TODO keywords were already handled correctly; only the priority branch was off. =vulpea-db-parser-epoch= is bumped so existing databases re-extract and pick up the corrected positions on next access.
+
 ** v2.5.0 (2026-07-02)
 
 *Features*

--- a/docs/api-reference.org
+++ b/docs/api-reference.org
@@ -1262,7 +1262,9 @@ Each violation carries =note-id=, =note-title=, =schema=, =field=,
 
 Where validation checks a note after the fact, authoring helps you write
 a conforming one. =vulpea-schema-insert-fields= is an interactive command
-that inserts the fields of an applicable schema into the current buffer:
+that inserts the fields of an applicable schema into the note at point -
+the heading's subtree when point is inside one, otherwise the file-level
+metadata:
 
 #+begin_src emacs-lisp
 ;; M-x vulpea-schema-insert-fields

--- a/test/vulpea-db-extract-test.el
+++ b/test/vulpea-db-extract-test.el
@@ -1708,6 +1708,37 @@ See https://github.com/d12frosted/vulpea/issues/257."
               (should (member "book-rt" dests))))
         (delete-file path)))))
 
+(ert-deftest vulpea-db-extract-heading-title-link-pos-accounts-for-cookies ()
+  "A title link's stored :pos is exact regardless of TODO/priority cookies.
+
+The heading offset must count the trailing space after both the TODO
+keyword and the priority cookie; a priority cookie is written as \"[#X] \"
+\(five characters).  A stored position that is off by one lands on the
+space before the link and silently breaks `vulpea-propagate-title-change'."
+  (dolist (head '("* Review of [[id:bk][t]]"
+                  "* TODO Review of [[id:bk][t]]"
+                  "* [#A] Review of [[id:bk][t]]"
+                  "* TODO [#A] Review of [[id:bk][t]]"))
+    (vulpea-test--with-temp-db
+      (vulpea-db)
+      (let ((path (vulpea-test--create-temp-org-file
+                   (concat ":PROPERTIES:\n:ID: file-id\n:END:\n#+TITLE: File\n\n"
+                           head "\n:PROPERTIES:\n:ID: h-cookie-pos\n:END:\n"))))
+        (unwind-protect
+            (let ((vulpea-db-index-heading-level t))
+              (vulpea-db-update-file path)
+              (let* ((link (car (vulpea-db-query-links-to "bk")))
+                     (db-pos (plist-get link :pos))
+                     (actual (with-temp-buffer
+                               (insert-file-contents path)
+                               (goto-char (point-min))
+                               (search-forward "[[id:bk")
+                               (match-beginning 0))))
+                (should link)
+                ;; the stored position must land exactly on the link
+                (should (= db-pos actual))))
+          (delete-file path))))))
+
 ;;; Case-insensitive Property Key Tests
 
 (ert-deftest vulpea-db-extract-file-node-lowercase-id ()

--- a/test/vulpea-db-schema-validation-test.el
+++ b/test/vulpea-db-schema-validation-test.el
@@ -136,5 +136,17 @@
       "#+title: Good Wine\n#+filetags: :wine:\n\n- name :: Chablis\n"
     (should (vulpea-db-get-by-id "33333333-3333-3333-3333-333333333333"))))
 
+(ert-deftest vulpea-db-schema-validation-error-skips-invalid-heading-keeps-file ()
+  "With `error', an invalid heading note is vetoed while the valid file note is kept."
+  (vulpea-dbsv-test--with-file 'error
+      "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+      (concat "#+title: Journal\n\n"
+              "* Bad Wine :wine:\n:PROPERTIES:"
+              "\n:ID: bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb\n:END:\n")
+    ;; the file-level note carries no wine tag, so no schema applies - it is kept
+    (should (vulpea-db-get-by-id "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
+    ;; the heading note is a wine without a name - validated per note and vetoed
+    (should-not (vulpea-db-get-by-id "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))))
+
 (provide 'vulpea-db-schema-validation-test)
 ;;; vulpea-db-schema-validation-test.el ends here

--- a/test/vulpea-meta-test.el
+++ b/test/vulpea-meta-test.el
@@ -1116,5 +1116,36 @@ This tests the fix for issue #200."
    (let ((count (vulpea-meta-batch-remove nil "status")))
      (should (= count 0)))))
 
+(ert-deftest vulpea-meta-batch-set-scopes-to-heading ()
+  "Batch set on a heading-level note writes to the heading, not file level.
+
+Regression guard for a scope bug: `vulpea-meta-batch-set' operated at
+whole-file scope regardless of the note's level, so setting a field on a
+heading note landed at file level (and could overwrite a same-named
+file-level value)."
+  (vulpea-meta-test--with-temp-db
+   ;; Section One is a heading-level note; the file-level note carries
+   ;; `file-prop :: file value'.  `file-prop' does not exist on the heading.
+   (let ((note (vulpea-db-get-by-id "11111111-1111-1111-1111-111111111111")))
+     (vulpea-meta-batch-set (list note) "file-prop" "heading batch value"))
+   ;; the heading gets its own value ...
+   (should (equal (vulpea-meta-get "11111111-1111-1111-1111-111111111111" "file-prop" 'string)
+                  "heading batch value"))
+   ;; ... and the file-level value is untouched
+   (should (equal (vulpea-meta-get "a1b2c3d4-e5f6-7890-abcd-ef1234567890" "file-prop" 'string)
+                  "file value"))))
+
+(ert-deftest vulpea-meta-batch-remove-scopes-to-heading ()
+  "Batch remove on a heading-level note does not delete a same-named file key.
+
+Section One has no `file-prop'; the file-level note does.  Removing
+`file-prop' from the heading must be a no-op - not a deletion of the
+file's value, which is what whole-file scope produced."
+  (vulpea-meta-test--with-temp-db
+   (let ((note (vulpea-db-get-by-id "11111111-1111-1111-1111-111111111111")))
+     (vulpea-meta-batch-remove (list note) "file-prop"))
+   (should (equal (vulpea-meta-get "a1b2c3d4-e5f6-7890-abcd-ef1234567890" "file-prop" 'string)
+                  "file value"))))
+
 (provide 'vulpea-meta-test)
 ;;; vulpea-meta-test.el ends here

--- a/test/vulpea-schema-flymake-test.el
+++ b/test/vulpea-schema-flymake-test.el
@@ -94,6 +94,27 @@
       (let ((cd (cl-find-if (lambda (d) (string-match-p "colour" (nth 3 d))) ds)))
         (should (vulpea-flymake-test--on-line-p (nth 0 cd) "- colour"))))))
 
+(ert-deftest vulpea-schema-flymake-scopes-diagnostics-per-heading ()
+  "Two heading notes get their own diagnostics, each on its own line (#356)."
+  (vulpea-flymake-test--with
+      (concat ":PROPERTIES:\n:ID: file1\n:END:\n#+title: File\n\n"
+              "* First :wine:\n:PROPERTIES:\n:ID: h1\n:END:\n- name :: A\n- colour :: blue\n\n"
+              "* Second :wine:\n:PROPERTIES:\n:ID: h2\n:END:\n- colour :: green\n")
+    (vulpea-flymake-test--wine)
+    (let* ((ds (vulpea-schema-flymake--collect)))
+      ;; First: colour blue disallowed (1). Second: name missing + colour green
+      ;; disallowed (2). Three diagnostics in total, none from the file note.
+      (should (= (length ds) 3))
+      ;; both colour diagnostics sit on their own heading's colour line
+      (let ((colour-ds (cl-remove-if-not
+                        (lambda (d) (string-match-p "colour" (nth 3 d))) ds)))
+        (should (= (length colour-ds) 2))
+        (should (cl-every (lambda (d) (vulpea-flymake-test--on-line-p (nth 0 d) "- colour"))
+                          colour-ds)))
+      ;; the missing-required name is anchored to the Second heading line
+      (let ((name-d (cl-find-if (lambda (d) (string-match-p "name" (nth 3 d))) ds)))
+        (should (vulpea-flymake-test--on-line-p (nth 0 name-d) "* Second"))))))
+
 (ert-deftest vulpea-schema-flymake-backend-reports-diagnostics ()
   "The backend hands flymake real diagnostic objects."
   (vulpea-flymake-test--with

--- a/test/vulpea-test.el
+++ b/test/vulpea-test.el
@@ -2199,6 +2199,119 @@ the whole match."
       (should-not (vulpea--schema-prompt-fields
                    '((:key "tags" :one-of (a b) :multiple t)) note)))))
 
+;;; Schema authoring into headings (#356)
+
+(ert-deftest vulpea-schema-insert-fields-into-heading-at-point ()
+  "Fields land under the heading at point, not at the top of the file (#356)."
+  (let ((vulpea-schema--registry (make-hash-table :test 'eq)))
+    (vulpea-schema-define 'execution :predicate #'ignore
+      :fields '((:key "efficacy" :required t) (:key "result" :required t)))
+    (with-temp-buffer
+      (org-mode)
+      (insert ":PROPERTIES:\n:ID: file\n:END:\n#+title: Journal\n#+filetags: :journal:\n\n"
+              "* Testing :execution:\n:PROPERTIES:\n:ID: h1\n:END:\n\n"
+              "* Target :execution:\n:PROPERTIES:\n:ID: h2\n:END:\n")
+      ;; point inside the "Target" subtree
+      (goto-char (point-max))
+      (vulpea-schema-insert-fields 'execution t)
+      (let ((s (buffer-string)))
+        (should (string-match-p "- efficacy ::" s))
+        (should (string-match-p "- result ::" s))
+        ;; the fields belong to Target, i.e. after its heading line ...
+        (should (> (string-match "- efficacy ::" s) (string-match "\\* Target" s)))
+        ;; ... and not before the first heading, where the bug put them
+        (should (< (string-match "\\* Testing" s) (string-match "- efficacy ::" s)))
+        ;; the sibling Testing heading is left untouched
+        (should-not
+         (string-match-p "ID: +h1\n:END:\n-" s))))))
+
+(ert-deftest vulpea-schema-buffer-note-scopes-meta-to-heading ()
+  "At a heading, the synthetic note reads that heading's meta, not the file's (#356)."
+  (let ((vulpea-schema--registry (make-hash-table :test 'eq)))
+    (vulpea-schema-define 'w :predicate #'ignore
+      :fields '((:key "efficacy") (:key "result")))
+    (with-temp-buffer
+      (org-mode)
+      (insert ":PROPERTIES:\n:ID: file\n:END:\n#+title: T\n\n"
+              "- efficacy :: file-level\n\n"
+              "* Heading\n:PROPERTIES:\n:ID: h\n:END:\n- efficacy :: heading-level\n")
+      (goto-char (point-max))
+      (let ((note (vulpea--schema-buffer-note 'w)))
+        (should (equal (vulpea-note-meta-get note "efficacy" 'string)
+                       "heading-level"))))))
+
+(ert-deftest vulpea-schema-insert-fields-heading-does-not-clobber ()
+  "Under a heading, an existing field is kept and only the missing one is added (#356)."
+  (let ((vulpea-schema--registry (make-hash-table :test 'eq)))
+    (vulpea-schema-define 'execution :predicate #'ignore
+      :fields '((:key "efficacy" :required t) (:key "result" :required t)))
+    (with-temp-buffer
+      (org-mode)
+      (insert ":PROPERTIES:\n:ID: file\n:END:\n#+title: Journal\n#+filetags: :journal:\n\n"
+              "* Target :execution:\n:PROPERTIES:\n:ID: h2\n:END:\n- efficacy :: complete\n")
+      (goto-char (point-max))
+      (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "done")))
+        (vulpea-schema-insert-fields 'execution))
+      (let ((s (buffer-string)))
+        ;; the existing value is read (heading-scoped) and left untouched
+        (should (string-match-p "- efficacy :: complete" s))
+        (should-not (string-match-p "- efficacy :: done" s))
+        ;; the missing field is added under the heading, not at file level
+        (should (string-match-p "- result :: done" s))
+        (should (> (string-match "- result ::" s) (string-match "\\* Target" s)))))))
+
+(ert-deftest vulpea-schema-buffer-note-reads-heading-title-and-tags ()
+  "At a heading, the synthetic note carries the heading's title and tags (#356)."
+  (with-temp-buffer
+    ;; insert before enabling org-mode so #+filetags is parsed for inheritance
+    (insert ":PROPERTIES:\n:ID: file\n:END:\n#+title: File Title\n#+filetags: :journal:\n\n"
+            "* Target :execution:\n:PROPERTIES:\n:ID: h\n:END:\n")
+    (org-mode)
+    (goto-char (point-max))
+    (let ((note (vulpea--schema-buffer-note)))
+      ;; title is the heading text, not the file #+title
+      (should (equal (vulpea-note-title note) "Target"))
+      ;; the heading's own tag ...
+      (should (member "execution" (vulpea-note-tags note)))
+      ;; ... plus the filetag it inherits
+      (should (member "journal" (vulpea-note-tags note))))))
+
+(ert-deftest vulpea-schema-buffer-note-file-level-before-first-heading ()
+  "Before the first heading, the synthetic note is still file-scoped (#356)."
+  (let ((vulpea-schema--registry (make-hash-table :test 'eq)))
+    (vulpea-schema-define 'w :predicate #'ignore :fields '((:key "efficacy")))
+    (with-temp-buffer
+      (org-mode)
+      (insert ":PROPERTIES:\n:ID: file\n:END:\n#+title: File Title\n#+filetags: :journal:\n\n"
+              "- efficacy :: file-level\n\n"
+              "* Heading :execution:\n:PROPERTIES:\n:ID: h\n:END:\n- efficacy :: heading-level\n")
+      ;; point before the first heading
+      (goto-char (point-min))
+      (let ((note (vulpea--schema-buffer-note 'w)))
+        (should (equal (vulpea-note-title note) "File Title"))
+        (should (member "journal" (vulpea-note-tags note)))
+        (should-not (member "execution" (vulpea-note-tags note)))
+        ;; reads the file-level value, not the heading's
+        (should (equal (vulpea-note-meta-get note "efficacy" 'string) "file-level"))))))
+
+(ert-deftest vulpea-schema-insert-fields-resolves-schema-from-heading ()
+  "With no schema given, the applicable schema is resolved from the heading at point (#356)."
+  (let ((vulpea-schema--registry (make-hash-table :test 'eq)))
+    (vulpea-schema-define 'execution
+      :predicate (lambda (n) (member "execution" (vulpea-note-tags n)))
+      :fields '((:key "efficacy" :required t)))
+    (with-temp-buffer
+      (insert ":PROPERTIES:\n:ID: file\n:END:\n#+title: Journal\n#+filetags: :journal:\n\n"
+              "* Target :execution:\n:PROPERTIES:\n:ID: h\n:END:\n")
+      (org-mode)
+      (goto-char (point-max))
+      ;; no schema argument: it is resolved from the heading note's tags, and
+      ;; the execution predicate matches only the heading, not the file
+      (vulpea-schema-insert-fields nil t)
+      (let ((s (buffer-string)))
+        (should (string-match-p "- efficacy ::" s))
+        (should (> (string-match "- efficacy ::" s) (string-match "\\* Target" s)))))))
+
 ;;; Schema quick-fix (#342)
 
 (ert-deftest vulpea-schema-fix-violation-missing ()
@@ -2243,6 +2356,82 @@ the whole match."
           (vulpea-schema-fix-violation v))
         (should (string-match-p "- producer :: \\[\\[id:p1\\]\\[Producer\\]\\]"
                                 (buffer-string)))))))
+
+(ert-deftest vulpea-schema-fix-violation-into-heading ()
+  "Fixing a missing-required violation writes under the heading at point (#356)."
+  (let ((vulpea-schema--registry (make-hash-table :test 'eq)))
+    (vulpea-schema-define 'execution
+      :predicate (lambda (n) (member "execution" (vulpea-note-tags n)))
+      :fields '((:key "efficacy" :required t)))
+    (with-temp-buffer
+      (org-mode)
+      (insert ":PROPERTIES:\n:ID: file\n:END:\n#+title: Journal\n#+filetags: :journal:\n\n"
+              "* Target :execution:\n:PROPERTIES:\n:ID: h\n:END:\n")
+      (goto-char (point-max))
+      (let ((v (car (vulpea-schema-validate
+                     (vulpea--schema-buffer-note 'execution) 'execution))))
+        (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "complete")))
+          (vulpea-schema-fix-violation v 'heading))
+        (let ((s (buffer-string)))
+          (should (string-match-p "- efficacy :: complete" s))
+          ;; written under the heading, not at the top of the file
+          (should (> (string-match "- efficacy ::" s) (string-match "\\* Target" s))))))))
+
+(ert-deftest vulpea-schema-fix-violation-heading-replaces-scoped ()
+  "Fixing a disallowed value replaces only the heading's value, sparing siblings (#356)."
+  (let ((vulpea-schema--registry (make-hash-table :test 'eq)))
+    (vulpea-schema-define 'execution
+      :predicate (lambda (n) (member "execution" (vulpea-note-tags n)))
+      :fields '((:key "colour" :type symbol :one-of (red white))))
+    (with-temp-buffer
+      (org-mode)
+      (insert ":PROPERTIES:\n:ID: file\n:END:\n#+title: T\n#+filetags: :journal:\n\n"
+              "* One :execution:\n:PROPERTIES:\n:ID: h1\n:END:\n- colour :: red\n\n"
+              "* Two :execution:\n:PROPERTIES:\n:ID: h2\n:END:\n- colour :: blue\n")
+      ;; point in the second heading, whose colour is invalid
+      (goto-char (point-max))
+      (let ((v (car (vulpea-schema-validate
+                     (vulpea--schema-buffer-note 'execution) 'execution))))
+        (should (eq (vulpea-violation-type v) 'disallowed-value))
+        (cl-letf (((symbol-function 'completing-read) (lambda (&rest _) "white")))
+          (vulpea-schema-fix-violation v 'heading))
+        (let ((s (buffer-string)))
+          ;; the first heading keeps its (valid) value
+          (should (string-match-p
+                   "One :execution:\n:PROPERTIES:\n:ID: h1\n:END:\n- colour :: red" s))
+          ;; the second heading's value is the replacement, blue is gone
+          (should (string-match-p "- colour :: white" s))
+          (should-not (string-match-p "- colour :: blue" s)))))))
+
+(ert-deftest vulpea-schema-fix-violation-defaults-to-heading-scope ()
+  "Without an explicit bound, the fix targets the note at point, not file level (#356).
+
+Guards a read/write scope mismatch: the fixer reads the violating note
+heading-scoped, so its write must default to the same scope - otherwise a
+heading-level fix silently rewrites an unrelated file-level value."
+  (let ((vulpea-schema--registry (make-hash-table :test 'eq)))
+    (vulpea-schema-define 'execution
+      :predicate (lambda (n) (member "execution" (vulpea-note-tags n)))
+      :fields '((:key "colour" :type symbol :one-of (red white))))
+    (with-temp-buffer
+      (insert ":PROPERTIES:\n:ID: file\n:END:\n#+title: T\n#+filetags: :journal:\n\n"
+              "- colour :: red\n\n"
+              "* Target :execution:\n:PROPERTIES:\n:ID: h\n:END:\n- colour :: blue\n")
+      (org-mode)
+      ;; point inside the heading whose colour is invalid
+      (goto-char (point-max))
+      (let ((v (car (vulpea-schema-validate
+                     (vulpea--schema-buffer-note 'execution) 'execution))))
+        (cl-letf (((symbol-function 'completing-read) (lambda (&rest _) "white")))
+          ;; no explicit bound - must still fix the heading, not the file
+          (vulpea-schema-fix-violation v))
+        (let ((s (buffer-string)))
+          ;; the heading's invalid value is the one replaced
+          (should (string-match-p
+                   "Target :execution:\n:PROPERTIES:\n:ID: h\n:END:\n- colour :: white" s))
+          (should-not (string-match-p "- colour :: blue" s))
+          ;; the valid file-level value is left untouched
+          (should (string-match-p "#\\+filetags: :journal:\n\n- colour :: red" s)))))))
 
 (ert-deftest vulpea-schema-prompt-field-target-tags-filter ()
   "A note field with :target-tags restricts selection to valid targets."

--- a/vulpea-db-extract.el
+++ b/vulpea-db-extract.el
@@ -655,7 +655,7 @@ Respects `vulpea-db-index-heading-level' setting."
                                    (org-element-property :raw-value headline)))
                        (title-start (+ pos level 1 ; stars + space
                                      (if todo (+ (length todo) 1) 0)
-                                     (if priority 4 0))) ; "[#X] "
+                                     (if priority 5 0))) ; "[#X] " incl. trailing space
                        (title-links (vulpea-db--extract-links-from-string
                                      raw-title title-start))
                        (links (append title-links

--- a/vulpea-db.el
+++ b/vulpea-db.el
@@ -132,7 +132,7 @@ changes to extraction logic that keep the schema intact, bump
 `vulpea-db-parser-epoch' instead - it re-extracts files without
 discarding the database.")
 
-(defconst vulpea-db-parser-epoch 2
+(defconst vulpea-db-parser-epoch 3
   "Epoch of the note extraction logic.
 
 Increment this whenever the parser/extractor in `vulpea-db-extract'

--- a/vulpea-meta.el
+++ b/vulpea-meta.el
@@ -323,22 +323,32 @@ When called interactively, operates on the note at point:
 (defun vulpea-meta-batch-set (notes prop value)
   "Set VALUE of PROP for all NOTES.
 
-Uses `vulpea-utils-process-notes' for efficient batch processing.
+Uses `vulpea-utils-process-notes' for efficient batch processing, which
+places point at each note.  For a heading-level note the write is scoped
+to that heading's subtree, mirroring `vulpea-meta-set'.
+
 Returns the count of notes processed."
   (let ((count 0))
     (vulpea-utils-process-notes notes
-      (vulpea-buffer-meta-set prop value)
+      (vulpea-buffer-meta-set
+       prop value nil
+       (when (and (vulpea-note-level it) (> (vulpea-note-level it) 0)) 'heading))
       (setq count (1+ count)))
     count))
 
 (defun vulpea-meta-batch-remove (notes prop)
   "Remove PROP from all NOTES.
 
-Uses `vulpea-utils-process-notes' for efficient batch processing.
+Uses `vulpea-utils-process-notes' for efficient batch processing, which
+places point at each note.  For a heading-level note the removal is
+scoped to that heading's subtree, mirroring `vulpea-meta-remove'.
+
 Returns the count of notes processed."
   (let ((count 0))
     (vulpea-utils-process-notes notes
-      (vulpea-buffer-meta-remove prop)
+      (vulpea-buffer-meta-remove
+       prop
+       (when (and (vulpea-note-level it) (> (vulpea-note-level it) 0)) 'heading))
       (setq count (1+ count)))
     count))
 

--- a/vulpea.el
+++ b/vulpea.el
@@ -1530,21 +1530,24 @@ Signals an error if:
 ;;; Schema authoring
 
 (defun vulpea--schema-buffer-note (&optional schema)
-  "Build a synthetic `vulpea-note' from the current buffer.
+  "Build a synthetic `vulpea-note' from the note at point.
 
-The note always carries the buffer's title and tags.  When SCHEMA is
-given, it also carries the current values of that schema's field keys,
-so predicates and conditional :required / :one-of rules see in-buffer
-content while authoring."
+The note carries the title and tags of the note at point - the heading
+when point is inside one, otherwise the file.  When SCHEMA is given, it
+also carries the current values of that schema's field keys within the
+same scope, so predicates, conditional :required / :one-of rules and the
+missing-field computation see in-buffer content while authoring."
   (make-vulpea-note
-   :title (vulpea-buffer-title-get)
+   :title (if (org-before-first-heading-p)
+              (vulpea-buffer-title-get)
+            (substring-no-properties (org-get-heading t t t t)))
    :tags (vulpea-buffer-tags-get)
    :meta (when schema
            (delq nil
                  (mapcar
                   (lambda (field)
                     (let* ((key (plist-get field :key))
-                           (vals (vulpea-buffer-meta-get-list key 'string)))
+                           (vals (vulpea-buffer-meta-get-list key 'string 'heading)))
                       (when vals (cons key vals))))
                   (vulpea-schema-fields (vulpea-schema--resolve schema)))))))
 
@@ -1646,18 +1649,21 @@ For each field the note does not already carry, prompt for a value -
 offering :one-of values as completion and selecting a note for `note'
 fields - and insert it; required fields are handled first.  With a
 prefix argument (SKELETON non-nil), skip prompting and insert empty
-placeholders for every missing field instead."
+placeholders for every missing field instead.
+
+The fields are inserted into the note at point: the heading's subtree
+when point is inside one, otherwise the file-level metadata."
   (interactive (list nil current-prefix-arg))
   (let* ((schema (or schema-or-name
                      (vulpea--schema-read-schema (vulpea--schema-buffer-note))))
          (note (vulpea--schema-buffer-note schema))
          (fields (vulpea-schema-missing-fields note schema)))
     (if skeleton
-        (vulpea--schema-insert-field-values fields nil)
+        (vulpea--schema-insert-field-values fields nil 'heading)
       (let ((values (vulpea--schema-prompt-fields fields note)))
         (vulpea--schema-insert-field-values
          (cl-remove-if-not (lambda (f) (assoc (plist-get f :key) values)) fields)
-         values)))))
+         values 'heading)))))
 
 ;;;###autoload
 (defun vulpea-schema-fix-violation (violation &optional bound)
@@ -1668,8 +1674,14 @@ value the way `vulpea-schema-insert-fields' does - offering :one-of
 values as completion, selecting a note for `note' fields, restricting to
 :target-tags - then writes it, replacing the offending value or
 inserting the field when it was missing.  Returns the value written, or
-nil when the prompt is skipped.  BOUND limits the scope as in
-`vulpea-buffer-meta-set'.
+nil when the prompt is skipped.
+
+BOUND limits the scope as in `vulpea-buffer-meta-set' and defaults to
+\\='heading, so the fix is written into the note at point - the heading's
+subtree when point is inside one, otherwise the file-level metadata.
+This matches how the violating note is read, so a heading-level fix does
+not rewrite an unrelated file-level value; pass \\='buffer to force
+file-level scope.
 
 This is the headless building block UIs use to offer one-key fixes for a
 `vulpea-schema-validate' violation."
@@ -1683,7 +1695,7 @@ This is the headless building block UIs use to offer one-key fixes for a
          (value (vulpea--schema-prompt-field field note required))
          (value (if (listp value) (remove "" value) value)))
     (when (and field value (not (equal value "")))
-      (vulpea-buffer-meta-set (plist-get field :key) value 'append bound)
+      (vulpea-buffer-meta-set (plist-get field :key) value 'append (or bound 'heading))
       value)))
 
 (provide 'vulpea)


### PR DESCRIPTION
Fixes #356, plus two more heading-level bugs I turned up while auditing that area.

**#356** — `vulpea-schema-insert-fields` was dropping a schema's fields at the top of the file instead of into the heading you're actually on. The root cause was scope: it read and wrote at file level regardless of point. It now targets the note at point — the heading's subtree when you're inside one, the file otherwise. Same scoping for the synthetic note it builds while authoring (title/tags/meta come from the heading now), and for `vulpea-schema-fix-violation`, which had the same read-the-heading/write-the-file split and could quietly rewrite an unrelated file-level value.

While I was in there I swept the rest of the heading-level paths and found two more:

- `vulpea-meta-batch-set` / `vulpea-meta-batch-remove` ignored heading scope, so batch edits landed at file level — and a batch remove could delete a same-named *file-level* value while leaving the heading's alone. The single-note `vulpea-meta-set` / `-remove` already did this correctly; only the batch layer was off.
- A link in a heading *title* got an off-by-one position when the heading carried a priority cookie (`[#A]`) — the extractor counted `[#X]` but forgot its trailing space. That silently broke `vulpea-propagate-title-change` for those links. Bumped the parser epoch so existing databases re-extract and pick up the corrected positions on next access.

Also beefed up heading-level test coverage across schema authoring, flymake, sync validation, batch meta, and link extraction, since a few of these paths had only ever been exercised at file level.
