### PR TITLE
feat(db-sync): add vulpea-db-sync-tracked-file-p, resolve symlinks

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -11,6 +11,8 @@
 
 *Features*
 
+- New =vulpea-db-sync-tracked-file-p= answers whether a path lives under one of =vulpea-db-sync-directories=, the "is this file in my vault?" question. It resolves symlinks on both sides with =file-truename=, so a vault reached through a symlink (a Termux storage link, an iCloud or Dropbox path) matches whichever side of the comparison carries the link. This also fixes external-change detection through =fswatch= on macOS, where fswatch reports the resolved path that a symlinked directory entry would otherwise not match; the untracked-file cleanup and the fswatch path filter both go through the new predicate now.
+
 - [[https://github.com/d12frosted/vulpea/issues/369][vulpea#369]] Unlinked mentions no longer include notes that are already linked: a note linking to the target is dropped from the target's incoming mentions, and notes already linked from the buffer are dropped from its outgoing mentions. Once a link exists, further plain-text occurrences are prose, not a missing connection. Set =vulpea-mentions-exclude-linked= to nil to restore the old behavior. Thanks to @drcxd for the implementation.
 
 ** v2.6.0 (2026-07-10)

--- a/test/vulpea-db-sync-test.el
+++ b/test/vulpea-db-sync-test.el
@@ -608,6 +608,60 @@ even with `vulpea-db-sync-scan-on-enable' set to nil."
         (when (file-directory-p similar)
           (delete-directory similar t))))))
 
+(ert-deftest vulpea-db-sync-tracked-file-p-basic ()
+  "A path counts as tracked only when it lives under a synced directory."
+  (let* ((dir (file-truename (make-temp-file "vulpea-tracked-" t)))
+         (vulpea-db-sync-directories (list dir)))
+    (unwind-protect
+        (progn
+          ;; inside the directory
+          (should (vulpea-db-sync-tracked-file-p
+                   (expand-file-name "note.org" dir)))
+          ;; a file in a subdirectory (fswatch reports these on creation)
+          (should (vulpea-db-sync-tracked-file-p
+                   (expand-file-name "journal/2026.org" dir)))
+          ;; a sibling that merely shares a name prefix
+          (should-not (vulpea-db-sync-tracked-file-p
+                       (concat dir "-archive/note.org")))
+          ;; somewhere else entirely
+          (should-not (vulpea-db-sync-tracked-file-p "/tmp/elsewhere/x.org"))
+          ;; a relative path is rejected
+          (should-not (vulpea-db-sync-tracked-file-p "note.org"))
+          ;; nil path
+          (should-not (vulpea-db-sync-tracked-file-p nil)))
+      (delete-directory dir t)))
+  ;; with no directories configured, nothing is tracked
+  (let ((vulpea-db-sync-directories nil))
+    (should-not (vulpea-db-sync-tracked-file-p "/tmp/vault/note.org"))))
+
+(ert-deftest vulpea-db-sync-tracked-file-p-symlink ()
+  "Symlinked directories match whichever side of the check carries the link.
+
+fswatch on macOS reports resolved paths, so a symlinked
+`vulpea-db-sync-directories' entry has to resolve both sides before
+comparing."
+  (let* ((real (file-truename (make-temp-file "vulpea-tracked-real-" t)))
+         (link (concat (file-truename
+                        (make-temp-file "vulpea-tracked-link-" t))
+                       "/vault")))
+    (unwind-protect
+        (progn
+          (make-symbolic-link real link)
+          ;; directory is the symlink, path is the resolved location
+          (let ((vulpea-db-sync-directories (list link)))
+            (should (vulpea-db-sync-tracked-file-p
+                     (expand-file-name "note.org" real))))
+          ;; directory is the resolved location, path goes through the link
+          (let ((vulpea-db-sync-directories (list real)))
+            (should (vulpea-db-sync-tracked-file-p
+                     (expand-file-name "note.org" link))))
+          ;; an outside file is still rejected through the link
+          (let ((vulpea-db-sync-directories (list link)))
+            (should-not (vulpea-db-sync-tracked-file-p "/tmp/elsewhere/x.org"))))
+      (when (file-symlink-p link) (delete-file link))
+      (delete-directory real t)
+      (delete-directory (file-name-directory link) t))))
+
 (ert-deftest vulpea-db-sync-full-scan-cleans-untracked ()
   "Test that full-scan automatically cleans up untracked files."
   (vulpea-test--with-temp-db
@@ -1372,10 +1426,15 @@ issue #344)."
             ;; Simulate mingw fswatch: backslash before the file name.
             ;; Pretend we are on Windows so backslash separators are
             ;; normalized; the temp paths themselves stay POSIX, and file
-            ;; I/O above runs under the real `system-type'.
-            (let ((system-type 'windows-nt))
-              (vulpea-db-sync--fswatch-filter
-               nil (format "%s\\note.org|||Updated\n" dir)))
+            ;; I/O above runs under the real `system-type'.  The
+            ;; watched-directory check resolves paths with `file-truename',
+            ;; which under a faked `windows-nt' calls `w32-long-file-name'
+            ;; (void off Windows); stub it to identity, standing in for the
+            ;; real function that exists on Windows.
+            (cl-letf (((symbol-function 'w32-long-file-name) #'identity))
+              (let ((system-type 'windows-nt))
+                (vulpea-db-sync--fswatch-filter
+                 nil (format "%s\\note.org|||Updated\n" dir))))
             (should (= (length vulpea-db-sync--queue) 1))
             ;; The enqueued path must be the canonical forward-slash form
             ;; so downstream DB lookups match.

--- a/vulpea-db-sync.el
+++ b/vulpea-db-sync.el
@@ -1044,6 +1044,30 @@ Returns count of removed files."
                                deleted (if (= deleted 1) "" "s")))
     deleted))
 
+(defun vulpea-db-sync-tracked-file-p (path)
+  "Return non-nil when PATH lives under a synced directory.
+
+PATH is checked against `vulpea-db-sync-directories'.  Both PATH and
+each directory are resolved with `file-truename' before comparing, so a
+directory reached through a symlink still matches when only one side of
+the comparison carries the link (for example a Termux storage link, or
+an iCloud or Dropbox path).  On Windows the comparison is
+case-insensitive.  Returns nil when PATH is nil or not absolute, or when
+no directories are configured.
+
+PATH may name a file or a directory; only membership is checked, so the
+file need not exist."
+  (when (and path
+             (file-name-absolute-p path)
+             vulpea-db-sync-directories)
+    (let ((path (file-truename path))
+          (ignore-case (memq system-type '(windows-nt ms-dos cygwin))))
+      (seq-some
+       (lambda (dir)
+         (string-prefix-p (file-name-as-directory (file-truename dir))
+                          path ignore-case))
+       vulpea-db-sync-directories))))
+
 (defun vulpea-db-sync--cleanup-untracked-files ()
   "Remove database entries for files outside tracked directories.
 
@@ -1059,17 +1083,13 @@ Returns count of removed files."
       0  ; No cleanup if no directories configured
     (let* ((db (vulpea-db))
            (all-paths (mapcar #'car (emacsql db [:select path :from files])))
-           (removed 0)
-           (tracked-dirs (mapcar #'expand-file-name vulpea-db-sync-directories)))
+           (removed 0))
       (emacsql-with-transaction db
         (dolist (path all-paths)
-          (let ((expanded-path (expand-file-name path)))
-            (unless (seq-some (lambda (dir)
-                                (file-in-directory-p expanded-path dir))
-                              tracked-dirs)
-              (vulpea-db--delete-file-notes path)
-              (emacsql db [:delete :from files :where (= path $s1)] path)
-              (setq removed (1+ removed))))))
+          (unless (vulpea-db-sync-tracked-file-p path)
+            (vulpea-db--delete-file-notes path)
+            (emacsql db [:delete :from files :where (= path $s1)] path)
+            (setq removed (1+ removed)))))
       (when (> removed 0)
         (vulpea-db-sync--message "Vulpea: Removed %d untracked file%s from database"
                                  removed (if (= removed 1) "" "s")))
@@ -1347,16 +1367,13 @@ a legal file-name character there."
 (defun vulpea-db-sync--fswatch-path-valid-p (path)
   "Return non-nil if PATH is within a watched directory.
 
-PATH is compared case-insensitively on Windows, whose file systems are
-case-insensitive and where fswatch may report a different drive-letter
-case than `expand-file-name'."
-  (and path
-       (file-name-absolute-p path)
-       (let ((ignore-case (memq system-type '(windows-nt ms-dos cygwin))))
-         (seq-some (lambda (dir)
-                     (string-prefix-p (file-name-as-directory (expand-file-name dir))
-                                      path ignore-case))
-                   vulpea-db-sync-directories))))
+A thin wrapper over `vulpea-db-sync-tracked-file-p', which resolves
+symlinks on both sides (fswatch on macOS reports the resolved path,
+which would otherwise not match a symlinked `vulpea-db-sync-directories'
+entry) and compares case-insensitively on Windows, whose file systems
+are case-insensitive and where fswatch may report a different
+drive-letter case."
+  (vulpea-db-sync-tracked-file-p path))
 
 (defun vulpea-db-sync--fswatch-to-cygwin-path (path)
   "Convert a native Windows PATH to the Cygwin `/cygdrive/' form.


### PR DESCRIPTION
## What

Adds a public predicate `vulpea-db-sync-tracked-file-p` that answers whether a path lives under one of `vulpea-db-sync-directories` (the "is this file in my vault?" question), and routes the two places that already hand-rolled this check through it.

## Why

The check existed in two internal spots with divergent correctness:

- `vulpea-db-sync--cleanup-untracked-files` used `file-in-directory-p` (resolves truenames, symlink-safe).
- `vulpea-db-sync--fswatch-path-valid-p` used `string-prefix-p` over `expand-file-name` (does not resolve symlinks).

The fswatch one carries a latent bug: on macOS fswatch reports the resolved path, so a symlinked `vulpea-db-sync-directories` entry never prefix-matches and external changes under such a vault get silently dropped. Same root cause showed up downstream in vulpea-para (d12frosted/vulpea-para#6), where a Termux vault reached through `~/storage/shared` (a symlink) failed the scope check.

The new predicate resolves both sides with `file-truename` before comparing, so it matches whichever side carries the link, and keeps the Windows case-insensitivity the fswatch check had. Both internal callers now delegate to it, so there is one implementation.

## Notes

- The #344 mingw regression test fakes `system-type` to `windows-nt`; `file-truename` then calls `w32-long-file-name` (void off Windows), so the test stubs it to identity, standing in for the real function that exists on Windows. CI is Ubuntu-only, so that test is a pure simulation.
- vulpea-para will delegate its `vulpea-para-vault-buffer-p` to this predicate in a follow-up.