### PR TITLE
fix(db-worker): force load-prefer-newer in the worker process

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -23,6 +23,8 @@
 
 - Disabling external monitoring no longer resurrects the fswatch watcher. The fswatch sentinel auto-restarts a died process after 2 seconds, and stopping used to kill the process without detaching that sentinel, so the watcher came back moments after =vulpea-db-autosync-mode= was turned off (and, in the test suite, came back watching the default =org-directory= instead of the test's temp dir). Stop now detaches the sentinel before killing and cancels an already-scheduled respawn.
 
+- The extraction worker now sets =load-prefer-newer= before loading anything. The worker is spawned with =-Q=, so a stale =.elc= sitting next to a newer =.el= used to load in the worker while the main process ran the source, and the two processes silently executed different versions of vulpea. Extraction results could then disagree with what the main process would have produced, in ways that depend on whatever the stale bytecode predates.
+
 ** v2.6.0 (2026-07-10)
 
 *Breaking changes*

--- a/test/vulpea-db-worker-test.el
+++ b/test/vulpea-db-worker-test.el
@@ -76,6 +76,20 @@ Ensures the worker and the file are cleaned up."
        (when (file-exists-p path)
          (delete-file path)))))
 
+(ert-deftest vulpea-db-worker-command-prefers-newer ()
+  "The worker command forces `load-prefer-newer'.
+
+The worker is spawned with -Q, so without this it silently loads a
+stale .elc even when the .el next to it is newer - and then runs
+different extraction code than the main process (which, under eldev,
+prefers the newer source).  The mismatch is invisible until an
+extractor observes behavior the stale bytecode predates."
+  (let ((cmd (vulpea-db-worker--command)))
+    (should (member "(setq load-prefer-newer t)" cmd))
+    ;; It must take effect before the worker library itself is loaded.
+    (should (< (seq-position cmd "(setq load-prefer-newer t)")
+               (seq-position cmd "-l")))))
+
 (ert-deftest vulpea-db-worker-async-database-equals-sync ()
   "Worker-extracted data lands in the database byte-identically.
 Indexes the adversarial corpus twice - synchronously in one database,

--- a/vulpea-db-worker.el
+++ b/vulpea-db-worker.el
@@ -413,7 +413,13 @@ output is not.")
     (append (list emacs "--batch" "-Q")
             (mapcan (lambda (dir) (list "-L" dir))
                     (seq-filter #'stringp load-path))
-            (list "-l" lib "-f" "vulpea-db-worker-batch-main"))))
+            ;; -Q leaves `load-prefer-newer' nil, so a stale .elc next
+            ;; to a newer .el would load in the worker while the main
+            ;; process runs the source - two processes silently
+            ;; executing different versions of vulpea.  Prefer the
+            ;; newer file, whatever it is, before anything loads.
+            (list "--eval" "(setq load-prefer-newer t)"
+                  "-l" lib "-f" "vulpea-db-worker-batch-main"))))
 
 (defun vulpea-db-worker--salvage ()
   "Re-enqueue in-flight work of a dead worker and reset client state.


### PR DESCRIPTION
The worker is spawned with -Q, which leaves load-prefer-newer nil. A stale .elc next to a newer .el then loads in the worker while the main process runs the source, so the two processes silently execute different versions of vulpea.

Found while chasing a test that failed only in source-mode eldev runs: a pre-AST-stripping .elc made the worker hand extractors the org-element tree that current code hides. Packaged mode (make test, CI) never sees this because both sides load the same freshly built copy.

Fix: set load-prefer-newer before the worker loads anything.