### PR TITLE
test: keep note creation inside temporary directories

### DIFF
--- a/test/vulpea-test-helpers-test.el
+++ b/test/vulpea-test-helpers-test.el
@@ -1,0 +1,78 @@
+;;; vulpea-test-helpers-test.el --- Tests for test helpers -*- lexical-binding: t; -*-
+;;
+;; Copyright (c) 2020-2026 Boris Buliga
+;;
+;; Author: Boris Buliga <boris@d12frosted.io>
+;; Maintainer: Boris Buliga <boris@d12frosted.io>
+;;
+;; Created: 30 Jul 2026
+;;
+;; URL: https://github.com/d12frosted/vulpea
+;;
+;; License: GPLv3
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; Commentary:
+;;
+;; The test harness must never write into the notes directory of whoever
+;; runs the suite.  Any test reaching `vulpea-create' - directly, or
+;; through `vulpea-insert' with no candidates - creates a real file in
+;; `vulpea--default-directory', so the helpers have to point that
+;; somewhere temporary.
+;;
+;;; Code:
+
+(require 'ert)
+(require 'vulpea)
+(require 'vulpea-test-helpers)
+
+(defmacro vulpea-test-helpers-test--with-sentinel-directory (&rest body)
+  "Execute BODY with the notes directory settings pointed at a sentinel.
+
+Binds `org-directory', `vulpea-default-notes-directory' and
+`vulpea-db-sync-directories' to a temporary directory available to BODY
+as the anaphoric variable `sentinel', standing in for the directory of
+whoever runs the suite.  Nothing is expected to be created there."
+  (declare (indent 0))
+  `(let* ((sentinel (file-name-as-directory
+                     (make-temp-file "vulpea-sentinel-" t)))
+          (org-directory sentinel)
+          (vulpea-default-notes-directory nil)
+          (vulpea-db-sync-directories nil))
+     (ignore sentinel)
+     (unwind-protect
+         (progn ,@body)
+       (delete-directory sentinel t))))
+
+(ert-deftest vulpea-test-helpers-temp-db-keeps-notes-out-of-org-directory ()
+  "Notes created within `vulpea-test--with-temp-db' land in a temp directory."
+  (vulpea-test-helpers-test--with-sentinel-directory
+    (vulpea-test--with-temp-db
+      (vulpea-db)
+      (let ((note (vulpea-create "Frodo" nil)))
+        (should note)
+        (should-not (file-in-directory-p (vulpea-note-path note) sentinel))))
+    (should-not (directory-files sentinel nil "\\.org\\'"))))
+
+(ert-deftest vulpea-test-helpers-temp-db-and-file-keeps-notes-out-of-org-directory ()
+  "Notes created within `vulpea-test--with-temp-db-and-file' stay temporary."
+  (vulpea-test-helpers-test--with-sentinel-directory
+    (vulpea-test--with-temp-db-and-file "some-id" "#+title: Some note\n"
+      (let ((note (vulpea-create "Frodo" nil)))
+        (should note)
+        (should-not (file-in-directory-p (vulpea-note-path note) sentinel))))
+    (should-not (directory-files sentinel nil "\\.org\\'"))))
+
+(ert-deftest vulpea-test-helpers-temp-db-cleans-up-created-notes ()
+  "The notes directory of `vulpea-test--with-temp-db' is removed afterwards."
+  (vulpea-test-helpers-test--with-sentinel-directory
+    (let (path)
+      (vulpea-test--with-temp-db
+        (vulpea-db)
+        (setq path (vulpea-note-path (vulpea-create "Frodo" nil)))
+        (should (file-exists-p path)))
+      (should-not (file-exists-p path)))))
+
+(provide 'vulpea-test-helpers-test)
+;;; vulpea-test-helpers-test.el ends here

--- a/test/vulpea-test-helpers.el
+++ b/test/vulpea-test-helpers.el
@@ -19,7 +19,13 @@
 ;;
 ;;; Code:
 
+(require 'org)
 (require 'vulpea-db)
+;; `vulpea-default-notes-directory' lives in vulpea.el, and the macros below
+;; bind it.  Without the library loaded the symbol is not special yet, and in
+;; a lexical-binding file that binding would be lexical, so
+;; `vulpea--default-directory' would keep pointing at the caller's collection.
+(require 'vulpea)
 
 ;;; Database Helpers
 
@@ -27,28 +33,46 @@
   "Execute BODY with temporary database.
 
 Creates a fresh temporary database file, binds `vulpea-db-location'
-to it, and ensures cleanup after BODY completes (even on error)."
+to it, and ensures cleanup after BODY completes (even on error).
+
+Also points `vulpea-default-notes-directory' and `org-directory' at a
+fresh temporary directory, so that a BODY reaching `vulpea-create' - on
+its own, or through `vulpea-insert' with no candidates - writes into
+that directory instead of the collection of whoever runs the suite."
   (declare (indent 0))
   `(let* ((temp-file (make-temp-file "vulpea-test-" nil ".db"))
+          (temp-notes-dir (file-name-as-directory
+                           (make-temp-file "vulpea-test-notes-" t)))
           (vulpea-db-location temp-file)
-          (vulpea-db--connection nil))
+          (vulpea-db--connection nil)
+          (vulpea-default-notes-directory temp-notes-dir)
+          (org-directory temp-notes-dir))
      (unwind-protect
          (progn ,@body)
        (when vulpea-db--connection
          (vulpea-db-close))
        (when (file-exists-p temp-file)
-         (delete-file temp-file)))))
+         (delete-file temp-file))
+       (when (file-directory-p temp-notes-dir)
+         (delete-directory temp-notes-dir t)))))
 
 (defmacro vulpea-test--with-temp-db-and-file (id content &rest body)
   "Execute BODY with temporary database and org file.
 
 Creates a temp org file with ID and CONTENT, initializes a temp
 database, indexes the file, then executes BODY. Cleans up both
-the database and org file afterward."
+the database and org file afterward.
+
+Like `vulpea-test--with-temp-db', keeps note creation inside a
+temporary directory."
   (declare (indent 2))
   `(let* ((temp-db-file (make-temp-file "vulpea-test-" nil ".db"))
+          (temp-notes-dir (file-name-as-directory
+                           (make-temp-file "vulpea-test-notes-" t)))
           (vulpea-db-location temp-db-file)
           (vulpea-db--connection nil)
+          (vulpea-default-notes-directory temp-notes-dir)
+          (org-directory temp-notes-dir)
           (temp-org-file (make-temp-file "vulpea-test-" nil ".org")))
      (with-temp-file temp-org-file
        (insert (format ":PROPERTIES:\n:ID: %s\n:END:\n%s" ,id ,content)))
@@ -62,7 +86,9 @@ the database and org file afterward."
        (when (file-exists-p temp-db-file)
          (delete-file temp-db-file))
        (when (file-exists-p temp-org-file)
-         (delete-file temp-org-file)))))
+         (delete-file temp-org-file))
+       (when (file-directory-p temp-notes-dir)
+         (delete-directory temp-notes-dir t)))))
 
 (defmacro vulpea-test--with-temp-db-and-files (files &rest body)
   "Execute BODY with temporary database constructed upon FILES.
@@ -75,7 +101,9 @@ afterward."
   `(let* ((dir (make-temp-file "vulpea-mentions-" t))
           (vulpea-db-location (make-temp-file "vulpea-mentions-" nil ".db"))
           (vulpea-db--connection nil)
-          (vulpea-db-sync-directories (list dir)))
+          (vulpea-db-sync-directories (list dir))
+          (vulpea-default-notes-directory dir)
+          (org-directory dir))
      (unwind-protect
          (progn
            (vulpea-db)
@@ -102,7 +130,9 @@ BODY completes (even on error)."
                  (make-temp-file "vulpea-notes-" t)))
           (vulpea-db-location (make-temp-file "vulpea-test-" nil ".db"))
           (vulpea-db--connection nil)
-          (vulpea-db-sync-directories (list root)))
+          (vulpea-db-sync-directories (list root))
+          (vulpea-default-notes-directory root)
+          (org-directory root))
      (ignore root)
      (unwind-protect
          (progn


### PR DESCRIPTION
Running the test suite creates real notes in the notes directory of whoever runs it.

`vulpea-test--with-temp-db` and `vulpea-test--with-temp-db-and-file` bind only `vulpea-db-location`, so a test that reaches `vulpea-create` (directly, or through `vulpea-insert` with an empty candidate list, where an empty list means "create it") writes the new file into `vulpea--default-directory`, which falls back to `org-directory`. My own `~/org` had 67 leftover `<timestamp>_frodo.org` stubs from past runs, and @drcxd hit the same thing while working on #412, which is what made me look.

Both macros now point `vulpea-default-notes-directory` and `org-directory` at a fresh temporary directory and remove it afterwards. `vulpea-test--with-temp-db-and-files` and `vulpea-test--with-temp-notes-dir` already had a temporary directory through `vulpea-db-sync-directories`, they get the same two bindings so that a globally set `vulpea-default-notes-directory` cannot take precedence over them.

The helpers also require `vulpea` explicitly. `vulpea-default-notes-directory` is defined in vulpea.el, and until that is loaded the symbol is not special, so binding it in a `lexical-binding` file binds it lexically and `vulpea--default-directory` keeps pointing at the caller's collection. Without the require it works only when some other test file happens to load vulpea first.

The new test file covers all of it: a note created inside the helpers stays out of the caller's directory, and the temporary directory is gone once the macro returns. All three tests fail without the change.

No changelog entry, nothing user facing moves here. Tell me if you want one anyway.
