### PR TITLE
docs: teach vulpea-doctor about async extraction and close the doc gaps

### DIFF
--- a/README.org
+++ b/README.org
@@ -57,7 +57,7 @@ Vulpea originally started as a layer over org-roam, but v2 is a complete rewrite
 ** Key Features
 
 - 🌳 *Files or headings* - A note is any org node with an =ID=: a whole file, or a single heading inside a larger file
-- 🚀 *Async-first* - File watchers + background processing, no save hooks blocking you
+- 🚀 *Actually async* - File watchers, background processing, and an opt-in worker process (=vulpea-db-async-extraction=) that parses and writes off the main thread - saving a 100MB file blocks Emacs for about a millisecond
 - 📊 *Optimized queries* - Hybrid database schema for fast reads
 - 🔌 *Extensible* - Plugin system for custom extractors and tables
 - 🏷️ *Rich metadata* - Type-aware metadata with automatic coercion

--- a/docs/architecture.org
+++ b/docs/architecture.org
@@ -99,7 +99,14 @@ Based on existing =vulpea-sync.el= prototype (PR #194):
 - Process updates in idle timer bursts
 
 *** Status
-IMPLEMENTED - vulpea-db-sync.el provides autosync-mode with file-notify, fswatch, and polling support
+IMPLEMENTED - vulpea-db-sync.el provides autosync-mode with file-notify, fswatch, and polling support.
+
+For a long time "non-blocking" only covered scheduling: once a queue
+timer fired, parsing and writing still ran on the main thread. This
+was completed in v2.6 with =vulpea-db-async-extraction=, which moves
+parsing (and optionally the database write) into a persistent
+=emacs --batch= worker process. See [[file:sync-architecture.org][sync-architecture]] for the full
+design: modes, flow control, freshness guards, and fallbacks.
 
 ** DECISION 4: Plugin/Extractor System
 *** Decision

--- a/docs/plugin-guide.org
+++ b/docs/plugin-guide.org
@@ -183,6 +183,46 @@ Example:
 :priority 900
 #+end_src
 
+* Extractors and Async Extraction
+
+With =vulpea-db-async-extraction= enabled, parsing happens in a
+worker subprocess - and the org-element AST never crosses the
+process boundary. This matters for extractors, because their
+contract includes the AST. Two declarations on =make-vulpea-extractor=
+control the interaction:
+
+#+begin_src emacs-lisp
+(vulpea-db-register-extractor
+ (make-vulpea-extractor
+  :name 'my-attachments
+  :requires-ast nil    ; works purely from NOTE-DATA
+  :worker-safe t       ; may run inside the worker (full mode)
+  :worker-lib 'my-lib  ; feature/file the worker loads for the fn
+  :schema '((attachments [(note-id :not-null) (file :not-null)]))
+  :extract-fn #'my-attachments-fn))
+#+end_src
+
+- Without any declaration (the default), a registered extractor
+  conservatively disables async extraction for *every* file and
+  forces the slower ='object= parse granularity. Correct, but you
+  lose both performance features.
+- =:requires-ast nil= declares that your function never touches
+  =(vulpea-parse-ctx-ast ctx)= - it works from the NOTE-DATA plist
+  \(=:id=, =:attach-dir=, =:meta=, ...). Extraction stays at
+  ='element= granularity and files stay worker-eligible; your
+  extractor runs in the main process when results arrive, against a
+  context whose AST slot may be nil.
+- =:worker-safe t= (requires =:requires-ast nil= in practice, and a
+  symbol =:extract-fn=) additionally lets the extractor run *inside*
+  the worker in ='full= mode, writing its tables through the
+  worker's connection - preserving the zero-freeze write. The worker
+  loads =:worker-lib= to resolve the function; if it cannot, it
+  transparently falls back to streaming results and your extractor
+  runs in the main process. Nothing is lost either way.
+
+Declare honestly: =:requires-ast nil= on a function that does read
+the AST will find that AST nil at apply time.
+
 * Version Tracking and Migrations
 
 ** Schema Versioning

--- a/docs/sync-architecture.org
+++ b/docs/sync-architecture.org
@@ -364,6 +364,62 @@ M-x vulpea-db-sync-update-directory
 #+end_example
 
 
+* Async Extraction (the worker process)
+
+Everything above describes scheduling: queues, timers, batching. By
+default the *work* - reading, hashing, parsing, extraction, database
+write - still runs on the main thread when a timer fires. Async
+extraction moves it into a persistent =emacs --batch= subprocess.
+
+** Modes
+
+| =vulpea-db-async-extraction= | parse    | db write | main thread blocks for       |
+|------------------------------+----------+----------+------------------------------|
+| =nil= (default)              | main     | main     | everything                   |
+| =t=                          | worker   | main     | db write of results          |
+| ='full=                      | worker   | worker   | org-id registration (~1ms)   |
+
+** How a file flows through the worker
+
+1. The queue does a cheap mtime/size comparison on the main thread -
+   no file reading, no hashing.
+2. Changed files are sent to the worker over a pipe, at most
+   =vulpea-db-worker-max-in-flight= (128) in flight - flow control,
+   so the pipe never blocks the main thread.
+3. The worker parses and extracts, then either streams results back
+   as printable plists (mode =t=; the main thread applies them
+   through the same write path as synchronous updates) or writes the
+   database itself through its own WAL connection (mode ='full=).
+4. Every result carries the file stamp as the worker read it. A file
+   that changed mid-parse is stale: discarded and re-queued. In
+   ='full= mode a compare-and-swap inside the write transaction also
+   protects against concurrent main-process writes (programmatic
+   APIs stay synchronous and always win).
+
+** Fidelity and fallbacks
+
+The worker mirrors an allowlist of settings (kept current through
+variable watchers) and does not run =org-mode-hook= - the same
+trade-off as =vulpea-db-parse-method= ='single-temp-buffer=. Files it
+cannot handle faithfully take the synchronous path automatically:
+non-.org files, function-valued =vulpea-db-index-heading-level=, and
+extractor plugins that read the AST (see the plugin guide for the
+=:requires-ast= and =:worker-safe= declarations).
+
+='full= degrades to =t= when WAL journaling cannot be enabled, when
+note index filters are active, or when the worker runs different
+vulpea code than the main session (it then refuses to open the
+database at all - the schema migration logic could rebuild it).
+
+** Self-healing
+
+The worker respawns after crashes with in-flight files re-queued; a
+crash loop (three quick deaths) or repeated hangs
+\(=vulpea-db-worker-hang-timeout=) mark it broken and fall back to
+synchronous indexing with a warning. =M-x vulpea-db-worker-reset=
+re-arms it, =M-x vulpea-db-worker-diagnose= explains the current
+state end to end, and =vulpea-db-worker-debug= logs the protocol.
+
 * Key Insights
 
 1. *Single entry point*: All updates go through ~vulpea-db-update-file~

--- a/docs/troubleshooting.org
+++ b/docs/troubleshooting.org
@@ -408,6 +408,56 @@ If conflicts occur with other org-mode packages:
    (setq vulpea-db-parse-method 'find-file)  ; Most compatible
    #+end_src
 
+* Async Extraction Issues
+
+First stop: =M-x vulpea-db-worker-diagnose=. It runs an end-to-end
+health check and tells you whether your files actually use the
+worker, why not if they don't, the database journal mode, round-trip
+timing, and the worker's stderr.
+
+** Async is enabled but saves still block
+
+Almost always: a registered extractor plugin. Extractors receive the
+parse context including the AST, which cannot cross the process
+boundary, so any extractor without a =:requires-ast nil= declaration
+routes *every* file to the synchronous path - silently. Both
+=vulpea-doctor= and =vulpea-db-worker-diagnose= flag this. Fix: add
+=:requires-ast nil= to extractors that work purely from note data
+\(see the plugin guide).
+
+** Full mode configured, but writes happen on the main thread
+
+='full= degrades to =t= in three cases, all reported by the doctor:
+WAL journaling failed (network/FUSE filesystems), note index filters
+are active (schema validation with a non-silent action), or the
+worker's vulpea version differs from the session's (upgrade Emacs's
+load path and restart).
+
+** Worker marked broken
+
+After a crash loop or repeated hangs, vulpea stops respawning the
+worker and falls back to synchronous indexing. The warning includes
+the worker's stderr tail. Investigate with
+=M-x vulpea-db-worker-diagnose=, then =M-x vulpea-db-worker-reset=
+to re-arm. For a full protocol trace, =(setq vulpea-db-worker-debug
+t)= and read =*vulpea-worker-log*=.
+
+** Data seems stale right after saving
+
+Worker-extracted files become queryable when the background sync
+completes (watch for the "background sync complete" message), a
+moment after the save. Programmatic APIs (=vulpea-create=,
+=vulpea-meta-set=) are unaffected - they are synchronous and
+read-your-writes. If code queries small files right after saving
+them, set =vulpea-db-async-extraction-threshold= to keep small files
+synchronous.
+
+** WAL sidecar files appeared next to my database
+
+Expected in ='full= mode: SQLite's write-ahead log creates =-wal=
+and =-shm= files. They are part of the database - include them in
+backups, and do not delete them while Emacs runs.
+
 * Getting Help
 
 If none of these solutions work:

--- a/test/vulpea-doctor-test.el
+++ b/test/vulpea-doctor-test.el
@@ -204,5 +204,40 @@ creating it as a side effect."
       (should (string-match-p "cached files +2\\b" report))
       (should (string-match-p "files without notes +1\\b" report)))))
 
+(ert-deftest vulpea-doctor-flags-async-disabled-by-extractors ()
+  "Doctor must expose async extraction being silently bypassed.
+The trap: async is enabled, but a registered AST-reading extractor
+makes every file take the synchronous path with no visible sign."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (let ((vulpea-db-async-extraction t)
+          (vulpea-db--extractors
+           (list (make-vulpea-extractor :name 'legacy :extract-fn #'ignore))))
+      (let ((report (vulpea-doctor)))
+        (should (string-match-p "will NOT use the worker" report))
+        (should (string-match-p ":requires-ast nil" report))))))
+
+(ert-deftest vulpea-doctor-reports-async-state ()
+  "The report carries an async extraction section."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (let ((vulpea-db-async-extraction 'full)
+          (vulpea-db--extractors nil)
+          (vulpea-db-note-index-filter-functions nil))
+      (let ((report (vulpea-doctor)))
+        (should (string-match-p "Async Extraction" report))
+        (should (string-match-p "mode.*full" report))
+        (should (string-match-p "handles .org files.*yes" report))))))
+
+(ert-deftest vulpea-doctor-no-async-issues-when-disabled ()
+  "With async off, no async issues appear no matter the extractors."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (let ((vulpea-db-async-extraction nil)
+          (vulpea-db--extractors
+           (list (make-vulpea-extractor :name 'legacy :extract-fn #'ignore))))
+      (should-not (string-match-p "will NOT use the worker"
+                                  (vulpea-doctor))))))
+
 (provide 'vulpea-doctor-test)
 ;;; vulpea-doctor-test.el ends here

--- a/vulpea.el
+++ b/vulpea.el
@@ -273,6 +273,40 @@ Returns nil when the database file is absent; does not create it."
                     " check that your notes have ID properties and live"
                     " under `vulpea-db-sync-directories'.")
             issues)))
+    ;; Async extraction
+    (when vulpea-db-async-extraction
+      (when-let* ((reasons (vulpea-db-worker-rejection-reasons "probe.org")))
+        (push (format
+               (concat "`vulpea-db-async-extraction' is enabled but your"
+                       " .org files will NOT use the worker (%s) - every"
+                       " file takes the synchronous path. %s")
+               (mapconcat #'symbol-name reasons ", ")
+               (cond
+                ((memq 'ast-extractors reasons)
+                 (concat "An extractor plugin reads the AST (or does not"
+                         " declare otherwise); add :requires-ast nil to its"
+                         " definition if it works purely from note data."))
+                ((memq 'broken reasons)
+                 (concat "The worker crash-looped; see *Warnings*, then"
+                         " M-x vulpea-db-worker-reset to retry."))
+                (t "Run M-x vulpea-db-worker-diagnose for details.")))
+              issues))
+      (when (and (eq vulpea-db-async-extraction 'full)
+                 (bound-and-true-p vulpea-db-worker--wal-failed))
+        (push (concat "Full-write mode is configured but WAL journaling"
+                      " could not be enabled on the database (filesystem"
+                      " without shared-memory support?) - degraded to"
+                      " extract-only. The database write runs on the main"
+                      " thread.")
+              issues))
+      (when (and (eq vulpea-db-async-extraction 'full)
+                 (not (vulpea-db-worker--filters-inert-p)))
+        (push (concat "Full-write mode is configured but note index"
+                      " filters are active (schema validation with a"
+                      " non-silent action, or a custom filter) - degraded"
+                      " to extract-only so the filters keep running in"
+                      " your session.")
+              issues)))
     (nreverse issues)))
 
 (defun vulpea-doctor--report ()
@@ -321,6 +355,27 @@ Returns nil when the database file is absent; does not create it."
        (funcall line "external monitoring" (vulpea-doctor--monitoring-status))
        (funcall line "pending queue"
                 (format "%d" (length vulpea-db-sync--queue)))
+       ""
+       "Async Extraction"
+       (funcall line "mode" (format "%s" vulpea-db-async-extraction))
+       (funcall line "worker"
+                (cond
+                 ((not vulpea-db-async-extraction) "n/a")
+                 ((bound-and-true-p vulpea-db-worker--broken)
+                  "BROKEN (crash loop; M-x vulpea-db-worker-reset)")
+                 ((process-live-p
+                   (bound-and-true-p vulpea-db-worker--process))
+                  (format "running (%d in flight)"
+                          (vulpea-db-worker-in-flight-count)))
+                 (t "not running (spawns on first change)")))
+       (funcall line "handles .org files"
+                (if vulpea-db-async-extraction
+                    (if-let* ((reasons (vulpea-db-worker-rejection-reasons
+                                        "probe.org")))
+                        (format "NO: %s"
+                                (mapconcat #'symbol-name reasons ", "))
+                      "yes")
+                  "n/a"))
        ""
        "External Tools"
        (funcall line "fd" (or (executable-find "fd") "not found"))


### PR DESCRIPTION
Follow-up to #361. Two things the async work left behind:

vulpea-doctor knew nothing about async extraction. It now reports the mode, worker status, and - the important one - whether your .org files actually use the worker. The silent trap from #361 (async enabled, but an AST-reading extractor routes everything to the synchronous path) is now flagged with the :requires-ast fix spelled out, and full-write degradation (WAL failure, active index filters) is reported too. Three new tests.

The docs were dark on the whole thing: sync-architecture gains the worker design section (modes, flow control, freshness guards, fallbacks, self-healing), troubleshooting gains an async section built around vulpea-db-worker-diagnose, the plugin guide documents :requires-ast / :worker-safe / :worker-lib for extractor authors, architecture's DECISION 3 stops claiming the UI never waits (it does, or did), and the README bullet now says what is actually true.

863 tests green, lint clean.