### PR TITLE
docs: surface heading-level notes and the vulpea ecosystem

### DIFF
--- a/README.org
+++ b/README.org
@@ -7,6 +7,11 @@
   <img width="256px" src="./images/logo.png" alt="Banner">
 </p>
 <p align="center">
+  <b>vulpea</b> /
+  <a href="https://github.com/d12frosted/vulpea-ui">vulpea-ui</a> /
+  <a href="https://github.com/d12frosted/vulpea-journal">vulpea-journal</a>
+</p>
+<p align="center">
   <a href="https://melpa.org/#/vulpea"><img alt="MELPA" src="https://melpa.org/packages/vulpea-badge.svg"/></a>
   <a href="https://github.com/d12frosted/vulpea/releases"><img alt="Release" src="https://img.shields.io/github/v/release/d12frosted/vulpea?include_prereleases"/></a>
   <a href="https://github.com/d12frosted/vulpea/actions"><img alt="CI" src="https://github.com/d12frosted/vulpea/actions/workflows/main.yml/badge.svg"/></a>
@@ -53,6 +58,7 @@ Vulpea originally started as a layer over org-roam, but v2 is a complete rewrite
 
 ** Key Features
 
+- 🌳 *Files or headings* - A note is any org node with an =ID=: a whole file, or a single heading inside a larger file
 - 🚀 *Async-first* - File watchers + background processing, no save hooks blocking you
 - 📊 *Optimized queries* - Hybrid database schema for fast reads
 - 🔌 *Extensible* - Plugin system for custom extractors and tables
@@ -76,7 +82,7 @@ Vulpea originally started as a layer over org-roam, but v2 is a complete rewrite
 ;; M-x vulpea-insert  - insert link to a note
 #+end_src
 
-*Note:* Vulpea only indexes notes with =ID= properties. Use =M-x org-id-get-create= to add IDs to your notes.
+*Note:* A note is any org node with an =ID= - a whole file /or/ a single heading. One file can hold many notes: keep every swim session as a heading in =swimming.org= and each one is a first-class, queryable note. Vulpea indexes exactly these ID-carrying entries; use =M-x org-id-get-create= to add one to the entry at point.
 
 → [[file:docs/getting-started.org][Full Getting Started Guide]]
 
@@ -141,7 +147,7 @@ Without =fswatch=, Vulpea falls back to polling (periodic directory scanning). W
 | [[file:docs/user-guide.org][User Guide]] | Daily usage, interactive commands, working with notes |
 | [[file:docs/configuration.org][Configuration]] | All options explained, performance tuning |
 | [[file:docs/api-reference.org][API Reference]] | Programmatic usage, query functions, data structures |
-| [[file:docs/journal.org][Journal Module]] | Daily notes with widgets and calendar integration |
+| [[https://github.com/d12frosted/vulpea-journal][Journal Module]] | Daily notes with widgets and calendar integration (separate package) |
 | [[file:docs/plugin-guide.org][Plugin Guide]] | Writing custom extractors for domain-specific data |
 | [[file:docs/troubleshooting.org][Troubleshooting]] | Common issues and solutions |
 | [[file:docs/comparison.org][Comparison]] | How vulpea compares to org-roam and org-node |

--- a/README.org
+++ b/README.org
@@ -6,10 +6,8 @@
 <p align="center">
   <img width="256px" src="./images/logo.png" alt="Banner">
 </p>
-<p align="center">
-  <b>vulpea</b> /
-  <a href="https://github.com/d12frosted/vulpea-ui">vulpea-ui</a> /
-  <a href="https://github.com/d12frosted/vulpea-journal">vulpea-journal</a>
+<p>
+  <pre align="center"><b>vulpea</b> / <a href="https://github.com/d12frosted/vulpea-ui">vulpea-ui</a> / <a href="https://github.com/d12frosted/vulpea-journal">vulpea-journal</a></pre>
 </p>
 <p align="center">
   <a href="https://melpa.org/#/vulpea"><img alt="MELPA" src="https://melpa.org/packages/vulpea-badge.svg"/></a>

--- a/docs/api-reference.org
+++ b/docs/api-reference.org
@@ -1188,6 +1188,52 @@ Registry and helpers:
 | =vulpea-schema-applies-p=                 | Does a schema's predicate match a note |
 | =vulpea-schema-field-value=               | Read a field's value with its type     |
 
+** Per note, not per file
+
+A schema is not tied to a file. Its predicate runs against every note,
+and a note is any org node with an =ID= - a whole file or a single
+heading - so one file can hold many independently validated notes. A
+=swimming.org= where each session is its own heading is a good example:
+
+#+begin_src org
+,#+title: Swimming
+
+,* 2026-06-28 Morning laps :swim:
+:PROPERTIES:
+:ID: 3f2a6d1c-0b7e-4a2f-9c14-6d5e8a1b2c3d
+:END:
+- distance :: 1500
+- style :: freestyle
+- pool :: 25m
+
+,* 2026-06-30 Intervals :swim:
+:PROPERTIES:
+:ID: 7c9b0e42-1a3d-4f56-8b90-2e4c6a8d0f11
+:END:
+- distance :: 2000
+- style :: medley
+- pool :: 50m
+#+end_src
+
+#+begin_src emacs-lisp
+(vulpea-schema-define 'swim
+  :predicate (lambda (note) (member "swim" (vulpea-note-tags note)))
+  :fields
+  '((:key "distance" :type number :required t)
+    (:key "style"    :type symbol :required t
+          :one-of (freestyle backstroke breaststroke butterfly medley))
+    (:key "pool"     :type string)))
+
+;; validates every swim session heading, wherever it lives
+(vulpea-schema-validate-all 'swim)
+#+end_src
+
+The =:swim= tag on each heading is what the predicate keys off, so only
+the sessions are checked - not the file-level =Swimming= note that
+contains them. (The tag can also come from =#+filetags:=, which
+heading-level notes inherit; tagging the headings directly is what keeps
+the container note out.)
+
 ** Composition
 
 A schema can inherit fields from others with =:include=, which takes a

--- a/docs/getting-started.org
+++ b/docs/getting-started.org
@@ -181,6 +181,12 @@ Content here...
 Content here...
 #+end_src
 
+Both are notes in every sense - found, linked, tagged, queried, and
+schema-validated the same way. This is what lets a single file hold many
+notes: a =swimming.org= where every session is its own heading is a whole
+collection of notes, and you can still read and edit the file as one org
+tree. Nothing forces one note per file.
+
 To add an ID to an existing entry: =M-x org-id-get-create=
 
 ** Tags


### PR DESCRIPTION
A reader on the schemas post had a small revelation partway through: a vulpea note is *any* node with an ID, so a single file (their swimming.org) can hold a whole collection of heading-notes, and that's exactly what makes schemas click for tracking-style workflows. Trouble is, the docs barely say this anywhere, so the natural assumption is one-note-per-file / schema-per-file.

This surfaces it:

- README: the ID note is now framed as a capability (whole file or a single heading), plus a Key Features bullet and a vulpea-ui / vulpea-journal nav bar up top so the sibling packages are actually discoverable
- getting-started: a couple of lines on *why* heading-notes matter
- api-reference: a worked swimming.org example, one schema validating many heading-notes
- drive-by: fixed a broken docs/journal.org link (journal lives in its own repo now)

Docs only, no behavior change.
