### PR TITLE
fix: signal user-error when vulpea-create title is not a string

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -15,6 +15,10 @@
 
 - [[https://github.com/d12frosted/vulpea/issues/369][vulpea#369]] Unlinked mentions no longer include notes that are already linked: a note linking to the target is dropped from the target's incoming mentions, and notes already linked from the buffer are dropped from its outgoing mentions. Once a link exists, further plain-text occurrences are prose, not a missing connection. Set =vulpea-mentions-exclude-linked= to nil to restore the old behavior. Thanks to @drcxd for the implementation.
 
+*Fixes*
+
+- [[https://github.com/d12frosted/vulpea/issues/379][vulpea#379]] =vulpea-create= now signals a clear =user-error= when TITLE is not a string, instead of failing deep inside content formatting with a cryptic type error. Notes without titles are not supported; the title is a structural invariant (it is derived from the org source on every sync), so passing nil was never going to work, it just failed badly.
+
 ** v2.6.0 (2026-07-10)
 
 *Breaking changes*

--- a/test/vulpea-test.el
+++ b/test/vulpea-test.el
@@ -514,6 +514,15 @@ Guards against arbitrary code execution from untrusted note titles."
         (when (file-directory-p vulpea-default-notes-directory)
           (delete-directory vulpea-default-notes-directory t))))))
 
+(ert-deftest vulpea-create-rejects-non-string-title ()
+  "Test that `vulpea-create' fails loudly when TITLE is not a string."
+  (should-error (vulpea-create nil) :type 'user-error)
+  (should-error (vulpea-create 'some-symbol) :type 'user-error)
+  (should-error (vulpea-create 42) :type 'user-error)
+  ;; heading-level path goes through the same guard
+  (should-error (vulpea-create nil nil :parent (make-vulpea-note :id "x"))
+                :type 'user-error))
+
 (ert-deftest vulpea-create-custom-file-name ()
   "Test note creation with custom file name."
   (vulpea-test--with-temp-db

--- a/vulpea.el
+++ b/vulpea.el
@@ -1268,7 +1268,14 @@ PROPERTIES values, and META values:
   %(elisp)   - Elisp evaluation (e.g., %(user-full-name))
   %<format>  - Timestamp formatting (e.g., %<[%Y-%m-%d]>)
 
-Note: Does not support %a or %i from org-capture."
+Note: Does not support %a or %i from org-capture.
+
+TITLE must be a string; signals `user-error' otherwise.  Notes
+without titles are not supported (see vulpea#379)."
+  (unless (stringp title)
+    (user-error
+     "Note title must be a string, got %S; notes without titles are not supported"
+     title))
   (let* ((id (or id (org-id-new)))
          (context (or context nil)))
     (if parent


### PR DESCRIPTION
While looking into #379 I hit the "quiet death" myself: passing a nil title to `vulpea-create` fails deep inside content formatting with a cryptic `wrong-type-argument char-or-string-p nil`, and in wrapped flows that reads as the note being silently rejected.

Now `vulpea-create` checks the title up front and signals a clear `user-error` when it is not a string. Notes without titles are not supported (the title is derived from the org source on every sync, so nil could never round-trip anyway); this just makes the failure honest.

Deliberately does not touch the defaults merge in `vulpea--create-file` or the `vulpea-create` docstring sections that #376 edits, so it should not conflict with that PR.

Refs #379