### PR TITLE
Add an option to use annotation-function for annotations

### DIFF
--- a/test/vulpea-select-test.el
+++ b/test/vulpea-select-test.el
@@ -160,8 +160,11 @@
     (should (equal (vulpea-note-id result) "id1"))
     (should (equal (vulpea-note-title result) "First Note"))))
 
-(ert-deftest vulpea-select-describe-basic ()
-  "Test vulpea-select-describe formats note for completion."
+(ert-deftest vulpea-select-describe-with-matchable-annotations ()
+  "Test `vulpea-select-describe' formats note for completion.
+
+Consider the default value of `vulpea-select-annotate-matchable', which
+is t. Tags and then included in the matchable string."
   (let* ((context "CTX")
          (note (make-vulpea-note
                 :id "test-id"
@@ -175,6 +178,36 @@
     ;; Should contain tags
     (should (string-match-p "#tag1" described))
     (should (string-match-p "#tag2" described))
+    ;; Should have id property
+    (should (equal (get-text-property 0 'vulpea-note-id described) "test-id"))
+
+    ;; Should have vulpea-note property
+    (should (equal (get-text-property 0 'vulpea-note described) note))
+
+    ;; Should have vulpea-select-context property
+    (should (equal (get-text-property 0 'vulpea-select-context described) context))))
+
+(ert-deftest vulpea-select-describe-without-matchable-annotations ()
+  "Test `vulpea-select-describe' formats note for completion.
+
+Consider the case where `vulpea-select-annotate-matchable' is nil. Tags
+are not included in the matchable string."
+  (let* ((vulpea-select-annotate-matchable nil)
+         (context "CTX")
+         (note (make-vulpea-note
+                :id "test-id"
+                :title "Test Note"
+                :level 0
+                :tags '("tag1" "tag2")))
+         (described (vulpea-select-describe note context)))
+
+    ;; Should contain title
+    (should (string-match-p "Test Note" described))
+
+    ;; Should not contain tags
+    (should (not (string-match-p "#tag1" described)))
+    (should (not (string-match-p "#tag2" described)))
+
     ;; Should have id property
     (should (equal (get-text-property 0 'vulpea-note-id described) "test-id"))
 
@@ -268,6 +301,44 @@ stay reachable on such copies."
     ;; Should contain tags
     (should (string-match-p "#tag1" annotation))
     (should (string-match-p "#tag2" annotation))))
+
+(ert-deftest vulpea-select--create-annotate-wrapper ()
+  "Test that `vulpea-select--create-annotate-wrapper' correctly wraps an annotation function like `vulpea-select-annotate'.
+
+The wrapped function can be called with a completion candidate (which
+has the note as a text property) and returns the same annotation string
+as the original annotation function (called with the note object)."
+  (let* ((context "CTX")
+         (note (make-vulpea-note
+                :id "test-id"
+                :title "Test Note"
+                :level 0
+                :tags '("tag1" "tag2")))
+         (completion-candidate (vulpea-select-describe note context)))
+
+    ;; Case where the annotation function takes one argument (note)
+    (let* ((annotation-fn 'vulpea-select-annotate)
+           (wrapped-annotate-fn (vulpea-select--create-annotate-wrapper annotation-fn))
+           (orig-annotation (funcall annotation-fn note))
+           (annotation (funcall wrapped-annotate-fn completion-candidate)))
+
+      ;; Both annotations should be equal
+      (should (equal orig-annotation annotation))
+
+      ;; Check that wrapper returns empty string for non-candidate input
+      (should (equal (funcall wrapped-annotate-fn "not-a-candidate") "")))
+
+    ;; Case where the annotation function takes two arguments (note and context)
+    (let* ((annotation-fn (lambda (n ctx) (format "%s (%s)" (vulpea-select-annotate n) ctx)))
+           (wrapped-annotate-fn (vulpea-select--create-annotate-wrapper annotation-fn))
+           (orig-annotation (funcall annotation-fn note context))
+           (annotation (funcall wrapped-annotate-fn completion-candidate)))
+
+      ;; Both annotations should be equal
+      (should (equal orig-annotation annotation))
+
+      ;; Check that wrapper returns empty string for non-candidate input
+      (should (equal (funcall wrapped-annotate-fn "not-a-candidate") "")))))
 
 ;;; Dynamic Context Tests
 
@@ -524,6 +595,28 @@ stay reachable on such copies."
                 'vulpea-note))
     ;; and the table still completes against the candidates
     (should (member "One" (all-completions "" table)))))
+
+(ert-deftest vulpea-select-completion-table-exposes-annotation-function ()
+  "Test that the completion table reports the annotation function."
+  ;; Assert the plain candidate; the id suffix has its own tests.
+  (let* ((vulpea-select-match-ids nil)
+         (note (make-vulpea-note :id "id1" :title "One" :level 0))
+         (table (vulpea-select--completion-table
+                 (list (cons (vulpea-select-describe note) note)))))
+
+    ;; metadata does not include annotation function, since the
+    ;; default value of `vulpea-select-annotate-matchable' is t, which
+    ;; makes annotations part of the matchable string
+    (should (null (completion-metadata-get
+                   (completion-metadata "" table nil)
+                   'annotation-function)))
+
+    (let ((vulpea-select-annotate-matchable nil))
+      ;; metadata includes the annotation function when
+      ;; `vulpea-select-annotate-matchable' is nil
+      (should (not (null (completion-metadata-get
+                          (completion-metadata "" table nil)
+                          'annotation-function)))))))
 
 (ert-deftest vulpea-select-from-exposes-category ()
   "Test that vulpea-select-from gives completing-read the `vulpea-note' category."

--- a/vulpea-select.el
+++ b/vulpea-select.el
@@ -80,6 +80,24 @@ surprising matches."
   :type 'boolean
   :group 'vulpea-select)
 
+
+(defcustom vulpea-select-annotate-inside-candidate-string t
+  "If t, annotations are added directly in the candidate string.
+
+When this is t, annotations from `vulpea-select-annotate-fn' are
+concatenated to the candidate string. This has the advantage that
+annotations can be matched during search.
+
+When this is nil, annotations from `vulpea-select-annotate-fn' are added
+through the `:annotation-function' property, which is a standard way to
+add annotations for minibuffer completion. This has the advantage that
+annotations are not part of the candidate string, which can be useful
+for some integrations, such as add multiple annotators that can be
+cycled using the marginalia package."
+  :type 'boolean
+  :group 'vulpea-select)
+
+
 (defcustom vulpea-select-dyncontext-fn nil
   "Function computing a shared context for the current selection.
 
@@ -133,21 +151,27 @@ instead of `get-text-property'. They are what makes a candidate
 string self-describing for code that only ever sees strings - a
 `display-sort-function' in `completion-category-overrides', an
 `annotation-function' added by an integration, an embark action."
-  (let ((id (vulpea-note-id note)))
-    (propertize
-     (concat
-      (vulpea-select--funcall vulpea-select-describe-fn note context)
-      (propertize
-       (vulpea-select--funcall vulpea-select-annotate-fn note context)
-       'face 'completions-annotations)
-      (when (and vulpea-select-match-ids id)
-        (propertize (concat " " id) 'invisible t)))
-     'vulpea-note-id
-     id
-     'vulpea-note
-     note
-     'vulpea-select-context
-     context)))
+  (let* ((id (vulpea-note-id note))
+         (description-part
+          (vulpea-select--funcall
+           vulpea-select-describe-fn note context))
+         (annotation-part
+          (if vulpea-select-annotate-inside-candidate-string
+              (propertize (vulpea-select--funcall
+                           vulpea-select-annotate-fn note context)
+                          'face 'completions-annotations)
+            ""))
+         (invisible-id-part
+          (when (and vulpea-select-match-ids id)
+            (propertize (concat " " id) 'invisible t))))
+    (propertize (concat
+                 description-part annotation-part invisible-id-part)
+                'vulpea-note-id
+                id
+                'vulpea-note
+                note
+                'vulpea-select-context
+                context)))
 
 (defun vulpea-select-candidate-note (candidate)
   "Return the `vulpea-note' carried by CANDIDATE, or nil.
@@ -199,6 +223,22 @@ candidate string. See `vulpea-select-candidate-note'."
     (if (null sections)
         ""
       (concat " " (string-join sections " ")))))
+
+(defun vulpea-select--create-annotate-wrapper (annotation-fn)
+  "Return a wrapper function for ANNOTATION-FN.
+
+Return a wrapper function that receives a candidate string and then
+calls ANNOTATION-FN with the note and context extracted from the
+candidate. The wrapper function is suitable for use as a completion
+annotation."
+  (lambda (candidate)
+    (let ((note (vulpea-select-candidate-note candidate))
+          (context (vulpea-select-candidate-context candidate)))
+      (if note
+          (propertize (vulpea-select--funcall
+                       annotation-fn note context)
+                      'face 'completions-annotations)
+        ""))))
 
 ;;; Describe Functions
 
@@ -333,14 +373,17 @@ title stored in `vulpea-note-primary-title'."
                          (cons (vulpea-select-describe n context)
                                n))
                        expanded-notes))
-         (notes-table (make-hash-table :test #'equal)))
-    (seq-each (lambda (note)
-                (puthash (vulpea-note-id note) note notes-table))
-              expanded-notes)
-    (let ((note (completing-read
-                 (concat prompt ": ")
-                 (vulpea-select--completion-table completions)
-                 nil require-match initial-prompt)))
+         )
+    (let* ((annotation-fn (when (not vulpea-select-annotate-inside-candidate-string)
+                            (vulpea-select--create-annotate-wrapper
+                             vulpea-select-annotate-fn)))
+           (completion-extra-properties
+            (list
+             :annotation-function annotation-fn))
+           (note (completing-read
+                  (concat prompt ": ")
+                  (vulpea-select--completion-table completions)
+                  nil require-match initial-prompt)))
       (or (cdr (assoc note completions))
           (make-vulpea-note
            :title (substring-no-properties note)

--- a/vulpea-select.el
+++ b/vulpea-select.el
@@ -81,7 +81,7 @@ surprising matches."
   :group 'vulpea-select)
 
 
-(defcustom vulpea-select-annotate-inside-candidate-string t
+(defcustom vulpea-select-annotate-matchable t
   "If t, annotations are added directly in the candidate string.
 
 When this is t, annotations from `vulpea-select-annotate-fn' are
@@ -156,7 +156,7 @@ string self-describing for code that only ever sees strings - a
           (vulpea-select--funcall
            vulpea-select-describe-fn note context))
          (annotation-part
-          (if vulpea-select-annotate-inside-candidate-string
+          (if vulpea-select-annotate-matchable
               (propertize (vulpea-select--funcall
                            vulpea-select-annotate-fn note context)
                           'face 'completions-annotations)
@@ -327,6 +327,9 @@ title stored in `vulpea-note-primary-title'."
 (defun vulpea-select--completion-table (completions)
   "Build a completion table over COMPLETIONS exposing the `vulpea-note' category.
 
+If `vulpea-select-annotate-matchable' is nil, then `annotation-function'
+is also included in the metadata.
+
 COMPLETIONS is an alist of (description . note). The table completes
 like COMPLETIONS and reports a completion category of `vulpea-note',
 so that completion UIs and integrations (marginalia, embark, consult)
@@ -338,7 +341,14 @@ the note itself and the dynamic context as text properties (see
 `vulpea-select-candidate-note' and `vulpea-select-candidate-context'."
   (lambda (string predicate action)
     (if (eq action 'metadata)
-        '(metadata (category . vulpea-note))
+        `(metadata
+          (category . vulpea-note)
+          ,@(when (not vulpea-select-annotate-matchable)
+              `((annotation-function
+                 .
+                 ,(vulpea-select--create-annotate-wrapper
+                   vulpea-select-annotate-fn)))))
+
       (complete-with-action action completions string predicate))))
 
 (cl-defun vulpea-select-from (prompt
@@ -372,15 +382,8 @@ title stored in `vulpea-note-primary-title'."
                        (lambda (n)
                          (cons (vulpea-select-describe n context)
                                n))
-                       expanded-notes))
-         )
-    (let* ((annotation-fn (when (not vulpea-select-annotate-inside-candidate-string)
-                            (vulpea-select--create-annotate-wrapper
-                             vulpea-select-annotate-fn)))
-           (completion-extra-properties
-            (list
-             :annotation-function annotation-fn))
-           (note (completing-read
+                       expanded-notes)))
+    (let* ((note (completing-read
                   (concat prompt ": ")
                   (vulpea-select--completion-table completions)
                   nil require-match initial-prompt)))


### PR DESCRIPTION
Add the `vulpea-select-annotate-inside-candidate-string` variable that allow users to control if annotations (from
`vulpea-select-annotate-fn`) should be concatenated with candidate strings (default behavior), or if candidates should be annotated via standard `annotation-function` (with the annotation function build by wrapping what is in `vulpea-select-annotate-fn`).