### PR TITLE
Skip searches for mentions of note that set the ignore property

### DIFF
--- a/test/vulpea-mentions-test.el
+++ b/test/vulpea-mentions-test.el
@@ -145,6 +145,17 @@
     (should-not (vulpea-mentions--shares-name-p
                  (make-vulpea-note :title "Merlot") terms))))
 
+(ert-deftest vulpea-mentions--ingore-note-p ()
+  "Ignore notes with certain property set to certain value."
+  (should (vulpea-mentions--ignore-note-p
+           (make-vulpea-note
+            :title "Ignore This"
+            :properties `((,vulpea-mentions-ignore-property-key
+                           .
+                           ,vulpea-mentions-ignore-property-value)))))
+  (should (not (vulpea-mentions--ignore-note-p
+                (make-vulpea-note :title "Do Not Ignore This")))))
+
 ;;; Integration with real ripgrep
 
 ;; The full subprocess pipeline is exercised by running ripgrep
@@ -199,6 +210,38 @@
               (setq mentions (vulpea-mentions--collect
                               output note (expand-file-name target)))
               (should (= (length mentions) 2)))))
+      (when vulpea-db--connection (vulpea-db-close))
+      (when (file-exists-p vulpea-db-location) (delete-file vulpea-db-location))
+      (delete-directory dir t))))
+
+(ert-deftest vulpea-mentions-ignore-note-with-property ()
+  "When a note set the ignore property, skip searching for its mentions."
+  (skip-unless (executable-find "rg"))
+  (let* ((dir (make-temp-file "vulpea-mentions-" t))
+         (target (expand-file-name "target.org" dir))
+         (mention (expand-file-name "mention.org" dir))
+         (vulpea-db-location (make-temp-file "vulpea-mentions-" nil ".db"))
+         (vulpea-db--connection nil)
+         (vulpea-db-sync-directories (list dir)))
+    (unwind-protect
+        (progn
+          (with-temp-file target
+            (insert ":PROPERTIES:\n:ID: ignored\n"
+                    (format ":%s: %s\n"
+                            vulpea-mentions-ignore-property-key
+                            vulpea-mentions-ignore-property-value)
+                    ":END:\n#+title: Ignored\n"))
+          (with-temp-file mention
+            (insert ":PROPERTIES:\n:ID: mention\n:END:\n#+title: Mention\n\n"
+                    "An ignored mention.\n"))
+          (vulpea-db)
+          (vulpea-db-update-file target)
+          (vulpea-db-update-file mention)
+          (vulpea-note-unlinked-mentions-async
+           (vulpea-db-get-by-id "ignored")
+           (lambda (mentions)
+             (should (not mentions)))
+           (lambda (_e) (should nil))))
       (when vulpea-db--connection (vulpea-db-close))
       (when (file-exists-p vulpea-db-location) (delete-file vulpea-db-location))
       (delete-directory dir t))))

--- a/test/vulpea-mentions-test.el
+++ b/test/vulpea-mentions-test.el
@@ -253,8 +253,11 @@
                                               done t))
                                       (lambda (_e) (setq done 'error)))))
                           (when proc
-                            (while (not done)
-                              (accept-process-output proc 0.2)))
+                            (let (proc-status)
+                              (while (and (not done)
+                                          (not (equal proc-status 'exit)))
+                                (setq proc-status (process-status proc))
+                                (accept-process-output proc 0.2))))
                           (funcall assert result done)))))
             (funcall test
                      "ignored"
@@ -386,11 +389,17 @@
     (vulpea-db)
     (vulpea-test--insert-test-note "cab" "Cabernet Sauvignon" :path "/n/cab.org")
     (vulpea-test--insert-test-note "merlot" "Merlot" :path "/n/merlot.org")
+    (vulpea-test--insert-test-note "syrah" "Syrah"
+                                   :path "/n/syrah.org"
+                                   :properties
+                                   `((,vulpea-mentions-ignore-property-key
+                                      .
+                                      ,vulpea-mentions-ignore-property-value)))
     (let* ((terms (cdr (vulpea-mentions--title-dictionary)))
            (dict (car (vulpea-mentions--title-dictionary)))
            (patterns (make-temp-file "vmp-"))
            (content (concat "We had Cabernet Sauvignon and [[id:merlot][Merlot]].\n"
-                            "More Merlot later.\n")))
+                            "More Merlot and Syrah later.\n")))
       (unwind-protect
           (progn
             (with-temp-file patterns (insert (mapconcat #'identity terms "\n") "\n"))
@@ -434,7 +443,7 @@
                                mentions)))
                   (should (equal (plist-get merlot :line) 2))
                   (should (equal (plist-get merlot :matched) "Merlot"))
-                  (should (equal (plist-get merlot :context) "More Merlot later."))))))
+                  (should (equal (plist-get merlot :context) "More Merlot and Syrah later."))))))
         (delete-file patterns)))))
 
 (ert-deftest vulpea-mentions-outgoing-rejects-without-rg ()

--- a/test/vulpea-mentions-test.el
+++ b/test/vulpea-mentions-test.el
@@ -145,7 +145,7 @@
     (should-not (vulpea-mentions--shares-name-p
                  (make-vulpea-note :title "Merlot") terms))))
 
-(ert-deftest vulpea-mentions--ingore-note-p ()
+(ert-deftest vulpea-mentions--ignore-note-p ()
   "Ignore notes with certain property set to certain value."
   (should (vulpea-mentions--ignore-note-p
            (make-vulpea-note
@@ -218,30 +218,54 @@
   "When a note set the ignore property, skip searching for its mentions."
   (skip-unless (executable-find "rg"))
   (let* ((dir (make-temp-file "vulpea-mentions-" t))
-         (target (expand-file-name "target.org" dir))
+         (ignored (expand-file-name "ignored.org" dir))
+         (not-ignored (expand-file-name "not-ignored.org" dir))
          (mention (expand-file-name "mention.org" dir))
          (vulpea-db-location (make-temp-file "vulpea-mentions-" nil ".db"))
          (vulpea-db--connection nil)
          (vulpea-db-sync-directories (list dir)))
     (unwind-protect
         (progn
-          (with-temp-file target
+          (with-temp-file ignored
             (insert ":PROPERTIES:\n:ID: ignored\n"
                     (format ":%s: %s\n"
                             vulpea-mentions-ignore-property-key
                             vulpea-mentions-ignore-property-value)
                     ":END:\n#+title: Ignored\n"))
+          (with-temp-file not-ignored
+            (insert ":PROPERTIES:\n:ID: not-ignored\n:END:\n"
+                    "#+title: Not Ignored\n\n"))
           (with-temp-file mention
             (insert ":PROPERTIES:\n:ID: mention\n:END:\n#+title: Mention\n\n"
-                    "An ignored mention.\n"))
+                    "An ignored mention.\n"
+                    "A not ignored mention.\n"))
           (vulpea-db)
-          (vulpea-db-update-file target)
+          (vulpea-db-update-file ignored)
+          (vulpea-db-update-file not-ignored)
           (vulpea-db-update-file mention)
-          (vulpea-note-unlinked-mentions-async
-           (vulpea-db-get-by-id "ignored")
-           (lambda (mentions)
-             (should (not mentions)))
-           (lambda (_e) (should nil))))
+          (let ((test (lambda (note-id assert)
+                        (let* (result
+                               done
+                               (proc (vulpea-note-unlinked-mentions-async
+                                      (vulpea-db-get-by-id note-id)
+                                      (lambda (mentions)
+                                        (setq result mentions
+                                              done t))
+                                      (lambda (_e) (setq done 'error)))))
+                          (when proc
+                            (while (not done)
+                              (accept-process-output proc 0.2)))
+                          (funcall assert result done)))))
+            (funcall test
+                     "ignored"
+                     (lambda (result done)
+                       (should (eq done t))
+                       (should (null result))))
+            (funcall test
+                     "not-ignored"
+                     (lambda (result done)
+                       (should (eq done t))
+                       (should (eq (length result) 1))))))
       (when vulpea-db--connection (vulpea-db-close))
       (when (file-exists-p vulpea-db-location) (delete-file vulpea-db-location))
       (delete-directory dir t))))
@@ -289,6 +313,33 @@
     (let* ((vulpea-mentions-note-filter (lambda (_n) t))
            (dict (car (vulpea-mentions--title-dictionary))))
       (should (gethash "heading wine" dict)))))
+
+(ert-deftest vulpea-mentions--title-dictionary-respects-ignore-property ()
+  "The candidate dictionary honors `vulpea-mentions--ignore-note-p'."
+  (vulpea-test--with-temp-db
+   (vulpea-db)
+   (vulpea-test--insert-test-note "c" "Cabernet"
+                                  :properties
+                                  `((,vulpea-mentions-ignore-property-key
+                                     .
+                                     ,vulpea-mentions-ignore-property-value)))
+   (vulpea-test--insert-test-note "m" "Merlot")
+   (let* ((dt (vulpea-mentions--title-dictionary))
+          (dict (car dt))
+          (terms (cdr dt)))
+     (should (equal terms '("Merlot")))))
+  (vulpea-test--with-temp-db
+   (vulpea-db)
+   (vulpea-test--insert-test-note "c1" "Cabernet"
+                                  :properties
+                                  `((,vulpea-mentions-ignore-property-key
+                                     .
+                                     ,vulpea-mentions-ignore-property-value)))
+   (vulpea-test--insert-test-note "c2" "Cabernet")
+   (let* ((dt (vulpea-mentions--title-dictionary))
+          (dict (car dt))
+          (terms (cdr dt)))
+     (should (equal (gethash "cabernet" dict) '("c2"))))))
 
 (ert-deftest vulpea-mentions--collect-outgoing ()
   "Outgoing collect maps matched terms to candidate notes and applies filters."

--- a/test/vulpea-mentions-test.el
+++ b/test/vulpea-mentions-test.el
@@ -243,32 +243,30 @@
           (vulpea-db-update-file ignored)
           (vulpea-db-update-file not-ignored)
           (vulpea-db-update-file mention)
-          (let ((test (lambda (note-id assert)
-                        (let* (result
-                               done
-                               (proc (vulpea-note-unlinked-mentions-async
-                                      (vulpea-db-get-by-id note-id)
-                                      (lambda (mentions)
-                                        (setq result mentions
-                                              done t))
-                                      (lambda (_e) (setq done 'error)))))
-                          (when proc
-                            (let (proc-status)
-                              (while (and (not done)
-                                          (not (equal proc-status 'exit)))
-                                (setq proc-status (process-status proc))
-                                (accept-process-output proc 0.2))))
-                          (funcall assert result done)))))
-            (funcall test
-                     "ignored"
-                     (lambda (result done)
-                       (should (eq done t))
-                       (should (null result))))
-            (funcall test
-                     "not-ignored"
-                     (lambda (result done)
-                       (should (eq done t))
-                       (should (eq (length result) 1))))))
+          ;; Notes set the ignore property short-circuit
+          ;; `vulpea-note-unlinked-mentions-async' without spawning
+          ;; the rg process. RESOLVE is called synchronously.
+          (let (result done)
+            (should (null (vulpea-note-unlinked-mentions-async
+                           (vulpea-db-get-by-id "ignored")
+                           (lambda (mentions) (setq done t
+                                                    result mentions))
+                           (lambda (_e) (setq done 'error)))))
+            (should (eq done t))
+            (should (null result)))
+          ;; Notes without the ignore property are discovered by the
+          ;; rg scan.
+          (let* ((note (vulpea-db-get-by-id "not-ignored"))
+                 (cmd (vulpea-mentions--rg-command
+                       (executable-find "rg")
+                       (vulpea-mentions--note-terms note)
+                       (list dir)))
+                 (output (with-temp-buffer
+                           (apply #'call-process (car cmd) nil t nil (cdr cmd))
+                           (buffer-string)))
+                 (mentions (vulpea-mentions--collect
+                            output note (expand-file-name not-ignored))))
+            (should (= (length mentions) 1))))
       (when vulpea-db--connection (vulpea-db-close))
       (when (file-exists-p vulpea-db-location) (delete-file vulpea-db-location))
       (delete-directory dir t))))

--- a/vulpea-mentions.el
+++ b/vulpea-mentions.el
@@ -243,7 +243,7 @@ the same reasoning as skipping the searched note's own file."
   "Return non-nil if NOTE set the property to ignore incoming mentions."
   (equal vulpea-mentions-ignore-property-value
          (cdr (assoc
-               vulpea-mentions-ignore-property-key
+               (upcase vulpea-mentions-ignore-property-key)
                (vulpea-note-properties note)))))
 
 (defun vulpea-mentions--paths-link-to-note (note)
@@ -296,13 +296,17 @@ to nil to disable this behavior.  Returns a list of plists with
 (defun vulpea-mentions--title-dictionary ()
   "Return (DICT . TERMS) describing the candidate notes' names.
 
-Candidates are the notes kept by `vulpea-mentions-note-filter'.  DICT is
-a hash table mapping a downcased title or alias to the list of note ids
-that bear it.  TERMS is the de-duplicated list of the original title and
-alias strings to search for."
+Candidates are the notes kept by `vulpea-mentions-note-filter' while not
+ignored by `vulpea-mentions--ignore-note-p'.  DICT is a hash table
+mapping a downcased title or alias to the list of note ids that bear it.
+TERMS is the de-duplicated list of the original title and alias strings
+to search for."
   (let ((dict (make-hash-table :test 'equal))
-        (terms nil))
-    (dolist (note (vulpea-db-query vulpea-mentions-note-filter))
+        (terms nil)
+        (filter (lambda (note)
+                  (and (not (vulpea-mentions--ignore-note-p note))
+                       (funcall vulpea-mentions-note-filter note)))))
+    (dolist (note (vulpea-db-query filter))
       (let ((id (vulpea-note-id note))
             (names (cons (vulpea-note-title note) (vulpea-note-aliases note))))
         (dolist (name names)

--- a/vulpea-mentions.el
+++ b/vulpea-mentions.el
@@ -103,6 +103,16 @@ every occurrence regardless of existing links."
   :type 'boolean
   :group 'vulpea-mentions)
 
+(defcustom vulpea-mentions-ignore-property-key "MENTIONS"
+  "Property key to ignore mentions for the current note."
+  :type 'string
+  :group 'vulpea-mentions)
+
+(defcustom vulpea-mentions-ignore-property-value "ignore"
+  "Property value to ignore mentions for the current note."
+  :type 'string
+  :group 'vulpea-mentions)
+
 ;;; Pure helpers
 
 (defun vulpea-mentions--note-terms (note)
@@ -228,6 +238,13 @@ the same reasoning as skipping the searched note's own file."
                              (vulpea-note-aliases note))))
         (lc-terms (mapcar #'downcase terms)))
     (seq-intersection names lc-terms #'string=)))
+
+(defun vulpea-mentions--ignore-note-p (note)
+  "Return non-nil if NOTE set the property to ignore incoming mentions."
+  (equal vulpea-mentions-ignore-property-value
+         (cdr (assoc
+               vulpea-mentions-ignore-property-key
+               (vulpea-note-properties note)))))
 
 (defun vulpea-mentions--paths-link-to-note (note)
   "Return a hash table of note paths that contain links to NOTE."
@@ -360,7 +377,9 @@ Org link, that live in NOTE's own file or in the file of a note sharing
 NOTE's title (a title collision), or that fall on an Org metadata
 line (a keyword or property-drawer line), or that live in a file
 already linking to NOTE (unless `vulpea-mentions-exclude-linked' is
-nil), and maps each remaining hit to the mentioning note.
+nil), and maps each remaining hit to the mentioning note.  If the note
+has property `vulpea-mentions-ignore-property-key' set to
+`vulpea-mentions-ignore-property-value', then skip searches for NOTE.
 
 This is asynchronous and promise-style: exactly one of RESOLVE or
 REJECT is called.
@@ -389,7 +408,8 @@ Returns the ripgrep process, so the caller can wait on or
                               (mapcar #'expand-file-name
                                       vulpea-db-sync-directories)))
             (own-path (expand-file-name (vulpea-note-path note))))
-        (if (or (null terms) (null dirs))
+        (if (or (null terms) (null dirs)
+                (vulpea-mentions--ignore-note-p note))
             (progn (funcall resolve nil) nil)
           (let ((output ""))
             (make-process


### PR DESCRIPTION
Hi, I just implemented the behavior to skip searches for mentions for notes that set a certain property to a certain value. Users can customize both the key and value of the property to ignore the note to searching for mentions.

Though I have a problem when I am writing test for it. I suppose I should test `vulpea-note-unlinked-mentions-async`, but I do not know how to get the resolve function executed when it does not return immediately. Currently, this test always succeed regardless of the underlying implementation.

`vulpea-mentions-async-rejects-without-rg` is a early return without actually spawning the async process. `vulpea-mentions-collect-with-real-rg` also avoids calling the function directly.