### PR TITLE
feat: move a note to another directory

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -7,6 +7,12 @@
 :ID:                     e3f3602c-426e-451e-bcb5-b59b99e3b10e
 :END:
 
+** Unreleased
+
+*Features*
+
+- [[https://github.com/d12frosted/vulpea/issues/405][vulpea#405]] New =vulpea-move-file= moves a note's file into another directory, keeping its file name. With several roots in =vulpea-db-sync-directories=, new notes always land in the first one, and getting them anywhere else meant moving the file by hand and then making sure the database and =org-id= caught up. Links are unaffected: they are ids and not paths, so nothing is rewritten, the file simply moves, =org-id= is pointed at the new location and the old file's rows are replaced by the new file's. Moving and renaming stay separate commands, since =vulpea-rename-file= derives the file name from a title while this one deliberately leaves it alone; both share the same mechanical half now. Moving outside =vulpea-db-sync-directories= is refused when any are configured, because the note would keep working until the next full scan and then silently drop out of the database; with none configured there is nothing to check and any existing directory is accepted. Interactively it takes the note the current buffer visits - always the file-level one, so point can sit in any heading - and completes the target over directories that already hold notes without restricting you to them, so a directory that exists but is still empty can be typed in and confirmed. A buffer visiting the note follows the file to its new location instead of being killed. Thanks to @edenworky for describing the pain in [[https://github.com/d12frosted/vulpea/issues/343][vulpea#343]].
+
 ** v2.7.0 (2026-07-23)
 
 *Breaking changes*

--- a/docs/api-reference.org
+++ b/docs/api-reference.org
@@ -800,6 +800,41 @@ Rename a note's file based on a new title:
 
 Only works for file-level notes (=level = 0=).
 
+** vulpea-move-file
+
+Move a note's file to another directory, keeping its file name:
+
+#+begin_src emacs-lisp
+(vulpea-move-file note-or-id "~/vault/projects/")
+;; => new file path
+
+;; Moves: notes/my_note.org → projects/my_note.org
+;; Updates database and org-id location
+;; Leaves links alone (they are ids, not paths)
+#+end_src
+
+This is the counterpart to =vulpea-rename-file=: renaming derives a new
+file name from a title and keeps the directory, moving keeps the file
+name and changes the directory.
+
+Signals a =user-error= when the note cannot be found, when it is a
+heading-level note, when its file is gone from disk, when the directory
+does not exist or is not writable, when the note already lives there,
+or when a file of the same name is already in the target directory.
+
+Moving outside =vulpea-db-sync-directories= is refused as well (unless
+no sync directories are configured): the note would keep working until
+the next full scan and then silently drop out of the database.
+
+When a buffer visits the note, it is saved and replaced by a buffer
+visiting the new location, with point kept.
+
+Called interactively, the note is the one the current buffer visits.
+This is always the file-level note, never a heading inside it, so it
+works with point anywhere in the file. Completion for the target offers
+directories that already hold notes, but is not restricted to them: a
+directory that exists but is still empty can be typed in and confirmed.
+
 ** vulpea-title-change-detection-mode
 
 Minor mode that detects title changes on save:

--- a/docs/user-guide.org
+++ b/docs/user-guide.org
@@ -466,6 +466,22 @@ You can also rename files programmatically:
 
 → See [[file:api-reference.org][API Reference]] for detailed function documentation.
 
+** Moving a Note to Another Directory
+
+Renaming changes the file name and keeps the directory. Moving does the opposite:
+
+#+begin_src emacs-lisp
+(vulpea-move-file note "~/vault/projects/")
+#+end_src
+
+Or interactively with =M-x vulpea-move-file=, which picks up the note the current buffer visits (point can be anywhere in the file) and completes the target over directories that already hold notes. You are not limited to those: a directory that exists but is still empty can be typed in and confirmed. If you are looking at the note when you move it, the buffer follows the file to its new location.
+
+This is mostly useful when =vulpea-db-sync-directories= has more than one root. New notes are created in the first one (or in =vulpea-default-notes-directory= when set), so moving a note elsewhere afterwards used to mean doing it by hand.
+
+Links keep working, because they are ids and not paths. Nothing is rewritten.
+
+Moving a note outside =vulpea-db-sync-directories= is refused: the note would keep working until the next full scan, then quietly disappear from the database. If you have no sync directories configured there is nothing to check, and any existing directory is accepted.
+
 * Synchronization
 
 ** Automatic Sync

--- a/test/vulpea-test.el
+++ b/test/vulpea-test.el
@@ -2426,6 +2426,300 @@ the whole match."
         (when (file-directory-p temp-dir)
           (delete-directory temp-dir t))))))
 
+;;;; File Move Tests (#405)
+
+(defmacro vulpea-test--with-move-fixture (spec &rest body)
+  "Execute BODY with a two-directory vault fixture.
+
+SPEC is a list (ID TITLE) naming the note created in the source
+directory.  Binds `root' (the vault, and the only entry of
+`vulpea-db-sync-directories'), `src-dir', `dst-dir' and `old-path',
+indexes the note, and removes the whole tree afterwards."
+  (declare (indent 1))
+  (let ((id (nth 0 spec))
+        (title (nth 1 spec)))
+    `(let* ((root (make-temp-file "vulpea-test-" t))
+            (vulpea-db-sync-directories (list root))
+            (src-dir (expand-file-name "src" root))
+            (dst-dir (expand-file-name "dst" root))
+            (old-path (expand-file-name
+                       (concat (vulpea-title-to-slug ,title) ".org")
+                       src-dir)))
+       (unwind-protect
+           (progn
+             (make-directory src-dir t)
+             (make-directory dst-dir t)
+             (with-temp-file old-path
+               (insert (format ":PROPERTIES:\n:ID: %s\n:END:\n#+TITLE: %s\n"
+                               ,id ,title)))
+             (vulpea-db-update-file old-path)
+             ,@body)
+         (dolist (buf (buffer-list))
+           (when-let* ((file (buffer-file-name buf)))
+             (when (string-prefix-p (file-name-as-directory root) file)
+               (with-current-buffer buf
+                 (set-buffer-modified-p nil))
+               (kill-buffer buf))))
+         (when (file-directory-p root)
+           (delete-directory root t))))))
+
+(ert-deftest vulpea-move-file-basic ()
+  "Moving a note relocates its file and keeps the file name."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--with-move-fixture ("move-basic-id" "Move Me")
+      (let ((expected (expand-file-name "move_me.org" dst-dir)))
+        (should (equal (vulpea-move-file "move-basic-id" dst-dir) expected))
+        (should (file-exists-p expected))
+        (should-not (file-exists-p old-path))))))
+
+(ert-deftest vulpea-move-file-updates-db ()
+  "Moving a note updates its path in the database."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--with-move-fixture ("move-db-id" "Database Move")
+      (vulpea-move-file "move-db-id" dst-dir)
+      (let ((note (vulpea-db-get-by-id "move-db-id")))
+        (should note)
+        (should (equal (vulpea-note-path note)
+                       (expand-file-name "database_move.org" dst-dir)))))))
+
+(ert-deftest vulpea-move-file-preserves-title ()
+  "Moving a note leaves its title alone."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--with-move-fixture ("move-title-id" "Untouched Title")
+      (vulpea-move-file "move-title-id" dst-dir)
+      (should (equal (vulpea-note-title (vulpea-db-get-by-id "move-title-id"))
+                     "Untouched Title")))))
+
+(ert-deftest vulpea-move-file-with-note-object ()
+  "Moving accepts a note object, not just an id."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--with-move-fixture ("move-obj-id" "Note Object Move")
+      (let ((note (vulpea-db-get-by-id "move-obj-id")))
+        (vulpea-move-file note dst-dir)
+        (should (file-exists-p
+                 (expand-file-name "note_object_move.org" dst-dir)))
+        (should-not (file-exists-p old-path))))))
+
+(ert-deftest vulpea-move-file-accepts-directory-without-slash ()
+  "DIRECTORY may be given with or without a trailing slash."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--with-move-fixture ("move-slash-id" "Slash Move")
+      (should (equal (vulpea-move-file "move-slash-id"
+                                       (directory-file-name dst-dir))
+                     (expand-file-name "slash_move.org" dst-dir))))))
+
+(ert-deftest vulpea-move-file-keeps-links-resolvable ()
+  "Links into a moved note still resolve, since they are ids."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--with-move-fixture ("move-link-id" "Linked Move")
+      (let ((linking-path (expand-file-name "linking.org" src-dir)))
+        (with-temp-file linking-path
+          (insert ":PROPERTIES:\n:ID: move-linking-id\n:END:\n"
+                  "#+TITLE: Linking Note\n\n"
+                  "See [[id:move-link-id][Linked Move]].\n"))
+        (vulpea-db-update-file linking-path)
+        (vulpea-move-file "move-link-id" dst-dir)
+        ;; The link target still resolves, and the linking note was
+        ;; never touched.
+        (should (vulpea-db-get-by-id "move-link-id"))
+        (should (equal (vulpea-note-path (vulpea-db-get-by-id "move-link-id"))
+                       (expand-file-name "linked_move.org" dst-dir)))
+        (with-temp-buffer
+          (insert-file-contents linking-path)
+          (should (string-match-p "\\[\\[id:move-link-id\\]"
+                                  (buffer-string))))))))
+
+(ert-deftest vulpea-move-file-conflict ()
+  "Moving errors when the target file already exists."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--with-move-fixture ("move-conflict-id" "Conflict Move")
+      (with-temp-file (expand-file-name "conflict_move.org" dst-dir)
+        (insert "Existing content"))
+      (should-error (vulpea-move-file "move-conflict-id" dst-dir)
+                    :type (quote user-error))
+      ;; Source is left alone when the move is refused.
+      (should (file-exists-p old-path)))))
+
+(ert-deftest vulpea-move-file-same-directory ()
+  "Moving a note into the directory it already lives in errors.
+
+Asserts the message, because the target file necessarily exists in this
+case too and the weaker check would pass on the wrong guard."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--with-move-fixture ("move-same-id" "Same Directory")
+      (let ((err (should-error (vulpea-move-file "move-same-id" src-dir)
+                               :type 'user-error)))
+        (should (string-match-p "already lives in" (cadr err))))
+      (should (file-exists-p old-path)))))
+
+(ert-deftest vulpea-move-file-missing-directory ()
+  "Moving to a directory that does not exist errors."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--with-move-fixture ("move-missing-id" "Missing Target")
+      (should-error (vulpea-move-file "move-missing-id"
+                                      (expand-file-name "nope" root))
+                    :type (quote user-error))
+      (should (file-exists-p old-path)))))
+
+(ert-deftest vulpea-move-file-untracked-directory ()
+  "Moving outside `vulpea-db-sync-directories' errors."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--with-move-fixture ("move-untracked-id" "Untracked Target")
+      (let ((outside (make-temp-file "vulpea-test-outside-" t)))
+        (unwind-protect
+            (progn
+              (should-error (vulpea-move-file "move-untracked-id" outside)
+                            :type (quote user-error))
+              (should (file-exists-p old-path)))
+          (delete-directory outside t))))))
+
+(ert-deftest vulpea-move-file-untracked-allowed-without-sync-directories ()
+  "With no sync directories configured, the vault check does not apply.
+
+The target is outside the fixture vault, so this only passes when the
+check is actually skipped rather than incidentally satisfied."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--with-move-fixture ("move-nosync-id" "No Sync Dirs")
+      (let ((outside (make-temp-file "vulpea-test-outside-" t))
+            (vulpea-db-sync-directories nil))
+        (unwind-protect
+            (should (equal (vulpea-move-file "move-nosync-id" outside)
+                           (expand-file-name "no_sync_dirs.org"
+                                             (file-name-as-directory outside))))
+          (delete-directory outside t))))))
+
+(ert-deftest vulpea-move-file-heading-note ()
+  "Moving a heading-level note errors."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--with-move-fixture ("move-heading-file-id" "Heading Host")
+      (with-temp-file old-path
+        (insert ":PROPERTIES:\n:ID: move-heading-file-id\n:END:\n"
+                "#+TITLE: Heading Host\n\n"
+                "* Child\n:PROPERTIES:\n:ID: move-heading-id\n:END:\n"))
+      (vulpea-db-update-file old-path)
+      (should-error (vulpea-move-file "move-heading-id" dst-dir)
+                    :type (quote user-error)))))
+
+(ert-deftest vulpea-move-file-unknown-id ()
+  "Moving a note that does not exist errors."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--with-move-fixture ("move-unknown-host-id" "Unknown Host")
+      (should-error (vulpea-move-file "no-such-note-id" dst-dir)
+                    :type (quote user-error)))))
+
+(ert-deftest vulpea-move-file-missing-file-on-disk ()
+  "Moving a note whose file is gone errors, and says so."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--with-move-fixture ("move-gone-id" "Gone From Disk")
+      (delete-file old-path)
+      (let ((err (should-error (vulpea-move-file "move-gone-id" dst-dir)
+                               :type 'user-error)))
+        (should (string-match-p "File does not exist" (cadr err)))))))
+
+(ert-deftest vulpea-move-file-revisits-open-buffer ()
+  "A buffer visiting the note follows it to the new location."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--with-move-fixture ("move-buffer-id" "Open Buffer")
+      (let* ((old-buffer (find-file-noselect old-path))
+             (new-path (expand-file-name "open_buffer.org" dst-dir)))
+        (vulpea-move-file "move-buffer-id" dst-dir)
+        ;; The stale buffer is gone and a live one visits the new path.
+        (should-not (buffer-live-p old-buffer))
+        (should (get-file-buffer new-path))))))
+
+(ert-deftest vulpea-move-file-updates-org-id-location ()
+  "Moving a note re-points `org-id' at the new location.
+
+`org-id' stores abbreviated paths, so the expectation is abbreviated
+too: under a `temporary-file-directory' inside HOME the stored path
+comes back as \"~/...\"."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--with-move-fixture ("move-orgid-id" "Org Id Move")
+      (let ((org-id-locations (make-hash-table :test 'equal)))
+        (org-id-add-location "move-orgid-id" old-path)
+        (vulpea-move-file "move-orgid-id" dst-dir)
+        (should (equal (gethash "move-orgid-id" org-id-locations)
+                       (abbreviate-file-name
+                        (expand-file-name "org_id_move.org" dst-dir))))))))
+
+(ert-deftest vulpea-move-file-keeps-backlinks-queryable ()
+  "Backlink queries still find the linking note after a move."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--with-move-fixture ("move-backlink-id" "Backlink Target")
+      (let ((linking-path (expand-file-name "backlink_source.org" src-dir)))
+        (with-temp-file linking-path
+          (insert ":PROPERTIES:\n:ID: move-backlink-source-id\n:END:\n"
+                  "#+TITLE: Backlink Source\n\n"
+                  "See [[id:move-backlink-id][Backlink Target]].\n"))
+        (vulpea-db-update-file linking-path)
+        (vulpea-move-file "move-backlink-id" dst-dir)
+        (let ((linking (vulpea-db-query-by-links-some
+                        (list "move-backlink-id"))))
+          (should (equal (seq-map #'vulpea-note-id linking)
+                         (list "move-backlink-source-id"))))))))
+
+(ert-deftest vulpea--buffer-file-note-resolves-file-not-heading ()
+  "The interactive note is the file, even with point in an id'd heading.
+
+Reading the id at point would resolve the heading and then refuse to
+move it, which is the common case rather than an edge one."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--with-move-fixture ("buffer-note-file-id" "Buffer Note Host")
+      (with-temp-file old-path
+        (insert ":PROPERTIES:\n:ID: buffer-note-file-id\n:END:\n"
+                "#+TITLE: Buffer Note Host\n\n"
+                "* Child\n:PROPERTIES:\n:ID: buffer-note-heading-id\n:END:\n"
+                "Body.\n"))
+      (vulpea-db-update-file old-path)
+      (let ((buffer (find-file-noselect old-path)))
+        (with-current-buffer buffer
+          (goto-char (point-max))
+          ;; Point is inside the heading, whose own id would win.
+          (should (equal (org-entry-get nil "ID" t) "buffer-note-heading-id"))
+          (let ((note (vulpea--buffer-file-note)))
+            (should note)
+            (should (equal (vulpea-note-id note) "buffer-note-file-id"))
+            (should (= (vulpea-note-level note) 0))))))))
+
+(ert-deftest vulpea--buffer-file-note-without-file ()
+  "Buffers not visiting a file resolve to no note."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (with-temp-buffer
+      (should-not (vulpea--buffer-file-note)))))
+
+(ert-deftest vulpea--note-directories-covers-notes-and-roots ()
+  "Completion candidates hold both note directories and vault roots."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--with-move-fixture ("dirs-id" "Directory Candidates")
+      (let ((dirs (vulpea--note-directories)))
+        ;; The directory the note lives in, and the configured root.
+        (should (member (file-name-as-directory src-dir) dirs))
+        (should (member (file-name-as-directory root) dirs))
+        ;; No duplicates, and every entry ends with a slash.
+        (should (equal dirs (seq-uniq dirs)))
+        (should (seq-every-p (lambda (dir) (string-suffix-p "/" dir))
+                             dirs))))))
+
 ;;; Schema authoring (#330)
 
 (ert-deftest vulpea-schema-insert-field-values-writes-in-order ()

--- a/vulpea-db-query.el
+++ b/vulpea-db-query.el
@@ -367,6 +367,21 @@ Returns list of `vulpea-note' structs."
                        level)))
     (mapcar #'vulpea-db--row-to-note rows)))
 
+(defun vulpea-db--note-directories ()
+  "Return distinct directories that hold file-level notes.
+
+Each directory ends with a slash.  This is a path-only query: unlike
+`vulpea-db-query-by-level' it does not build `vulpea-note' structs, so
+it stays cheap on large vaults where it only feeds completion."
+  (seq-uniq
+   (seq-keep
+    (lambda (row)
+      (when-let* ((path (car row)))
+        (file-name-as-directory (file-name-directory path))))
+    (emacsql (vulpea-db)
+             [:select :distinct path :from notes :where (= level 0)]))
+   #'string-equal))
+
 ;;; File Path Queries
 
 (defun vulpea-db-query-by-file-path (file-path &optional level)

--- a/vulpea.el
+++ b/vulpea.el
@@ -1776,13 +1776,28 @@ Signals an error if:
       (error "vulpea-rename-file: Cannot rename file for heading-level note"))
     (when (file-exists-p new-path)
       (error "vulpea-rename-file: Target file already exists: %s" new-path))
+    (vulpea--relocate-file note new-path)))
+
+(defun vulpea--relocate-file (note new-path)
+  "Move NOTE's file to NEW-PATH.
+
+Saves and kills the file's buffer when it is open, moves the file on
+disk, points `org-id' at the new location, and replaces the old file's
+notes in the database with the new file's.
+
+This is the shared mechanical half of `vulpea-rename-file' and
+`vulpea-move-file': it performs no validation, so callers must have
+checked NOTE and NEW-PATH already.
+
+Returns NEW-PATH."
+  (let ((old-path (vulpea-note-path note)))
     ;; Kill buffer if file is open
     (let ((buf (get-file-buffer old-path)))
       (when buf
         (with-current-buffer buf
           (save-buffer))
         (kill-buffer buf)))
-    ;; Rename file on disk
+    ;; Move file on disk
     (rename-file old-path new-path)
     ;; Update org-id location
     (org-id-add-location (vulpea-note-id note) new-path)
@@ -1790,6 +1805,117 @@ Signals an error if:
     (vulpea-db--delete-file-notes old-path)
     (vulpea-db-update-file new-path)
     new-path))
+
+(defun vulpea--note-directories ()
+  "Return directories that currently hold notes.
+
+The result is the directories of all file-level notes in the database,
+unioned with `vulpea-db-sync-directories' themselves so that an empty
+but configured vault root is still offered."
+  (seq-uniq
+   (append
+    (vulpea-db--note-directories)
+    (seq-map (lambda (dir)
+               (file-name-as-directory (expand-file-name dir)))
+             vulpea-db-sync-directories))
+   #'string-equal))
+
+(defun vulpea--buffer-file-note ()
+  "Return the file-level note of the current buffer, or nil.
+
+Deliberately resolves the file rather than the ID at point: moving or
+renaming a file is a file-level operation, while point usually sits
+inside some heading, and heading IDs are indexed too."
+  (when-let* ((path (buffer-file-name)))
+    (car (vulpea-db-query-by-file-path path 0))))
+
+;;;###autoload
+(defun vulpea-move-file (note-or-id directory)
+  "Move NOTE-OR-ID's file into DIRECTORY.
+
+The file name is left alone: this moves the note, it does not rename
+it.  Use `vulpea-rename-file' for the other half.
+
+Links are not touched, because they are ids and not paths, so nothing
+needs rewriting.  The file is moved on disk, `org-id' is pointed at the
+new location and the database is updated.
+
+When called interactively, the note is the one the current buffer
+visits (the file, never a heading inside it), and DIRECTORY is
+completed over directories that already hold notes.  The completion is
+not restricted to those, so a directory that exists but holds no notes
+yet can be typed in and confirmed.
+
+When the note's file is visited by a buffer, that buffer is saved and
+replaced by one visiting the new location, with point kept.
+
+Returns the new file path.
+
+Signals a `user-error' if:
+- The note cannot be found
+- The note is a heading-level note (level > 0)
+- The note's file is gone from disk (a stale database row)
+- DIRECTORY does not exist or is not writable
+- DIRECTORY is outside `vulpea-db-sync-directories' (when any are
+  configured), since the note would silently fall out of the database
+  on the next full scan
+- The note already lives in DIRECTORY
+- A file of the same name already exists in DIRECTORY"
+  (interactive
+   (let* ((note (or (vulpea--buffer-file-note)
+                    (vulpea-select "Note to move" :require-match t)))
+          (dir (completing-read
+                (format "Move \"%s\" to directory: " (vulpea-note-title note))
+                (vulpea--note-directories)
+                nil 'confirm)))
+     (when (string-empty-p (string-trim dir))
+       (user-error "vulpea-move-file: No directory given"))
+     (list note dir)))
+  (let* ((note (if (vulpea-note-p note-or-id)
+                   note-or-id
+                 (vulpea-db-get-by-id note-or-id)))
+         (old-path (when note (vulpea-note-path note)))
+         (dir (file-name-as-directory (expand-file-name directory)))
+         (new-path (when old-path
+                     (expand-file-name (file-name-nondirectory old-path) dir))))
+    (unless note
+      (user-error "vulpea-move-file: Cannot find note with ID: %s"
+                  (if (vulpea-note-p note-or-id)
+                      (vulpea-note-id note-or-id)
+                    note-or-id)))
+    (when (> (vulpea-note-level note) 0)
+      (user-error
+       "vulpea-move-file: Cannot move file for heading-level note"))
+    (unless (and old-path (file-exists-p old-path))
+      (user-error "vulpea-move-file: File does not exist: %s" old-path))
+    (unless (file-directory-p dir)
+      (user-error "vulpea-move-file: Directory does not exist: %s" dir))
+    (when (and vulpea-db-sync-directories
+               (not (vulpea-db-sync-tracked-file-p dir)))
+      (user-error
+       "vulpea-move-file: %s is outside `vulpea-db-sync-directories'" dir))
+    (when (string-equal (file-truename (file-name-directory old-path))
+                        (file-truename dir))
+      (user-error "vulpea-move-file: Note already lives in %s" dir))
+    (when (file-exists-p new-path)
+      (user-error "vulpea-move-file: Target file already exists: %s" new-path))
+    (unless (file-writable-p new-path)
+      (user-error "vulpea-move-file: Directory is not writable: %s" dir))
+    ;; Remember how the note was being looked at, so the move does not
+    ;; just kill the buffer from under the user.
+    (let* ((buffer (get-file-buffer old-path))
+           (selected (eq buffer (window-buffer (selected-window))))
+           (old-point (when buffer
+                        (with-current-buffer buffer (point))))
+           (moved (vulpea--relocate-file note new-path)))
+      (when buffer
+        (let ((new-buffer (find-file-noselect moved)))
+          (with-current-buffer new-buffer
+            (goto-char (min old-point (point-max))))
+          (when selected
+            (switch-to-buffer new-buffer))))
+      (message "Moved \"%s\" to %s" (vulpea-note-title note) dir)
+      moved)))
 
 
 


### PR DESCRIPTION
Adds `vulpea-move-file`: move a note's file into another directory, keeping its file name. It is the counterpart to `vulpea-rename-file`, which derives a new file name from a title and keeps the directory. The mechanical half both need is shared now (`vulpea--relocate-file`).

Links need no rewriting, they are ids and not paths.

Moving outside `vulpea-db-sync-directories` is refused when any are configured. Otherwise the note keeps working until the next full scan and then quietly drops out of the db. `vulpea-db-sync-tracked-file-p` from #377 already answers exactly that question, symlinks and all.

Interactively it takes the note the current buffer visits (the file-level one, so point can sit in any heading) and completes the target over directories that already hold notes, without restricting you to them: a directory that exists but is still empty can be typed in and confirmed. A buffer visiting the note follows the file instead of getting killed.

Two known leftovers, both pre-existing and shared with rename, so this PR leaves them alone:

- `vulpea-db--delete-file-notes` only clears the `notes` table, so a stale `files` row survives a move or a rename
- the vault check compares paths without NFC normalization, so a sync directory spelled NFD would reject moves inside its own vault

Closes #405, came out of #343.
