### PR TITLE
Overwrite title with :title from default template

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -31,6 +31,8 @@
 
 - [[https://github.com/d12frosted/vulpea/issues/382][vulpea#382]] The plugin guide no longer implies that custom =note-data= keys end up in the database. They are transient: a way to pass data between extractors within a single extraction run, dropped once the run is over - only the documented core fields are persisted, and unknown keys are silently ignored. The guide now says so explicitly and gains a "Storing Per-Note Data" section with the recipes for data that should survive: a 1:1 side table keyed by =note-id=, a generic =(note-id, axis, value)= table when there are several axes, or a property/metadata entry in the file itself. Thanks to @edenworky for pointing out the misleading wording.
 
+- [[https://github.com/d12frosted/vulpea/issues/375][vulpea#375]] If =:title "Note title"= is present in the template returned by =vulpea-create-default-function= (or in =vulpea-create-default-template=), it overrides the note title passed to =vulpea-create=. This allows =vulpea-create-default-function= to modify the note title.
+
 ** v2.6.0 (2026-07-10)
 
 *Breaking changes*

--- a/docs/configuration.org
+++ b/docs/configuration.org
@@ -104,6 +104,22 @@ For context-aware defaults:
                       '("note")))))
 #+end_src
 
+In the example above, if the word "TODO" appears in the note title, the template automatically adds the "task" tag; otherwise, it assigns the "note" tag. If you prefer not to include the word "TODO" in the final note title, you can customize the title in the returned template as below.
+
+#+begin_src emacs-lisp
+(setq vulpea-create-default-function
+      (lambda (title)
+        (let* ((has-todo? (string-match-p "TODO" title))
+               (title (if has-todo? (string-replace "TODO " "" title) title))
+               (file-name
+                (format "%s_%s.org"
+                        (format-time-string "%Y%m%d%H%M%S")
+                        (vulpea-title-to-slug title))))
+          (if has-todo?
+              (list :file-name file-name :tags '("task") :title title)
+            (list :file-name file-name :tags '("note"))))))
+#+end_src
+
 ** Template Parameters
 
 | Parameter     | Description                             | Example                      |

--- a/test/vulpea-test.el
+++ b/test/vulpea-test.el
@@ -868,10 +868,10 @@ Guards against arbitrary code execution from untrusted note titles."
            (vulpea-create-default-template '(:file-name "${slug}.org"))
            (vulpea-create-default-function
             (lambda (title)
-              (list :tags (if (string-match-p "TODO" title)
-                              '("task" "inbox")
-                            '("note"))
-                    :head (format "#+created: %s" (format-time-string "[%Y-%m-%d]")))))
+              (let ((head (format "#+created: %s" (format-time-string "[%Y-%m-%d]"))))
+                (if (string-match-p "TODO" title)
+                    (list :tags '("task" "inbox") :head head :title (string-replace "TODO " "" title))
+                  (list :tags '("note") :head head)))))
            note1 note2 created-file1 created-file2)
       (unwind-protect
           (progn
@@ -881,10 +881,13 @@ Guards against arbitrary code execution from untrusted note titles."
             (setq created-file1 (vulpea-note-path note1))
             (should (file-exists-p created-file1))
 
-            ;; Verify task tags applied
             (with-temp-buffer
               (insert-file-contents created-file1)
-              (should (string-match-p ":task:inbox:" (buffer-string))))
+              ;; Verify task tags applied
+              (should (string-match-p ":task:inbox:" (buffer-string)))
+
+              ;; Verify "TODO" was removed from title in file content
+              (should (string-match-p "#\\+title: Fix bug" (buffer-string))))
 
             ;; Create note without TODO
             (setq note2 (vulpea-create "Regular Note"))

--- a/vulpea.el
+++ b/vulpea.el
@@ -470,7 +470,11 @@ The function allows dynamic parameter computation based on context:
                 :properties (list (cons \"SOURCE\"
                                         (buffer-name))))))
 
-Parameters explicitly passed to `vulpea-create' override these defaults.
+Parameters explicitly passed to `vulpea-create' override these defaults,
+except for the title. If the template returned by this function includes
+`:title', it will take precedence over the title passed to
+`vulpea-create' in order to allow for this function to modify the note
+title.
 
 These defaults seed file-level note creation only.  When
 `vulpea-create' is called with a non-nil `:parent' (a heading-level
@@ -521,6 +525,10 @@ Available parameters:
   :properties  - Alist of (key . value) for property drawer
   :meta        - Alist of (key . value) for metadata
   :context     - Plist of custom template variables
+  :title       - Note title. Takes precedence over the title passed to
+                 `vulpea-create'. Mainly used to allow
+                 `vulpea-create-default-function' to modify the note
+                 title.
 
 Template variables for :file-name:
   ${title}     - Note title
@@ -1219,6 +1227,11 @@ file-level note (PARENT is nil).  When PARENT is provided no
 defaults are consulted; the heading is built solely from the
 arguments passed here.
 
+If `:title' is present in the template, it takes precedence over the
+TITLE argument. This allows the function set in
+`vulpea-create-default-function' to override the title based on the
+template or other logic.
+
 Returns the created `vulpea-note' object.
 
 ID is automatically generated unless explicitly passed.
@@ -1299,6 +1312,7 @@ are as documented in `vulpea-create'."
                      vulpea-create-default-template)
                     (t nil)))
          ;; Merge explicit parameters with defaults (explicit takes precedence)
+         (title (or (plist-get defaults :title) title))
          (file-name (or file-name (plist-get defaults :file-name)))
          (head (or head (plist-get defaults :head)))
          (body (or body (plist-get defaults :body)))


### PR DESCRIPTION
This allows `vulpea-create-default-function` to modify the note title.

Implements #375.