### PR TITLE
Ignore mentions per note

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -17,6 +17,8 @@
 
 - [[https://github.com/d12frosted/vulpea/issues/369][vulpea#369]] A note can now opt out of mention detection entirely by setting the =MENTIONS= property to =ignore= (both customizable via =vulpea-mentions-ignore-property-key= and =vulpea-mentions-ignore-property-value=). An opted-out note gets no incoming mention scan, and its title and aliases are never suggested as outgoing mentions in other notes. Made for notes whose titles are everyday words (a note called "Sets" matching the verb in every other file). Thanks to @drcxd for the implementation.
 
+- [[https://github.com/d12frosted/vulpea/issues/369][vulpea #369]] a note can now drop mentions from another note by setting the =IGNORE_MENTIONS_FROM= (customizable via =vulpea-mentions-per-note-ignore-property-key=) org property. Its value is a whitespace-separated list of file-level note ids. Any mention from those notes to this note will be excluded from the "Unlinked Mentions" list of this note and the "Outgoing Mentions" list of those note.
+
 *Fixes*
 
 - [[https://github.com/d12frosted/vulpea/issues/379][vulpea#379]] =vulpea-create= now signals a clear =user-error= when TITLE is not a string, instead of failing deep inside content formatting with a cryptic type error. Notes without titles are not supported; the title is a structural invariant (it is derived from the org source on every sync), so passing nil was never going to work, it just failed badly.

--- a/test/vulpea-mentions-test.el
+++ b/test/vulpea-mentions-test.el
@@ -24,7 +24,7 @@
 ;;; Pure helpers
 
 (defun vulpea-mentions-test--collect-incoming-mentions-for-note (id)
-  "Return mentions for note specified by ID. "
+  "Return mentions for note specified by ID."
   (let* ((note (vulpea-db-get-by-id id))
          (path (vulpea-note-path note))
          (cmd (vulpea-mentions--rg-command
@@ -54,7 +54,7 @@ NOTE can be either an ID or a `vulpea-note' object."
           (let* (linked-ids
                  (note-path (expand-file-name (vulpea-note-path note)))
                  (output (with-temp-buffer
-                           (insert-file note-path)
+                           (insert-file-contents note-path)
                            (setq linked-ids
                                  (vulpea-mentions--buffer-link-ids))
                            (let ((out (generate-new-buffer " *rg*")))
@@ -347,7 +347,6 @@ NOTE can be either an ID or a `vulpea-note' object."
      (should (eq (length mentions) 1)))
    ;; Outgoing mentions to notes explicitly ignore us are dropped.
    (let ((mentions (vulpea-mentions-test--collect-outgoing-mentions-for-note "pc-prediction")))
-     (eldev-debug "%s" (plist-get (car mentions) :context))
      (should (eq (length mentions) 0)))))
 
 (ert-deftest vulpea-mentions-async-rejects-without-rg ()

--- a/test/vulpea-mentions-test.el
+++ b/test/vulpea-mentions-test.el
@@ -38,6 +38,41 @@
                     output note (expand-file-name path))))
     mentions))
 
+(defun vulpea-mentions-test--collect-outgoing-mentions-for-note (note)
+  "Returns outgoing mentions for NOTE.
+
+NOTE can be either an ID or a `vulpea-note' object."
+  (let* ((terms-dict (vulpea-mentions--title-dictionary))
+         (terms (cdr terms-dict))
+         (dict (car terms-dict))
+         (patterns (make-temp-file "vmp-")))
+    (unwind-protect
+        (progn
+          (unless (vulpea-note-p note)
+            (setq note (vulpea-db-get-by-id note)))
+          (with-temp-file patterns (insert (mapconcat #'identity terms "\n") "\n"))
+          (let* (linked-ids
+                 (note-path (expand-file-name (vulpea-note-path note)))
+                 (output (with-temp-buffer
+                           (insert-file note-path)
+                           (setq linked-ids
+                                 (vulpea-mentions--buffer-link-ids))
+                           (let ((out (generate-new-buffer " *rg*")))
+                             (call-process-region
+                              (point-min) (point-max) (executable-find "rg")
+                              nil out nil "--json" "--fixed-strings" "--ignore-case"
+                              "--word-regexp" "-f" patterns "-")
+                             (prog1 (with-current-buffer out (buffer-string))
+                               (kill-buffer out)))))
+                 (self-ids (mapcar #'vulpea-note-id
+                                   (vulpea-db-query-by-file-path note-path))))
+            (vulpea-mentions--collect-outgoing
+             output
+             dict
+             self-ids
+             linked-ids)))
+      (delete-file patterns))))
+
 (ert-deftest vulpea-mentions--note-terms-title-and-aliases ()
   "Terms are the title and aliases, trimmed and de-duplicated."
   (let ((note (make-vulpea-note :title "Cabernet Sauvignon"
@@ -287,23 +322,33 @@
       (delete-directory dir t))))
 
 (ert-deftest vulpea-mentions-per-note-ignore ()
-  "When a note is specifically ignored, drop its mentions to that note."
+  "Mentions from explicitly ignored notes should be dropped."
   (vulpea-test--with-temp-db-and-files
-   `((:name "target.org"
+   `((:name "stems.org"
             :content
-            ,(concat ":PROPERTIES:\n:ID: target\n"
-                     (format ":%s: ignored-mention\n" vulpea-mentions-per-note-ignore-property-key)
-                     ":END:\n#+title: Target\n\n"))
-     (:name "mention.org"
+            ,(concat ":PROPERTIES:\n:ID: stems\n"
+                     (format ":%s: pc-prediction\n" vulpea-mentions-per-note-ignore-property-key)
+                     ":END:\n#+title: Stems\n\n"))
+     (:name "notes.org"
             :content
-            ,(concat ":PROPERTIES:\n:ID: mention\n:END:\n#+title: Mention\n\n"
-                     "A mention to target that should not be ignored.\n"))
-     (:name "ignored-mention.org"
+            ,(concat ":PROPERTIES:\n:ID: notes\n:END:\n#+title: Notes\n\n"
+                     "Notes may have stems attached to them."))
+     (:name "pc-prediction.org"
             :content
-            ,(concat ":PROPERTIES:\n:ID: ignored-mention\n:END:\n#+title: Ignored Mention\n\n"
-                     "A mention to target that should be ignored\n")))
-   (let ((mentions (vulpea-mentions-test--collect-incoming-mentions-for-note "target")))
-     (should (eq 1 (length mentions))))))
+            ,(concat ":PROPERTIES:\n:ID: pc-prediction\n:END:\n#+title: PC Prediction\n\n"
+                     "This strategy stems from ...")))
+   ;; Only one incoming mentions from Notes
+   (let ((mentions (vulpea-mentions-test--collect-incoming-mentions-for-note "stems")))
+     (should (eq 1 (length mentions)))
+     (should (string-match-p "Notes may have"
+                             (plist-get (car mentions) :context))))
+   ;; Normal outgoing mentions
+   (let ((mentions (vulpea-mentions-test--collect-outgoing-mentions-for-note "notes")))
+     (should (eq (length mentions) 1)))
+   ;; Outgoing mentions to notes explicitly ignore us are dropped.
+   (let ((mentions (vulpea-mentions-test--collect-outgoing-mentions-for-note "pc-prediction")))
+     (eldev-debug "%s" (plist-get (car mentions) :context))
+     (should (eq (length mentions) 0)))))
 
 (ert-deftest vulpea-mentions-async-rejects-without-rg ()
   "When ripgrep is unavailable, REJECT is called."
@@ -477,6 +522,25 @@
                   (should (equal (plist-get merlot :matched) "Merlot"))
                   (should (equal (plist-get merlot :context) "More Merlot and Syrah later."))))))
         (delete-file patterns)))))
+
+(ert-deftest vulpea-mentions-outgoing-ignore-per-note ()
+  "When this note is ignored by another note, drop its mentions to that note."
+  (vulpea-test--with-temp-db-and-files
+   `((:name "target.org"
+            :content
+            ,(concat ":PROPERTIES:\n:ID: target\n"
+                     (format ":%s: ignored-mention\n" vulpea-mentions-per-note-ignore-property-key)
+                     ":END:\n#+title: Target\n\n"))
+     (:name "mention.org"
+            :content
+            ,(concat ":PROPERTIES:\n:ID: mention\n:END:\n#+title: Mention\n\n"
+                     "A mention to target that should not be ignored.\n"))
+     (:name "ignored-mention.org"
+            :content
+            ,(concat ":PROPERTIES:\n:ID: ignored-mention\n:END:\n#+title: Ignored Mention\n\n"
+                     "A mention to target that should be ignored\n")))
+
+   ))
 
 (ert-deftest vulpea-mentions-outgoing-rejects-without-rg ()
   "When ripgrep is unavailable, the outgoing search REJECTs."

--- a/test/vulpea-mentions-test.el
+++ b/test/vulpea-mentions-test.el
@@ -23,6 +23,21 @@
 
 ;;; Pure helpers
 
+(defun vulpea-mentions-test--collect-incoming-mentions-for-note (id)
+  "Return mentions for note specified by ID. "
+  (let* ((note (vulpea-db-get-by-id id))
+         (path (vulpea-note-path note))
+         (cmd (vulpea-mentions--rg-command
+               (executable-find "rg")
+               (vulpea-mentions--note-terms note)
+               vulpea-db-sync-directories))
+         (output (with-temp-buffer
+                   (apply #'call-process (car cmd) nil t nil (cdr cmd))
+                   (buffer-string)))
+         (mentions (vulpea-mentions--collect
+                    output note (expand-file-name path))))
+    mentions))
+
 (ert-deftest vulpea-mentions--note-terms-title-and-aliases ()
   "Terms are the title and aliases, trimmed and de-duplicated."
   (let ((note (make-vulpea-note :title "Cabernet Sauvignon"
@@ -270,6 +285,25 @@
       (when vulpea-db--connection (vulpea-db-close))
       (when (file-exists-p vulpea-db-location) (delete-file vulpea-db-location))
       (delete-directory dir t))))
+
+(ert-deftest vulpea-mentions-per-note-ignore ()
+  "When a note is specifically ignored, drop its mentions to that note."
+  (vulpea-test--with-temp-db-and-files
+   `((:name "target.org"
+            :content
+            ,(concat ":PROPERTIES:\n:ID: target\n"
+                     (format ":%s: ignored-mention\n" vulpea-mentions-per-note-ignore-property-key)
+                     ":END:\n#+title: Target\n\n"))
+     (:name "mention.org"
+            :content
+            ,(concat ":PROPERTIES:\n:ID: mention\n:END:\n#+title: Mention\n\n"
+                     "A mention to target that should not be ignored.\n"))
+     (:name "ignored-mention.org"
+            :content
+            ,(concat ":PROPERTIES:\n:ID: ignored-mention\n:END:\n#+title: Ignored Mention\n\n"
+                     "A mention to target that should be ignored\n")))
+   (let ((mentions (vulpea-mentions-test--collect-incoming-mentions-for-note "target")))
+     (should (eq 1 (length mentions))))))
 
 (ert-deftest vulpea-mentions-async-rejects-without-rg ()
   "When ripgrep is unavailable, REJECT is called."

--- a/test/vulpea-mentions-test.el
+++ b/test/vulpea-mentions-test.el
@@ -523,25 +523,6 @@ NOTE can be either an ID or a `vulpea-note' object."
                   (should (equal (plist-get merlot :context) "More Merlot and Syrah later."))))))
         (delete-file patterns)))))
 
-(ert-deftest vulpea-mentions-outgoing-ignore-per-note ()
-  "When this note is ignored by another note, drop its mentions to that note."
-  (vulpea-test--with-temp-db-and-files
-   `((:name "target.org"
-            :content
-            ,(concat ":PROPERTIES:\n:ID: target\n"
-                     (format ":%s: ignored-mention\n" vulpea-mentions-per-note-ignore-property-key)
-                     ":END:\n#+title: Target\n\n"))
-     (:name "mention.org"
-            :content
-            ,(concat ":PROPERTIES:\n:ID: mention\n:END:\n#+title: Mention\n\n"
-                     "A mention to target that should not be ignored.\n"))
-     (:name "ignored-mention.org"
-            :content
-            ,(concat ":PROPERTIES:\n:ID: ignored-mention\n:END:\n#+title: Ignored Mention\n\n"
-                     "A mention to target that should be ignored\n")))
-
-   ))
-
 (ert-deftest vulpea-mentions-outgoing-rejects-without-rg ()
   "When ripgrep is unavailable, the outgoing search REJECTs."
   (cl-letf (((symbol-function 'executable-find) (lambda (&rest _) nil)))

--- a/test/vulpea-test-helpers.el
+++ b/test/vulpea-test-helpers.el
@@ -64,6 +64,31 @@ the database and org file afterward."
        (when (file-exists-p temp-org-file)
          (delete-file temp-org-file)))))
 
+(defmacro vulpea-test--with-temp-db-and-files (files &rest body)
+  "Execute BODY with temporary database constructed upon FILES.
+
+FILES is a list of plists, where each plist has two properties `:name'
+and `:content', which specifies the name and content of a temporary file
+respectively.  Cleans up both the database and the temporary files
+afterward."
+  (declare (indent 2))
+  `(let* ((dir (make-temp-file "vulpea-mentions-" t))
+          (vulpea-db-location (make-temp-file "vulpea-mentions-" nil ".db"))
+          (vulpea-db--connection nil)
+          (vulpea-db-sync-directories (list dir)))
+     (unwind-protect
+         (progn
+           (vulpea-db)
+           (dolist (file ,files)
+             (let ((path (expand-file-name (plist-get file :name) dir)))
+               (with-temp-file path
+                 (insert (plist-get file :content)))
+               (vulpea-db-update-file path)))
+           ,@body)
+       (when vulpea-db--connection (vulpea-db-close))
+       (when (file-exists-p vulpea-db-location) (delete-file vulpea-db-location))
+       (delete-directory dir t))))
+
 ;;; File Helpers
 
 (defun vulpea-test--create-temp-org-file (content)

--- a/test/vulpea-test-helpers.el
+++ b/test/vulpea-test-helpers.el
@@ -71,7 +71,7 @@ FILES is a list of plists, where each plist has two properties `:name'
 and `:content', which specifies the name and content of a temporary file
 respectively.  Cleans up both the database and the temporary files
 afterward."
-  (declare (indent 2))
+  (declare (indent 1))
   `(let* ((dir (make-temp-file "vulpea-mentions-" t))
           (vulpea-db-location (make-temp-file "vulpea-mentions-" nil ".db"))
           (vulpea-db--connection nil)

--- a/vulpea-mentions.el
+++ b/vulpea-mentions.el
@@ -120,6 +120,14 @@ otherwise produce mostly false positives."
   :type 'string
   :group 'vulpea-mentions)
 
+(defcustom vulpea-mentions-per-note-ignore-property-key "IGNORE-MENTIONS-FROM"
+  "Org property marking notes ignored from mention detection for this note.
+
+Its value is a list of note ids.  Mentions from those notes to this note
+are excluded from mention lists."
+  :type 'string
+  :group 'vulpea-mentions)
+
 ;;; Pure helpers
 
 (defun vulpea-mentions--note-terms (note)
@@ -268,6 +276,22 @@ candidate dictionary."
     (mapc (lambda (path) (puthash (expand-file-name path) t result)) paths)
     result))
 
+(defun vulpea-mentions--ignore-mention-ids (note)
+  "Return note ids that mentions from them are ignored by NOTE.
+
+NOTE can be either a note object or a note id."
+  (unless (vulpea-note-p note)
+    (setq note (vulpea-db-get-by-id note)))
+  (let* ((result (make-hash-table :test 'equal))
+         (properties (vulpea-note-properties note))
+         (ignore-mentions
+          (assoc (upcase vulpea-mentions-per-note-ignore-property-key)
+                 properties)))
+    (when ignore-mentions
+      (let ((ignored-ids (split-string (cdr ignore-mentions))))
+        (mapc (lambda (id) (puthash id t result)) ignored-ids)))
+    result))
+
 (defun vulpea-mentions--collect (output note own-path)
   "Collect unlinked mentions of NOTE from ripgrep OUTPUT.
 
@@ -275,14 +299,17 @@ OWN-PATH is NOTE's own expanded file path, whose hits are skipped.  Hits
 whose mentioning note shares a name with NOTE (a title collision) are
 skipped too.  Hits whose mentioning note contains at least one explicit
 link to NOTE are skipped as well.  Set `vulpea-mentions-exclude-linked'
-to nil to disable this behavior.  Returns a list of plists with
-:note (the mentioning note), :path, :line, and :context."
+to nil to disable this behavior.  Hits whose mentioning note are ignored
+explicitly by `vulpea-mentions-per-note-ignore-property' are skipped as
+well.  Returns a list of plists with :note (the mentioning note), :path,
+:line, and :context."
   (let* ((terms (vulpea-mentions--note-terms note))
          (path->note (make-hash-table :test 'equal))
          (hits (vulpea-mentions--parse-rg-json output))
          (paths-link-to-note
           (when (and vulpea-mentions-exclude-linked hits)
             (vulpea-mentions--paths-link-to-note note)))
+         (ignore-mention-ids (vulpea-mentions--ignore-mention-ids note))
          (result nil))
     (dolist (hit hits)
       (let* ((path (plist-get hit :path))
@@ -295,7 +322,8 @@ to nil to disable this behavior.  Returns a list of plists with
                    (vulpea-mentions--line-unlinked-p line-text terms))
           (let ((mentioning (vulpea-mentions--file-note path path->note)))
             (when (and mentioning
-                       (not (vulpea-mentions--shares-name-p mentioning terms)))
+                       (not (vulpea-mentions--shares-name-p mentioning terms))
+                       (not (gethash (vulpea-note-id mentioning) ignore-mention-ids)))
               (push (list :note mentioning
                           :path path
                           :line (plist-get hit :line)
@@ -347,15 +375,28 @@ search for \"[[\" is also much cheaper than the plain-link regexp."
          (puthash (plist-get link :dest) t result))))
     result))
 
+(defun vulpea-mentions--ignored-by-note-p (ids note)
+  "Return non-nil if at least one of IDS is ignored by NOTE.
+
+NOTE can be a note object or a note id."
+  (let (result
+        (ignore-mentions-id (vulpea-mentions--ignore-mention-ids note)))
+    (dolist (id ids)
+      (when (gethash id ignore-mentions-id)
+        (setq result t)))
+    result))
+
 (defun vulpea-mentions--collect-outgoing (output dict self-ids linked-ids)
   "Collect outgoing unlinked mentions from ripgrep OUTPUT over one buffer.
 
 DICT maps a downcased title/alias to candidate note ids (see
 `vulpea-mentions--title-dictionary').  SELF-IDS are the note ids in the
-buffer's own file, excluded as candidates.  LINKED-IDS is a hash table
-keyed by the note ids the buffer already links to (see
-`vulpea-mentions--buffer-link-ids'); candidates found in it are
-dropped.  Pass an empty table to keep them all.
+buffer's own file, excluded as candidates.  If one of SELF-IDS are
+explicitly ignored by the mentioned note, then the mention will be
+dropped (see `vulpea-mentions-per-note-ignore-property-key').
+LINKED-IDS is a hash table keyed by the note ids the buffer already
+links to (see `vulpea-mentions--buffer-link-ids'); candidates found in
+it are dropped.  Pass an empty table to keep them all.
 
 Returns a list of plists with :note (a candidate note to link to),
 :line, :context, and :matched (the text that matched)."
@@ -374,7 +415,8 @@ Returns a list of plists with :note (a candidate note to link to),
                 (when (vulpea-mentions--line-unlinked-p line-text (list term))
                   (dolist (id (gethash (downcase term) dict))
                     (unless (or (member id self-ids)
-                                (gethash id linked-ids))
+                                (gethash id linked-ids)
+                                (vulpea-mentions--ignored-by-note-p self-ids id))
                       (when-let* ((cand (resolve-note id)))
                         (push (list :note cand :line line-no
                                     :context (string-trim line-text)

--- a/vulpea-mentions.el
+++ b/vulpea-mentions.el
@@ -120,11 +120,11 @@ otherwise produce mostly false positives."
   :type 'string
   :group 'vulpea-mentions)
 
-(defcustom vulpea-mentions-per-note-ignore-property-key "IGNORE-MENTIONS-FROM"
+(defcustom vulpea-mentions-per-note-ignore-property-key "IGNORE_MENTIONS_FROM"
   "Org property marking notes ignored from mention detection for this note.
 
-Its value is a list of note ids.  Mentions from those notes to this note
-are excluded from mention lists."
+Its value is a whitespace-separated list of file level note ids.
+Mentions from those notes to this note are excluded from mention lists."
   :type 'string
   :group 'vulpea-mentions)
 
@@ -277,11 +277,7 @@ candidate dictionary."
     result))
 
 (defun vulpea-mentions--ignore-mention-ids (note)
-  "Return note ids that mentions from them are ignored by NOTE.
-
-NOTE can be either a note object or a note id."
-  (unless (vulpea-note-p note)
-    (setq note (vulpea-db-get-by-id note)))
+  "Return note ids that mentions from them are ignored by NOTE."
   (let* ((result (make-hash-table :test 'equal))
          (properties (vulpea-note-properties note))
          (ignore-mentions
@@ -300,9 +296,9 @@ whose mentioning note shares a name with NOTE (a title collision) are
 skipped too.  Hits whose mentioning note contains at least one explicit
 link to NOTE are skipped as well.  Set `vulpea-mentions-exclude-linked'
 to nil to disable this behavior.  Hits whose mentioning note are ignored
-explicitly by `vulpea-mentions-per-note-ignore-property' are skipped as
-well.  Returns a list of plists with :note (the mentioning note), :path,
-:line, and :context."
+explicitly by `vulpea-mentions-per-note-ignore-property-key' are skipped
+as well.  Returns a list of plists with :note (the mentioning note),
+:path, :line, and :context."
   (let* ((terms (vulpea-mentions--note-terms note))
          (path->note (make-hash-table :test 'equal))
          (hits (vulpea-mentions--parse-rg-json output))
@@ -376,15 +372,9 @@ search for \"[[\" is also much cheaper than the plain-link regexp."
     result))
 
 (defun vulpea-mentions--ignored-by-note-p (ids note)
-  "Return non-nil if at least one of IDS is ignored by NOTE.
-
-NOTE can be a note object or a note id."
-  (let (result
-        (ignore-mentions-id (vulpea-mentions--ignore-mention-ids note)))
-    (dolist (id ids)
-      (when (gethash id ignore-mentions-id)
-        (setq result t)))
-    result))
+  "Return non-nil if at least one of IDS is ignored by NOTE."
+  (let ((ignore-mentions-id (vulpea-mentions--ignore-mention-ids note)))
+    (seq-some (lambda (id) (gethash id ignore-mentions-id)) ids)))
 
 (defun vulpea-mentions--collect-outgoing (output dict self-ids linked-ids)
   "Collect outgoing unlinked mentions from ripgrep OUTPUT over one buffer.
@@ -415,13 +405,13 @@ Returns a list of plists with :note (a candidate note to link to),
                 (when (vulpea-mentions--line-unlinked-p line-text (list term))
                   (dolist (id (gethash (downcase term) dict))
                     (unless (or (member id self-ids)
-                                (gethash id linked-ids)
-                                (vulpea-mentions--ignored-by-note-p self-ids id))
+                                (gethash id linked-ids))
                       (when-let* ((cand (resolve-note id)))
-                        (push (list :note cand :line line-no
+                        (unless (vulpea-mentions--ignored-by-note-p self-ids cand)
+                          (push (list :note cand :line line-no
                                     :context (string-trim line-text)
                                     :matched term)
-                              result))))))))))
+                                result)))))))))))
       (nreverse result))))
 
 ;;; Async entry point


### PR DESCRIPTION
Hi @d12frosted , this is my first draft of the idea 2 from #369. Basically, I think users should be able to silence mentions from particular notes, by specifying ids of those notes in an org property. The test contains another real use case in my notes which demonstrates situation that mention may be unintended.

Please let me know your opinion about this.