### PR TITLE
fix(mentions): drop ripgrep hits with non-UTF-8 paths

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -29,6 +29,8 @@
 
 *Fixes*
 
+- Unlinked mention detection no longer dies on a file whose name is not valid UTF-8. ripgrep encodes such a path in its JSON output as base64 =bytes= instead of plain =text=; the parser read only =text= and handed a nil path to =expand-file-name=, and that error rejected the scan's entire result, so one mis-encoded file name killed mention detection for the whole vault. Hits from such files are now dropped instead: a path that is not valid UTF-8 cannot name an indexed note anyway (the database holds decoded strings, and rebuilding a file name from raw bytes means guessing its encoding). Non-UTF-8 line content and matched substrings were already dropped harmlessly and stay that way.
+
 - [[https://github.com/d12frosted/vulpea/issues/418][vulpea#418]] Schema note prompts no longer show a doubled colon (=producer: :=). The field prompt already carried a separator when it was handed to =vulpea-select=, which appends its own.
 
 - [[https://github.com/d12frosted/vulpea/issues/418][vulpea#418]] Confirming empty input in a schema note prompt no longer writes a broken =[[id:]]= link; the field is skipped, the same as quitting. =completing-read= lets null input through even with require-match, so the phantom "note" it produced used to flow into the buffer - and through =vulpea-schema-fix-violation= could replace a real value with garbage.

--- a/test/vulpea-mentions-test.el
+++ b/test/vulpea-mentions-test.el
@@ -125,6 +125,31 @@ default minimum of 3 while a 2-letter Latin title does not."
       (should (equal (plist-get (car hits) :line-text) "see Cabernet here"))
       (should (equal (plist-get (car hits) :matched) '("Cabernet"))))))
 
+(ert-deftest vulpea-mentions--parse-rg-json-drops-bytes-values ()
+  "Values ripgrep encodes as base64 bytes are dropped, not read as nil.
+ripgrep emits {\"bytes\": ...} instead of {\"text\": ...} when a path,
+line, or match is not valid UTF-8.  A bytes path or line drops the hit;
+a bytes submatch is dropped from :matched while text ones survive."
+  (let ((output (concat
+                 ;; path is not valid UTF-8 -> hit dropped
+                 "{\"type\":\"match\",\"data\":{\"path\":{\"bytes\":\"L24vY2Fm6S5vcmc=\"},"
+                 "\"lines\":{\"text\":\"see Cabernet here\\n\"},\"line_number\":3,"
+                 "\"submatches\":[{\"match\":{\"text\":\"Cabernet\"},\"start\":4,\"end\":12}]}}\n"
+                 ;; line content is not valid UTF-8 -> hit dropped
+                 "{\"type\":\"match\",\"data\":{\"path\":{\"text\":\"/n/a.org\"},"
+                 "\"lines\":{\"bytes\":\"Y2Fm6SBub3RlCg==\"},\"line_number\":5,"
+                 "\"submatches\":[{\"match\":{\"text\":\"Cabernet\"},\"start\":0,\"end\":8}]}}\n"
+                 ;; one submatch is bytes -> that submatch alone is dropped
+                 "{\"type\":\"match\",\"data\":{\"path\":{\"text\":\"/n/a.org\"},"
+                 "\"lines\":{\"text\":\"Cabernet and more\\n\"},\"line_number\":7,"
+                 "\"submatches\":[{\"match\":{\"bytes\":\"Q2Fm6Q==\"},\"start\":0,\"end\":4},"
+                 "{\"match\":{\"text\":\"Cabernet\"},\"start\":0,\"end\":8}]}}\n")))
+    (let ((hits (vulpea-mentions--parse-rg-json output)))
+      (should (= (length hits) 1))
+      (should (equal (plist-get (car hits) :path) "/n/a.org"))
+      (should (equal (plist-get (car hits) :line) 7))
+      (should (equal (plist-get (car hits) :matched) '("Cabernet"))))))
+
 (ert-deftest vulpea-mentions--link-spans-and-in-link-p ()
   "Link spans are found and positions tested against them."
   (let* ((line "[[id:abc][Cabernet]] and bare Cabernet")
@@ -281,6 +306,28 @@ default minimum of 3 while a 2-letter Latin title does not."
       (should (equal (vulpea-note-id (plist-get (car mentions) :note)) "mentioner"))
       (should (equal (plist-get (car mentions) :line) 3))
       (should (equal (plist-get (car mentions) :context) "a lovely Cabernet")))))
+
+(ert-deftest vulpea-mentions--collect-survives-bytes-path ()
+  "A hit in a file with a non-UTF-8 name must not sink the whole scan.
+ripgrep encodes such a path as {\"bytes\": ...}; the hit is dropped and
+the remaining hits are still collected, instead of a nil path blowing
+up in `expand-file-name' and rejecting the entire result."
+  (vulpea-test--with-temp-db
+    (vulpea-db)
+    (vulpea-test--insert-test-note "target" "Cabernet" :path "/n/target.org")
+    (vulpea-test--insert-test-note "mentioner" "Tasting" :path "/n/tasting.org")
+    (let* ((note (vulpea-db-get-by-id "target"))
+           (own (expand-file-name "/n/target.org"))
+           (output (concat
+                    ;; a file whose name is not valid UTF-8 -> dropped
+                    "{\"type\":\"match\",\"data\":{\"path\":{\"bytes\":\"L24vY2Fm6S5vcmc=\"},"
+                    "\"lines\":{\"text\":\"a lovely Cabernet\\n\"},\"line_number\":1}}\n"
+                    ;; a genuine unlinked mention -> still collected
+                    "{\"type\":\"match\",\"data\":{\"path\":{\"text\":\"/n/tasting.org\"},"
+                    "\"lines\":{\"text\":\"a lovely Cabernet\\n\"},\"line_number\":3}}\n"))
+           (mentions (vulpea-mentions--collect output note own)))
+      (should (= (length mentions) 1))
+      (should (equal (vulpea-note-id (plist-get (car mentions) :note)) "mentioner")))))
 
 (ert-deftest vulpea-mentions--shares-name-p ()
   "A note that shares a title or alias with the search terms is detected."

--- a/vulpea-mentions.el
+++ b/vulpea-mentions.el
@@ -290,7 +290,10 @@ PATTERNS-FILE holds one regex per line (see
 
 Each hit is a plist with :path, :line, :line-text, and :matched (the
 list of matched substrings on the line).  Non-match events and
-unparseable lines are ignored."
+unparseable lines are ignored, as are hits whose path or line content
+ripgrep encodes as base64 bytes rather than text (the value was not
+valid UTF-8, e.g. a mis-encoded file name); one such file must not
+take down the rest of the scan."
   (let ((result nil))
     (dolist (line (split-string output "\n" t))
       (let ((obj (ignore-errors (json-parse-string line :object-type 'alist))))
@@ -305,7 +308,13 @@ unparseable lines are ignored."
                                      (mapcar (lambda (sm)
                                                (alist-get 'text (alist-get 'match sm)))
                                              (append submatches nil))))))
-            (when text
+            ;; A value that is not valid UTF-8 arrives as {"bytes":
+            ;; base64} instead of {"text": ...}, leaving the binding
+            ;; nil.  Such a path cannot name an indexed note (the
+            ;; database holds decoded strings, and reconstructing a
+            ;; file name from raw bytes means guessing its encoding),
+            ;; so the hit is dropped rather than decoded.
+            (when (and path text)
               (push (list :path path
                           :line line-no
                           :line-text (string-trim-right text "[\n\r]+")


### PR DESCRIPTION
ripgrep's --json output encodes any value that is not valid UTF-8 as {"bytes": "<base64>"} instead of {"text": ...}. That happens for files with mis-encoded names on disk. The parser only read the text key, so such a file produced a hit with a nil path, expand-file-name signaled on it, and the sentinel's condition-case rejected the whole result. One weird file name was enough to kill mention detection for the entire vault.

Now such hits are dropped. Decoding the bytes would not buy anything: a non-UTF-8 path cannot match a note indexed in the database (paths there are decoded strings), and rebuilding a file name from raw bytes means guessing the filesystem encoding, so the hit would be discarded downstream anyway.

The other two places rg can emit bytes (line content and submatches) were already handled: a bytes line was skipped, a bytes submatch fell out of the matched list. That behavior is unchanged and now covered by tests.
