### PR TITLE
refactor(db): route file removal through vulpea-db--forget-file

### DIFF
--- a/test/vulpea-db-path-test.el
+++ b/test/vulpea-db-path-test.el
@@ -102,6 +102,18 @@
       (vulpea-db--delete-file-notes vulpea-db-path-test--nfd)
       (should-not (emacsql (vulpea-db) [:select * :from notes])))))
 
+(ert-deftest vulpea-db-forget-file/normalizes-path ()
+  "Forgetting by NFD path drops both rows stored under NFC path."
+  (vulpea-test--with-temp-db
+    (let ((vulpea-db-path-normalization 'nfc))
+      (vulpea-db)
+      (vulpea-test--insert-test-note "id-1" "note"
+                                     :path vulpea-db-path-test--nfc)
+      (vulpea-db--update-file-hash vulpea-db-path-test--nfc "deadbeef" 1 2)
+      (vulpea-db--forget-file vulpea-db-path-test--nfd)
+      (should-not (emacsql (vulpea-db) [:select * :from notes]))
+      (should-not (emacsql (vulpea-db) [:select * :from files])))))
+
 (ert-deftest vulpea-db-query-by-file-path/normalizes-path ()
   "Querying by NFD path finds notes stored under NFC path."
   (vulpea-test--with-temp-db

--- a/test/vulpea-db-sync-test.el
+++ b/test/vulpea-db-sync-test.el
@@ -87,6 +87,38 @@
               (should (equal (elt row 1) "Test"))))
         (delete-file path)))))
 
+(ert-deftest vulpea-db-sync-cleanup-deleted-files-forgets-rows ()
+  "Cleaning up a deleted file drops its change-detection row too.
+
+Leaving that row behind makes a file restored at the same path compare
+unchanged, so it is never indexed again."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (let ((path (vulpea-test--create-temp-org-file
+                 ":PROPERTIES:\n:ID: cleanup-id\n:END:\n#+TITLE: Cleanup\n")))
+      (vulpea-db-update-file path)
+      (should (vulpea-db--get-file-hash path))
+      (delete-file path)
+      (should (= 1 (vulpea-db-sync--cleanup-deleted-files)))
+      (should-not (vulpea-db-get-by-id "cleanup-id"))
+      (should-not (vulpea-db--get-file-hash path)))))
+
+(ert-deftest vulpea-db-sync-cleanup-deleted-files-using-forgets-rows ()
+  "The listed-files variant forgets the rows of anything not listed."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (let ((path (vulpea-test--create-temp-org-file
+                 ":PROPERTIES:\n:ID: cleanup-using-id\n:END:\n#+TITLE: U\n")))
+      (unwind-protect
+          (progn
+            (vulpea-db-update-file path)
+            ;; The scan came back without this file, so it is gone as far
+            ;; as the database is concerned.
+            (should (= 1 (vulpea-db-sync--cleanup-deleted-files-using nil)))
+            (should-not (vulpea-db-get-by-id "cleanup-using-id"))
+            (should-not (vulpea-db--get-file-hash path)))
+        (when (file-exists-p path) (delete-file path))))))
+
 (ert-deftest vulpea-db-sync-process-queue-batch-limit ()
   "Test queue respects batch size limit."
   (vulpea-test--with-temp-db

--- a/test/vulpea-db-test.el
+++ b/test/vulpea-db-test.el
@@ -430,6 +430,46 @@ same path with the same bytes is never indexed again."
       (should (vulpea-db--get-file-hash other))
       (should (vulpea-db-get-by-id "other-id")))))
 
+(ert-deftest vulpea-db-forget-file-nested-survives-locked-database ()
+  "Forgetting inside a transaction does not discard the outer one.
+
+`emacsql-with-transaction' retries a locked database by rolling back
+without checking the nesting level, so a transaction opened here would
+throw away the work of the transaction already in progress and then
+retry only its own body.  A cleanup loop would report files removed and
+leave their rows behind, which is the state this function prevents."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (let ((first "/tmp/vulpea-nested-first.org")
+          (second "/tmp/vulpea-nested-second.org")
+          (locked nil))
+      (dolist (path (list first second))
+        (vulpea-db--insert-note
+         :id (concat "id" path)
+         :path path
+         :level 0
+         :pos 0
+         :title "Note"
+         :properties nil
+         :modified-at "2026-07-30")
+        (vulpea-db--update-file-hash path "deadbeef" 1 2))
+      (let ((real (symbol-function 'vulpea-db--forget-file-1)))
+        (cl-letf (((symbol-function 'vulpea-db--forget-file-1)
+                   (lambda (path)
+                     ;; The database is busy once, while the second file
+                     ;; is being forgotten.
+                     (when (and (equal path second) (not locked))
+                       (setq locked t)
+                       (signal 'emacsql-locked (list "database is locked")))
+                     (funcall real path))))
+          (emacsql-with-transaction (vulpea-db)
+            (vulpea-db--forget-file first)
+            (ignore-errors (vulpea-db--forget-file second)))))
+      ;; The first file was forgotten before the lock, and stays
+      ;; forgotten: both of its rows are gone, not just its notes.
+      (should-not (vulpea-db--get-file-hash first))
+      (should-not (vulpea-db-get-by-id (concat "id" first))))))
+
 (ert-deftest vulpea-db-delete-file-notes-keeps-change-detection ()
   "Deleting a file's notes leaves its change-detection row alone.
 

--- a/vulpea-db-sync.el
+++ b/vulpea-db-sync.el
@@ -699,8 +699,7 @@ all files under that directory are removed."
   (let ((db (vulpea-db)))
     (emacsql-with-transaction db
       ;; Try exact match first
-      (vulpea-db--delete-file-notes path)
-      (emacsql db [:delete :from files :where (= path $s1)] path)
+      (vulpea-db--forget-file path)
       ;; Also handle directory removal - delete all files under this path
       ;; This handles the case when a directory is deleted externally
       ;; Use GLOB instead of LIKE - GLOB uses * and ? as wildcards,
@@ -1146,8 +1145,7 @@ Returns count of removed files."
     (emacsql-with-transaction db
       (dolist (path all-paths)
         (unless (file-exists-p path)
-          (vulpea-db--delete-file-notes path)
-          (emacsql db [:delete :from files :where (= path $s1)] path)
+          (vulpea-db--forget-file path)
           (setq deleted (1+ deleted)))))
     (when (> deleted 0)
       (vulpea-db-sync--message "Vulpea: Removed %d deleted file%s from database"
@@ -1175,8 +1173,7 @@ Returns count of removed files."
     (emacsql-with-transaction db
       (dolist (path all-paths)
         (unless (gethash path existing-set)
-          (vulpea-db--delete-file-notes path)
-          (emacsql db [:delete :from files :where (= path $s1)] path)
+          (vulpea-db--forget-file path)
           (setq deleted (1+ deleted)))))
     (when (> deleted 0)
       (vulpea-db-sync--message "Vulpea: Removed %d deleted file%s from database"
@@ -1217,6 +1214,12 @@ directories will be removed.
 This is useful when narrowing `vulpea-db-sync-directories' to a
 subdirectory - files outside that subdirectory will be cleaned up.
 
+Rows keyed by a non-canonical path are not reached from here, because
+`vulpea-db--forget-file' matches the canonical spelling.  Unlike its
+sibling cleanups this one does not purge them itself, so it relies on
+running after `vulpea-db-sync--purge-denormalized-rows', as it does in
+the startup scan.
+
 Returns count of removed files."
   (if (null vulpea-db-sync-directories)
       0  ; No cleanup if no directories configured
@@ -1226,8 +1229,7 @@ Returns count of removed files."
       (emacsql-with-transaction db
         (dolist (path all-paths)
           (unless (vulpea-db-sync-tracked-file-p path)
-            (vulpea-db--delete-file-notes path)
-            (emacsql db [:delete :from files :where (= path $s1)] path)
+            (vulpea-db--forget-file path)
             (setq removed (1+ removed)))))
       (when (> removed 0)
         (vulpea-db-sync--message "Vulpea: Removed %d untracked file%s from database"

--- a/vulpea-db-worker.el
+++ b/vulpea-db-worker.el
@@ -805,10 +805,7 @@ file behind it."
         ;; them.  The removal event handler was a no-op if it ran
         ;; before the commit.
         ((null attrs)
-         (let ((db (vulpea-db)))
-           (emacsql-with-transaction db
-             (vulpea-db--delete-file-notes path)
-             (emacsql db [:delete :from files :where (= path $s1)] path)))
+         (vulpea-db--forget-file path)
          (run-hook-with-args 'vulpea-db-worker-done-functions
                              path 'missing nil))
         (t
@@ -1349,10 +1346,7 @@ database afterwards."
                 (insert "\nprotocol log:\n"
                         (with-current-buffer log (buffer-string))))))
         ;; Cleanup: temp note out of the database, worker down
-        (ignore-errors (vulpea-db--delete-file-notes path))
-        (ignore-errors
-          (emacsql (vulpea-db) [:delete :from files :where (= path $s1)]
-                   path))
+        (ignore-errors (vulpea-db--forget-file path))
         (delete-file path)
         (vulpea-db-worker-stop)))
     (pop-to-buffer report)))

--- a/vulpea-db.el
+++ b/vulpea-db.el
@@ -791,12 +791,31 @@ restored at the same path with the same content compares equal and is
 never indexed again.
 
 Both deletions happen together: dropping the notes while keeping the
-row is the very state this exists to avoid."
-  (emacsql-with-transaction (vulpea-db)
-    (vulpea-db--delete-file-notes path)
-    (emacsql (vulpea-db)
-             [:delete :from files :where (= path $s1)]
-             (vulpea-db-normalize-path path))))
+row is the very state this exists to avoid.
+
+A transaction is opened only when there is not one already.
+`emacsql-with-transaction' claims to nest, and it does until the
+database is locked: its retry issues a rollback without looking at the
+nesting level, so at depth two a transient SQLITE_BUSY throws away the
+outer transaction's work and then retries the inner body alone, leaving
+the caller to finish in autocommit and report success.  A cleanup loop
+that forgets several files would announce them all and leave some of
+their rows behind, which is the exact state this function exists to
+prevent."
+  (if (> emacsql--transaction-level 0)
+      (vulpea-db--forget-file-1 path)
+    (emacsql-with-transaction (vulpea-db)
+      (vulpea-db--forget-file-1 path))))
+
+(defun vulpea-db--forget-file-1 (path)
+  "Delete PATH's notes and its change-detection row.
+
+The body of `vulpea-db--forget-file', without a transaction of its own.
+Call that instead unless you already hold one."
+  (vulpea-db--delete-file-notes path)
+  (emacsql (vulpea-db)
+           [:delete :from files :where (= path $s1)]
+           (vulpea-db-normalize-path path)))
 
 (defun vulpea-db--delete-note (id)
   "Delete note with ID.


### PR DESCRIPTION
Follow-up to #422. Six places open-coded what `vulpea-db--forget-file` does: delete a file's notes, then delete its change-detection row, as two separate statements. They now call the helper, so how a file is forgotten lives in one place and the path is normalized the same way everywhere.

Two sites that look like the same pattern are deliberately left alone:

- the directory branch of `vulpea-db-sync--handle-removed-file` matches the `files` table by glob rather than by path
- the non-canonical purge deletes a row keyed by a raw, unnormalized path on purpose, which is exactly what normalizing would undo

The helper now only opens a transaction when there is not one already. `emacsql-with-transaction` claims to nest, and does until the database is locked: its retry issues a rollback without looking at the nesting level, so at depth two a transient `SQLITE_BUSY` throws away the outer transaction's work and then retries the inner body alone, leaving the caller to finish in autocommit and report success. Four of the six sites sit inside a cleanup transaction, which would otherwise announce files as removed while leaving their rows behind. That is reachable in full-write mode, where the worker subprocess writes the same database concurrently.

One other behavior change worth naming: the worker's diagnose path used a separate `ignore-errors` per statement and now uses one for both, so a failure in the first no longer leaves the second to run alone.

Tests cover the two cleanup paths that had none, the nesting case under a locked database, and forgetting by an NFD path dropping both rows written under the NFC one.
