### PR TITLE
fix(insert): use created note title as link description

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -27,6 +27,8 @@
 
 - The extraction worker now sets =load-prefer-newer= before loading anything. The worker is spawned with =-Q=, so a stale =.elc= sitting next to a newer =.el= used to load in the worker while the main process ran the source, and the two processes silently executed different versions of vulpea. Extraction results could then disagree with what the main process would have produced, in ways that depend on whatever the stale bytecode predates.
 
+- [[https://github.com/d12frosted/vulpea/issues/375][vulpea#375]] =vulpea-insert= now derives the inserted link description from the created note's final title. When =vulpea-create-default-function= rewrites the title during creation (say, stripping a =#contact= routing marker the user typed to pick a template), the link used to keep the raw typed text as its description while the note itself got the clean title. A selected region still wins as the description, as before.
+
 *Documentation*
 
 - [[https://github.com/d12frosted/vulpea/issues/382][vulpea#382]] The plugin guide no longer implies that custom =note-data= keys end up in the database. They are transient: a way to pass data between extractors within a single extraction run, dropped once the run is over - only the documented core fields are persisted, and unknown keys are silently ignored. The guide now says so explicitly and gains a "Storing Per-Note Data" section with the recipes for data that should survive: a 1:1 side table keyed by =note-id=, a generic =(note-id, axis, value)= table when there are several axes, or a property/metadata entry in the file itself. Thanks to @edenworky for pointing out the misleading wording.

--- a/test/vulpea-test.el
+++ b/test/vulpea-test.el
@@ -1565,6 +1565,27 @@ Guards against arbitrary code execution from untrusted note titles."
         (should explicit-called)
         (should-not default-called)))))
 
+(ert-deftest vulpea-insert-uses-rewritten-title-as-description ()
+  "Test that the link description follows a title rewritten during creation.
+
+When `vulpea-create-default-function' rewrites the title (e.g. to
+strip a routing marker), the inserted link should use the created
+note's final title, not the raw text the user typed."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (let ((vulpea-insert-default-create-fn nil)
+          (vulpea-create-default-function
+           (lambda (title)
+             (list :title (string-replace " #contact" "" title)))))
+      (cl-letf (((symbol-function 'vulpea-select-from)
+                 (lambda (_prompt _notes &rest _)
+                   (make-vulpea-note :title "Frodo #contact" :level 0))))
+        (with-temp-buffer
+          (org-mode)
+          (vulpea-insert :candidates-fn (lambda (_) nil))
+          (should (string-match-p "\\[Frodo\\]\\]" (buffer-string)))
+          (should-not (string-match-p "#contact" (buffer-string))))))))
+
 ;;; Title Propagation Tests
 
 ;;;; Link Categorization Tests

--- a/vulpea.el
+++ b/vulpea.el
@@ -1070,7 +1070,11 @@ for the original title and once for each alias."
                     (set-marker end nil))
                   (insert (org-link-make-string
                            (concat "id:" (vulpea-note-id new-note))
-                           description))
+                           ;; Prefer the created note's title: it may have
+                           ;; been rewritten during creation (e.g. by
+                           ;; `vulpea-create-default-function'), while
+                           ;; `description' still holds the typed text.
+                           (or region-text (vulpea-note-title new-note))))
                   (run-hook-with-args
                    'vulpea-insert-handle-functions
                    new-note)))))))


### PR DESCRIPTION
Follow-up to #375. When `vulpea-create-default-function` rewrites the title during creation (e.g. stripping a `#contact` marker used to pick a template), `vulpea-insert` kept the raw typed text as the link description while the note got the clean title. Now the description follows the created note's final title. A selected region still wins, same as before.